### PR TITLE
Style by data element for event layers

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-10-04T14:37:58.055Z\n"
-"PO-Revision-Date: 2018-10-04T14:37:58.055Z\n"
+"POT-Creation-Date: 2018-10-17T14:42:44.097Z\n"
+"PO-Revision-Date: 2018-10-17T14:42:44.097Z\n"
 
 msgid "No favorite selected"
 msgstr ""
@@ -153,6 +153,9 @@ msgid "Buffer"
 msgstr ""
 
 msgid "Radius in meters"
+msgstr ""
+
+msgid "You can style events by data element after selecting a program."
 msgstr ""
 
 msgid "Program is required"
@@ -356,6 +359,9 @@ msgstr ""
 msgid "Relocate"
 msgstr ""
 
+msgid "Not set"
+msgstr ""
+
 msgid "Organisation unit"
 msgstr ""
 
@@ -363,9 +369,6 @@ msgid "Event time"
 msgstr ""
 
 msgid "Groups"
-msgstr ""
-
-msgid "No data found"
 msgstr ""
 
 msgid "Last updated"
@@ -457,17 +460,23 @@ msgstr ""
 msgid "Facilities"
 msgstr ""
 
+msgid "No data found"
+msgstr ""
+
 msgid "Tracked entity"
 msgstr ""
 
 msgid "No tracked entities found"
 msgstr ""
 
+msgid "true"
+msgstr ""
+
+msgid "false"
+msgstr ""
+
 msgid "No"
 msgstr ""
 
 msgid "Map could not be created"
-msgstr ""
-
-msgid "Not set"
 msgstr ""

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "@dhis2/d2-ui-file-menu": "^3.2.1",
         "@dhis2/d2-ui-interpretations": "^1.1.12",
         "@dhis2/d2-ui-org-unit-tree": "^1.0.13",
-        "@dhis2/gis-api": "30.0.0",
+        "@dhis2/gis-api": "31.0.3",
         "@material-ui/core": "^3.0.3",
         "@material-ui/icons": "^3.0.1",
         "@material-ui/lab": "^3.0.0-alpha.15",

--- a/src/components/classification/Classification.js
+++ b/src/components/classification/Classification.js
@@ -26,13 +26,6 @@ const styles = {
         top: -8,
         float: 'left',
     },
-    /*
-    scale: {
-        float: 'left',
-        width: 190,
-        whiteSpace: 'nowrap',
-    },
-    */
 };
 
 const classRange = range(3, 10).map(num => ({ id: num, name: num.toString() })); // 3 - 9
@@ -52,12 +45,12 @@ const Classification = ({
         <SelectField
             key="classification"
             label={i18n.t('Classification')}
-            value={method ? String(method) : CLASSIFICATION_EQUAL_INTERVALS}
+            value={method || CLASSIFICATION_EQUAL_INTERVALS}
             items={classificationTypes.map(({ id, name }) => ({
                 id,
                 name: i18n.t(name),
             }))}
-            onChange={method => setClassification(Number(method.id))}
+            onChange={method => setClassification(method.id)}
             style={styles.select}
         />,
         <div key="scale">
@@ -73,7 +66,6 @@ const Classification = ({
             <ColorScaleSelect
                 palette={colorScale ? colorScale : defaultColorScale}
                 onChange={setColorScale}
-                // style={styles.scale}
                 width={190}
             />
             <div style={{ clear: 'both' }} />

--- a/src/components/classification/LegendTypeSelect.js
+++ b/src/components/classification/LegendTypeSelect.js
@@ -22,25 +22,25 @@ const styles = {
 };
 
 // Select between user defined (automatic) and predefined legends
+// MUI RadioGroup/Radio only accepts strings as value
 export const LegendTypeSelect = ({ method, setClassification, classes }) => (
     <RadioGroup
         name="method"
-        value={
-            method == CLASSIFICATION_PREDEFINED
+        value={String(
+            method === CLASSIFICATION_PREDEFINED
                 ? CLASSIFICATION_PREDEFINED
                 : CLASSIFICATION_EQUAL_INTERVALS
-        }
+        )}
         onChange={(event, method) => setClassification(Number(method))}
         className={classes.radioGroup}
-        // style={{ ...styles.flexInnerColumnFlow, marginTop: 8 }}
     >
         <Radio
-            value={CLASSIFICATION_EQUAL_INTERVALS}
+            value={String(CLASSIFICATION_EQUAL_INTERVALS)}
             label={i18n.t('Automatic')}
             className={classes.radio}
         />
         <Radio
-            value={CLASSIFICATION_PREDEFINED}
+            value={String(CLASSIFICATION_PREDEFINED)}
             label={i18n.t('Predefined')}
             className={classes.radio}
         />
@@ -53,6 +53,7 @@ LegendTypeSelect.propTypes = {
     classes: PropTypes.object.isRequired,
 };
 
-export default connect(null, { setClassification })(
-    withStyles(styles)(LegendTypeSelect)
-);
+export default connect(
+    null,
+    { setClassification }
+)(withStyles(styles)(LegendTypeSelect));

--- a/src/components/classification/NumericLegendStyle.js
+++ b/src/components/classification/NumericLegendStyle.js
@@ -38,7 +38,11 @@ export class NumericLegendStyle extends Component {
         return (
             <div style={style}>
                 <LegendTypeSelect method={method} />
-                {method == 1 ? <LegendSetSelect /> : <Classification />}
+                {method === CLASSIFICATION_PREDEFINED ? (
+                    <LegendSetSelect />
+                ) : (
+                    <Classification />
+                )}
             </div>
         );
     }
@@ -61,7 +65,7 @@ export class NumericLegendStyle extends Component {
             }
         }
 
-        if (method !== prevMethod && method == CLASSIFICATION_PREDEFINED) {
+        if (method !== prevMethod && method === CLASSIFICATION_PREDEFINED) {
             setLegendSet(dataItem.legendSet);
         }
     }

--- a/src/components/core/DatePicker.js
+++ b/src/components/core/DatePicker.js
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
+import { timeFormat } from 'd3-time-format';
+
+const formatTime = timeFormat('%Y-%m-%d');
 
 const styles = {
     root: {
@@ -9,13 +12,15 @@ const styles = {
     },
 };
 
+// react-dom.development.js:3337 The specified value "2018-10-17T00:00:00.000" does not conform to the required format, "yyyy-MM-dd".
+
 // DatePicker not yet supported in Material-UI: https://github.com/mui-org/material-ui/issues/4787
 // Fallback on browser native
 const DatePicker = ({ label, value, onChange, classes, style }) => (
     <TextField
         type="date"
         label={label}
-        defaultValue={value}
+        defaultValue={formatTime(new Date(value))}
         onChange={event => onChange(event.target.value)}
         style={style}
         classes={classes}

--- a/src/components/edit/EventDialog.js
+++ b/src/components/edit/EventDialog.js
@@ -190,7 +190,7 @@ export class EventDialog extends Component {
         const period = getPeriodFromFilters(filters) || {
             id: 'START_END_DATES',
         };
-        console.log('rows', rows);
+
         const selectedUserOrgUnits = getUserOrgUnitsFromRows(rows);
 
         return (

--- a/src/components/edit/EventDialog.js
+++ b/src/components/edit/EventDialog.js
@@ -61,6 +61,10 @@ const styles = {
         width: 110,
         marginTop: 12,
     },
+    text: {
+        paddingTop: 8,
+        lineHeight: '22px',
+    },
 };
 
 export class EventDialog extends Component {
@@ -360,7 +364,15 @@ export class EventDialog extends Component {
                                 </div>
                             </div>
                             <div style={styles.flexColumn}>
-                                {program && <StyleByDataItem />}
+                                {program ? (
+                                    <StyleByDataItem />
+                                ) : (
+                                    <div style={styles.text}>
+                                        {i18n.t(
+                                            'You can style events by data element after selecting a program.'
+                                        )}
+                                    </div>
+                                )}
                             </div>
                         </div>
                     )}

--- a/src/components/filter/FilterSelect.js
+++ b/src/components/filter/FilterSelect.js
@@ -25,7 +25,7 @@ const styles = {
         width: 'calc((100% - 48px) / 8 * 3)',
     },
     datePicker: {
-        width: 165,
+        width: 164,
     },
 };
 

--- a/src/components/layers/LayersToggle.js
+++ b/src/components/layers/LayersToggle.js
@@ -20,18 +20,23 @@ const styles = theme => ({
         borderRadius: 0,
         boxShadow: '3px 1px 5px -1px rgba(0, 0, 0, 0.2)',
         zIndex: 1100,
-    }
+    },
 });
 
 // This expand/collapse toggle is separate from LayersPanel to avoid overflow issue
-const LayersToggle = ({ isOpen, openLayersPanel, closeLayersPanel, classes }) => (
+const LayersToggle = ({
+    isOpen,
+    openLayersPanel,
+    closeLayersPanel,
+    classes,
+}) => (
     <IconButton
         onClick={isOpen ? closeLayersPanel : openLayersPanel}
         className={classes.button}
         disableTouchRipple={true}
         style={isOpen ? {} : { left: 0 }}
     >
-        {isOpen ? <LeftIcon /> : <RightIcon /> }
+        {isOpen ? <LeftIcon /> : <RightIcon />}
     </IconButton>
 );
 

--- a/src/components/layers/LayersToggle.js
+++ b/src/components/layers/LayersToggle.js
@@ -20,6 +20,9 @@ const styles = theme => ({
         borderRadius: 0,
         boxShadow: '3px 1px 5px -1px rgba(0, 0, 0, 0.2)',
         zIndex: 1100,
+        '&:hover': {
+            backgroundColor: theme.palette.background.hover,
+        },
     },
 });
 

--- a/src/components/layers/legend/Legend.js
+++ b/src/components/layers/legend/Legend.js
@@ -22,6 +22,10 @@ export const styles = {
         marginLeft: 32,
         lineHeight: '24px',
     },
+    explanation: {
+        paddingTop: 16,
+        // fontSize: 12,
+    },
     source: {
         paddingTop: 16,
         fontSize: 12,
@@ -34,6 +38,7 @@ const Legend = ({
     filters,
     unit,
     items,
+    explanation,
     source,
     sourceUrl,
 }) => (
@@ -56,6 +61,9 @@ const Legend = ({
                 </tbody>
             </table>
         )}
+        {explanation && (
+            <div className={classes.explanation}>{explanation}</div>
+        )}
         {source && (
             <div className={classes.source}>
                 Source:&nbsp;
@@ -75,6 +83,7 @@ Legend.propTypes = {
     filters: PropTypes.array,
     unit: PropTypes.string,
     items: PropTypes.array,
+    explanation: PropTypes.string,
     source: PropTypes.string,
     sourceUrl: PropTypes.string,
 };

--- a/src/components/layers/legend/Legend.js
+++ b/src/components/layers/legend/Legend.js
@@ -24,7 +24,6 @@ export const styles = {
     },
     explanation: {
         paddingTop: 16,
-        // fontSize: 12,
     },
     source: {
         paddingTop: 16,

--- a/src/components/map/EventLayer.js
+++ b/src/components/map/EventLayer.js
@@ -124,7 +124,6 @@ class EventLayer extends Layer {
 
         // Create legend in HTML if showed as plugin
         if (isPlugin && legend) {
-            console.log('Event', legend);
             map.legend =
                 (map.legend || '') + getHtmlLegend(legend, data.length > 0);
         }

--- a/src/components/map/EventLayer.js
+++ b/src/components/map/EventLayer.js
@@ -197,9 +197,9 @@ class EventLayer extends Layer {
 
             // Output value if styled by data item, and item is not included in display elements
             if (styleDataItem && !this.displayElements[styleDataItem.id]) {
-                content += `<tr><th>${styleDataItem.name}</th><td>${
-                    props.value
-                }</td></tr>`;
+                content += `<tr><th>${
+                    styleDataItem.name
+                }</th><td>${props.value || i18n.t('Not set')}</td></tr>`;
             }
 
             if (Array.isArray(dataValues)) {
@@ -215,9 +215,8 @@ class EventLayer extends Layer {
                             value = displayEl.optionSet[value];
                         }
 
-                        content += `<tr><th>${
-                            displayEl.name
-                        }</th><td>${value}</td></tr>`;
+                        content += `<tr><th>${displayEl.name}</th><td>${value ||
+                            i18n.t('Not set')}</td></tr>`;
                     }
                 });
 

--- a/src/components/map/EventLayer.js
+++ b/src/components/map/EventLayer.js
@@ -11,6 +11,7 @@ import {
 } from '../../util/analytics';
 import { EVENT_COLOR, EVENT_RADIUS } from '../../constants/layers';
 import Layer from './Layer';
+import { getHtmlLegend } from '../../util/legend';
 import { getDisplayPropertyUrl } from '../../util/helpers';
 
 class EventLayer extends Layer {
@@ -34,6 +35,8 @@ class EventLayer extends Layer {
             styleDataItem,
             areaRadius,
             relativePeriodDate,
+            legend,
+            isPlugin,
         } = this.props;
 
         // Some older favorites don't have a valid color code
@@ -118,6 +121,13 @@ class EventLayer extends Layer {
 
         // Create and add event layer based on config object
         this.layer = map.createLayer(config).addTo(map);
+
+        // Create legend in HTML if showed as plugin
+        if (isPlugin && legend) {
+            console.log('Event', legend);
+            map.legend =
+                (map.legend || '') + getHtmlLegend(legend, data.length > 0);
+        }
 
         const layerBounds = this.layer.getBounds();
 

--- a/src/components/map/MapProvider.js
+++ b/src/components/map/MapProvider.js
@@ -1,6 +1,6 @@
 import { Component, Children } from 'react';
 import PropTypes from 'prop-types';
-import d2map from '@dhis2/gis-api/build';
+import d2map from '@dhis2/gis-api';
 
 // Makes the Leaflet map instance available in all child components
 class MapProvider extends Component {

--- a/src/components/map/PluginMap.js
+++ b/src/components/map/PluginMap.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import d2map from '@dhis2/gis-api/build';
+import d2map from '@dhis2/gis-api';
 import ContextMenu from './PluginContextMenu';
 import Layer from './Layer';
 import EventLayer from './EventLayer';

--- a/src/components/map/PluginMap.js
+++ b/src/components/map/PluginMap.js
@@ -197,22 +197,27 @@ class PluginMap extends Component {
 
         // Disabled alerts as one layer without data will result in no map
         // No data warning added to legend instead
-        const alerts = [] // getMapAlerts(this.props); // ADDED
+        const alerts = []; // getMapAlerts(this.props); // ADDED
 
         return !alerts.length ? (
             <div ref={node => (this.node = node)} style={styles.map}>
-                {mapViews.filter(layer => layer.isLoaded).map(config => {
-                    const Overlay = layerType[config.layer] || Layer;
+                {mapViews
+                    .filter(layer => layer.isLoaded)
+                    .map((config, index) => {
+                        const Overlay = layerType[config.layer] || Layer;
 
-                    return (
-                        <Overlay
-                            key={config.id}
-                            openContextMenu={this.onOpenContextMenu.bind(this)}
-                            {...config}
-                            isPlugin={true}
-                        />
-                    );
-                })}
+                        return (
+                            <Overlay
+                                key={config.id}
+                                index={index}
+                                openContextMenu={this.onOpenContextMenu.bind(
+                                    this
+                                )}
+                                {...config}
+                                isPlugin={true}
+                            />
+                        );
+                    })}
                 {basemap.isVisible !== false && (
                     <Layer key="basemap" {...basemap} />
                 )}

--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -39,7 +39,6 @@ class ThematicLayer extends Layer {
 
         // Create legend in HTML if showed as plugin
         if (isPlugin && legend) {
-            console.log('Thematic', legend);
             map.legend =
                 (map.legend || '') + getHtmlLegend(legend, data.length > 0);
         }

--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -1,9 +1,9 @@
-import i18n from '@dhis2/d2-i18n';
 import Layer from './Layer';
 import { filterData } from '../../util/filter';
+import { getHtmlLegend } from '../../util/legend';
 
 class ThematicLayer extends Layer {
-    createLayer(callback) {
+    createLayer() {
         const {
             id,
             data,
@@ -37,9 +37,11 @@ class ThematicLayer extends Layer {
         this.layer.on('click', this.onFeatureClick, this);
         this.layer.on('contextmenu', this.onFeatureRightClick, this);
 
+        // Create legend in HTML if showed as plugin
         if (isPlugin && legend) {
-            // TODO: Better way to assemble the legend?
-            map.legend = (map.legend || '') + this.getHtmlLegend(legend, data);
+            console.log('Thematic', legend);
+            map.legend =
+                (map.legend || '') + getHtmlLegend(legend, data.length > 0);
         }
 
         const layerBounds = this.layer.getBounds();
@@ -48,34 +50,6 @@ class ThematicLayer extends Layer {
             map.invalidateSize();
             map.fitBounds(layerBounds);
         }
-    }
-
-    // Used for legend in map plugins
-    getHtmlLegend({ title, period, items }, data) {
-        return `<div class="dhis2-legend">
-            <h2>${title}</h2>
-            <span>${period}</span>
-            ${
-                data.length
-                    ? `<dl class="dhis2-legend-automatic">
-                        ${items
-                            .map(
-                                item => `
-                        <dt style="background-color:${item.color}"></dt>
-                        <dd>${item.name || ''} ${
-                                    !isNaN(item.startValue)
-                                        ? `${item.startValue} - ${
-                                              item.endValue
-                                          }`
-                                        : ''
-                                } (${item.count})</dd>
-                    `
-                            )
-                            .join('')}
-                    </dl>`
-                    : `<p><em>${i18n.t('No data found')}</em></p>`
-            }
-        </div>`;
     }
 
     onFeatureClick(evt) {

--- a/src/constants/layers.js
+++ b/src/constants/layers.js
@@ -26,9 +26,9 @@ export const BUFFER_MAX_LINE_OPACITY = 0.7;
 
 /* CLASSIFICATION */
 
-export const CLASSIFICATION_PREDEFINED = '1';
-export const CLASSIFICATION_EQUAL_INTERVALS = '2';
-export const CLASSIFICATION_EQUAL_COUNTS = '3';
+export const CLASSIFICATION_PREDEFINED = 1;
+export const CLASSIFICATION_EQUAL_INTERVALS = 2;
+export const CLASSIFICATION_EQUAL_COUNTS = 3;
 
 export const classificationTypes = [
     {

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -109,8 +109,6 @@ const eventLoader = async layerConfig => {
             }
         }
 
-        console.log('dataFilters', dataFilters);
-
         config.legend.filters =
             dataFilters &&
             getFiltersAsText(dataFilters, {

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -58,6 +58,7 @@ const eventLoader = async layerConfig => {
     config.name = programStage.name;
 
     config.legend = {
+        title: config.name,
         period: period
             ? getPeriodNameFromId(period.id)
             : `${formatTime(startDate)} - ${formatTime(endDate)}`,

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -109,6 +109,8 @@ const eventLoader = async layerConfig => {
             }
         }
 
+        console.log('dataFilters', dataFilters);
+
         config.legend.filters =
             dataFilters &&
             getFiltersAsText(dataFilters, {

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -103,9 +103,7 @@ const eventLoader = async layerConfig => {
             }
 
             if (areaRadius) {
-                config.legend.items.forEach(
-                    item => (item.name += ` + ${areaRadius} ${'m'} ${'buffer'}`)
-                );
+                config.legend.explanation = `${areaRadius} ${'m'} ${'buffer'}`;
             }
         }
 

--- a/src/util/analytics.js
+++ b/src/util/analytics.js
@@ -160,17 +160,29 @@ export const getFiltersFromColumns = (columns = []) => {
     return filters.length ? filters : null;
 };
 
+// Returns list of filters in a readable format
 export const getFiltersAsText = (filters = [], names = {}) =>
     filters.map(({ dimension, filter }) => {
         const [operator, value] = filter.split(':');
-        return `${names[dimension]} ${getFilterOperatorAsText(
-            operator
-        )} [${getFilterValueName(value, names)}]`;
+        const filterName = names[dimension];
+        const filterOperator = getFilterOperatorAsText(operator, value);
+        const filterValue = getFilterValueName(value, operator, names);
+
+        return `${filterName} ${filterOperator} ${filterValue}`;
     });
 
-// TODO: Cache?
-export const getFilterOperatorAsText = id =>
-    ({
+// Returns filter operator in a readable format
+export const getFilterOperatorAsText = (operator, value) => {
+    // If only one value, use is / is not
+    if (!value.includes(';')) {
+        if (operator === 'IN') {
+            return i18n.t('is');
+        } else if (operator === '!IN') {
+            return i18n.t('is not');
+        }
+    }
+
+    return {
         EQ: '=',
         GT: '>',
         GE: '>=',
@@ -181,13 +193,24 @@ export const getFilterOperatorAsText = id =>
         '!IN': i18n.t('not one of'),
         LIKE: i18n.t('contains'),
         '!LIKE': i18n.t("doesn't contains"),
-    }[id]);
+    }[operator];
+};
 
-export const getFilterValueName = (value, names) =>
-    value
+// Returns filter value is a readable fromat
+export const getFilterValueName = (value, operator, names) => {
+    if (operator === 'IN') {
+        if (value === '1') {
+            return i18n.t('true');
+        } else if (value === '0') {
+            return i18n.t('false');
+        }
+    }
+
+    return value
         .split(';')
         .map(val => names[val] || val)
         .join(', ');
+};
 
 // Combine data items into one array and exclude certain value types
 export const combineDataItems = (

--- a/src/util/classify.js
+++ b/src/util/classify.js
@@ -38,9 +38,9 @@ export const getLegendItems = (values, method, numClasses) => {
     const maxValue = values[values.length - 1];
     let bins;
 
-    if (method == CLASSIFICATION_EQUAL_INTERVALS) {
+    if (method === CLASSIFICATION_EQUAL_INTERVALS) {
         bins = getEqualIntervals(minValue, maxValue, numClasses);
-    } else if (method == CLASSIFICATION_EQUAL_COUNTS) {
+    } else if (method === CLASSIFICATION_EQUAL_COUNTS) {
         bins = getQuantiles(values, numClasses);
     }
 
@@ -52,9 +52,9 @@ export const getClassBins = (values, method, numClasses) => {
     const maxValue = values[values.length - 1];
     let bins;
 
-    if (method == CLASSIFICATION_EQUAL_INTERVALS) {
+    if (method === CLASSIFICATION_EQUAL_INTERVALS) {
         bins = getEqualIntervals(minValue, maxValue, numClasses);
-    } else if (method == CLASSIFICATION_EQUAL_COUNTS) {
+    } else if (method === CLASSIFICATION_EQUAL_COUNTS) {
         bins = getQuantiles(values, numClasses);
     }
 

--- a/src/util/legend.js
+++ b/src/util/legend.js
@@ -102,17 +102,17 @@ export const getHtmlLegend = (
         <h2>${title} <span>${period}</span></h2>`;
 
     if (description) {
-        legend += `<div className="dhis2-legend-description">${description}</div>`;
+        legend += `<div class="dhis2-legend-description">${description}</div>`;
     }
 
     if (filters) {
-        legend += `<div className="dhis2-legend-filters">
+        legend += `<div class="dhis2-legend-filters">
             ${i18n.t('Filters')}: ${filters.join(', ')}
         </div>`;
     }
 
     if (unit) {
-        legend += `<div className="dhis2-legend-unit">${unit}</div>`;
+        legend += `<div class="dhis2-legend-unit">${unit}</div>`;
     }
 
     if (hasData) {
@@ -124,11 +124,11 @@ export const getHtmlLegend = (
     }
 
     if (explanation) {
-        legend += `<div className="dhis2-legend-explanation">${explanation}</div>`;
+        legend += `<div class="dhis2-legend-explanation">${explanation}</div>`;
     }
 
     if (source) {
-        legend += `<div className="dhis2-legend-source">
+        legend += `<div class="dhis2-legend-source">
                 Source:&nbsp;
                 ${
                     sourceUrl

--- a/src/util/legend.js
+++ b/src/util/legend.js
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n';
 import { getInstance as getD2 } from 'd2/lib/d2';
 import { sortBy } from 'lodash/fp';
 import { pick } from 'lodash/fp';
@@ -81,3 +82,70 @@ export const getAutomaticLegendItems = (
         color: colors[index],
     }));
 };
+
+// Used for legend in map plugins
+export const getHtmlLegend = (
+    {
+        title,
+        period,
+        description,
+        filters,
+        unit,
+        items,
+        explanation,
+        source,
+        sourceUrl,
+    },
+    hasData
+) => {
+    let legend = `<div class="dhis2-legend">
+        <h2>${title} <span>${period}</span></h2>`;
+
+    if (description) {
+        legend += `<div className="dhis2-legend-description">${description}</div>`;
+    }
+
+    if (filters) {
+        legend += `<div className="dhis2-legend-filters">
+            ${i18n.t('Filters')}: ${filters.join(', ')}
+        </div>`;
+    }
+
+    if (unit) {
+        legend += `<div className="dhis2-legend-unit">${unit}</div>`;
+    }
+
+    if (hasData) {
+        legend += `<dl class="dhis2-legend-automatic">${items
+            .map(getHtmlLegendItem)
+            .join('')}</dl>`;
+    } else {
+        `<p><em>${i18n.t('No data found')}</em></p>`;
+    }
+
+    if (explanation) {
+        legend += `<div className="dhis2-legend-explanation">${explanation}</div>`;
+    }
+
+    if (source) {
+        legend += `<div className="dhis2-legend-source">
+                Source:&nbsp;
+                ${
+                    sourceUrl
+                        ? `<a href=${sourceUrl}>{source}</a>`
+                        : `<span>${source}</span>`
+                }
+            </div>`;
+    }
+
+    legend += `</div>`;
+
+    return legend;
+};
+
+// Helper function to get a legend item
+const getHtmlLegendItem = ({ color, name, startValue, endValue, count }) => `
+  <dt style="background-color:${color}"></dt>
+  <dd>${name || ''} ${!isNaN(startValue) ? `${startValue} - ${endValue}` : ''} 
+    ${count !== undefined ? `(${count})` : ''}
+  </dd>`;

--- a/src/util/styleByDataItem.js
+++ b/src/util/styleByDataItem.js
@@ -26,7 +26,7 @@ export const styleByDataItem = async config => {
         await styleByNumeric(config);
     } else if (styleDataItem.valueType === 'BOOLEAN') {
         await styleByBoolean(config);
-    }    
+    }
 
     config.legend.items.push({
         name: i18n.t('Not set'),
@@ -37,7 +37,6 @@ export const styleByDataItem = async config => {
     return config;
 };
 
-
 export const styleByBoolean = async config => {
     const { styleDataItem, data, legend, eventPointRadius } = config;
     const { id, name, values } = styleDataItem;
@@ -47,7 +46,7 @@ export const styleByBoolean = async config => {
 
         if (!value) {
             return feature;
-        }        
+        }
 
         // TODO: Not sure if return values are '1' and '0'
         return {
@@ -57,27 +56,29 @@ export const styleByBoolean = async config => {
                 value: value === '1' ? i18n.t('Yes') : i18n.t('No'),
                 color: value === '1' ? values.true : values.false,
             },
-        }
+        };
     });
 
     legend.unit = name || (await getDataElementName(id));
 
-    legend.items = [{
-        name: i18n.t('Yes'),
-        color: values.true,
-        radius: eventPointRadius || EVENT_RADIUS,
-    }];    
+    legend.items = [
+        {
+            name: i18n.t('Yes'),
+            color: values.true,
+            radius: eventPointRadius || EVENT_RADIUS,
+        },
+    ];
 
     if (values.false) {
         legend.items.push({
             name: i18n.t('No'),
             color: values.false,
             radius: eventPointRadius || EVENT_RADIUS,
-        });     
+        });
     }
 
     return config;
-}
+};
 
 export const styleByNumeric = async config => {
     const {
@@ -89,7 +90,7 @@ export const styleByNumeric = async config => {
         data,
     } = config;
 
-    // If legend set
+    // If legend set (can be 1 or '1')
     if (method === CLASSIFICATION_PREDEFINED) {
         // Load legend set from server
         const legendSet = await loadLegendSet(config.legendSet);

--- a/src/util/styleByDataItem.js
+++ b/src/util/styleByDataItem.js
@@ -89,7 +89,7 @@ export const styleByNumeric = async config => {
         data,
     } = config;
 
-    // If legend set (can be 1 or '1')
+    // If legend set
     if (method === CLASSIFICATION_PREDEFINED) {
         // Load legend set from server
         const legendSet = await loadLegendSet(config.legendSet);

--- a/src/util/styleByDataItem.js
+++ b/src/util/styleByDataItem.js
@@ -1,12 +1,12 @@
 import i18n from '@dhis2/d2-i18n';
 import { getInstance as getD2 } from 'd2/lib/d2';
 import { curry } from 'lodash/fp';
-import { getLegendItemForValue } from '../util/classify';
+import { getLegendItemForValue } from './classify';
 import {
     loadLegendSet,
     getAutomaticLegendItems,
     getPredefinedLegendItems,
-} from '../util/legend';
+} from './legend';
 import {
     EVENT_COLOR,
     EVENT_RADIUS,
@@ -48,7 +48,6 @@ export const styleByBoolean = async config => {
             return feature;
         }
 
-        // TODO: Not sure if return values are '1' and '0'
         return {
             ...feature,
             properties: {
@@ -132,6 +131,10 @@ export const styleByNumeric = async config => {
     config.data = config.data.map(feature => {
         const value = Number(feature.properties[styleDataItem.id]);
         const legendItem = getLegendItem(value);
+
+        if (legendItem) {
+            legendItem.count++;
+        }
 
         return {
             ...feature,

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,9 +253,9 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/gis-api@30.0.0":
-  version "30.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/gis-api/-/gis-api-30.0.0.tgz#6b2da8fc6b23fbb573cf9496559be18c97e11728"
+"@dhis2/gis-api@31.0.3":
+  version "31.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/gis-api/-/gis-api-31.0.3.tgz#94103e0b1c65ddcf82d3a15ef5a6f50de638f70e"
   dependencies:
     "@turf/buffer" "^5.1.5"
     d3-color "^1.0.3"


### PR DESCRIPTION
This PR finalises "style by data element" for event layers: https://jira.dhis2.org/browse/DHIS2-3215

Includes:
- Classification constants are now numbers all over (as in analytical objects, but we need to do some conversion as MUI SelectField and Radio components only accept string values.
- The backend transforms the date format, and we need to change it back after switching to a native date picker. 
- Added notification that a program needs to be selected before style by data item is available. 
- Added legend support for event layers when shown in a plugin. 
- Added "explanation" prop to legend object. Is used in event layer tell abot the buffer radius, if used.
- Show "Not set" in event popup if value is not avalable for a data element. 
- Fix for showing the layers in correct orderin a plugin (buffer circles below event points).
- Improved the way filters are displayed in the legend (more readable).
- Various minor style fixes 