### PR TITLE
Bug fix for indicator select

### DIFF
--- a/src/components/indicator/IndicatorSelect.js
+++ b/src/components/indicator/IndicatorSelect.js
@@ -40,8 +40,6 @@ export class IndicatorSelect extends Component {
 
         let items = indicators;
 
-        console.log('A', indicatorGroup, indicators);
-
         if (!indicatorGroup && !indicator) {
             return null;
         } else if (!indicators && indicator) {

--- a/src/components/indicator/IndicatorSelect.js
+++ b/src/components/indicator/IndicatorSelect.js
@@ -40,9 +40,11 @@ export class IndicatorSelect extends Component {
 
         let items = indicators;
 
+        console.log('A', indicatorGroup, indicators);
+
         if (!indicatorGroup && !indicator) {
             return null;
-        } else if (indicator) {
+        } else if (!indicators && indicator) {
             items = [indicator]; // If favorite is loaded, we only know the used indicator
         }
 


### PR DESCRIPTION
Problem: 
1) open maps app and create a thematic layer
2) select item type: indicator, indicator group: anc, indicator: anc1
3) try to change the indicator from anc1 to something else

you need to re-select the group to be able to change the indicator

The fix was to add an extra check if list of indicators exists. 
