### PR TITLE
Update translation order (no-op)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-09-12T11:16:24.750Z\n"
-"PO-Revision-Date: 2018-09-12T11:16:24.750Z\n"
+"POT-Creation-Date: 2018-09-18T14:04:59.374Z\n"
+"PO-Revision-Date: 2018-09-18T14:04:59.374Z\n"
 
 msgid "No favorite selected"
 msgstr ""
@@ -287,13 +287,13 @@ msgstr ""
 msgid "Basemap"
 msgstr ""
 
-msgid "Toggle visibility"
-msgstr ""
-
 msgid "Collapse"
 msgstr ""
 
 msgid "Expand"
+msgstr ""
+
+msgid "Toggle visibility"
 msgstr ""
 
 msgid "deleted"


### PR DESCRIPTION
The order of translation strings changed when we moved the visibility toggle, but the translation pot wasn't updated before PR #17 was merged.  This is because the translations are only generated in the prestart script.