### PR TITLE
Web API upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "31.0.12",
+    "version": "31.0.13",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/app.js
+++ b/src/app.js
@@ -30,7 +30,7 @@ getManifest('manifest.webapp')
             process.env.NODE_ENV === 'production'
                 ? manifest.getBaseUrl()
                 : DHIS_CONFIG.baseUrl;
-        config.baseUrl = `${baseUrl}/api/30`;
+        config.baseUrl = `${baseUrl}/api/31`;
         config.context = manifest.activities.dhis; // Added temporarily for util/api.js
 
         log.info(`Loading: ${manifest.name} v${manifest.version}`);

--- a/src/map.js
+++ b/src/map.js
@@ -15,7 +15,7 @@ import { translateConfig } from './util/favorites';
 import { defaultBasemaps } from './constants/basemaps';
 import '../scss/plugin.scss';
 
-const apiVersion = 30;
+const apiVersion = 31;
 
 const Plugin = () => {
     let _configs = [];


### PR DESCRIPTION
Upgrade to version 31 of the Web API. 

For later, it would be nice to keep the API version setting at one place in the repo. 
