### PR TITLE
Setting default layer opacity to 1

### DIFF
--- a/src/components/layers/toolbar/LayerToolbar.js
+++ b/src/components/layers/toolbar/LayerToolbar.js
@@ -94,4 +94,8 @@ LayerToolbar.propTypes = {
     onEdit: PropTypes.func,
 };
 
+LayerToolbar.defaultProps = {
+    opacity: 1,
+};
+
 export default withStyles(styles)(LayerToolbar);


### PR DESCRIPTION
Some favorites created with old versions of the GIS app don't have an opacity property. This PR sets the default opacity 1. It was already done for the map, but not for the opacity slider. 