### PR TITLE
DHIS2-4727 - Set default basemap state properties

### DIFF
--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -205,6 +205,10 @@ const map = (state = defaultState, action) => {
             return {
                 ...defaultState,
                 ...action.payload,
+                basemap: {
+                    ...defaultState.basemap,
+                    ...action.payload.basemap,
+                },
             };
 
         case types.MAP_PROPS_SET:


### PR DESCRIPTION
Closes [DHIS2-4727](https://jira.dhis2.org/browse/DHIS2-4727)

We have to save the basemap as a string in the API, so we lose the additional properties (isVisible, isExpanded, transparency).  So for now we'll set them to the default whenever we load a saved favorite.