### PR TITLE
Thematic as first layer item in add layer dialog

### DIFF
--- a/src/reducers/layers.js
+++ b/src/reducers/layers.js
@@ -5,7 +5,7 @@ const defaultLayers = [
         layer: 'thematic',
         type: 'Thematic',
         img: 'images/thematic.png',
-        opacity: 0.8,
+        opacity: 0.9,
     },
     {
         layer: 'event',

--- a/src/reducers/layers.js
+++ b/src/reducers/layers.js
@@ -2,6 +2,12 @@ import * as types from '../constants/actionTypes';
 
 const defaultLayers = [
     {
+        layer: 'thematic',
+        type: 'Thematic',
+        img: 'images/thematic.png',
+        opacity: 0.8,
+    },
+    {
         layer: 'event',
         type: 'Events',
         img: 'images/events.png',
@@ -19,12 +25,6 @@ const defaultLayers = [
         type: 'Facilities',
         img: 'images/facilities.png',
         opacity: 1,
-    },
-    {
-        layer: 'thematic',
-        type: 'Thematic',
-        img: 'images/thematic.png',
-        opacity: 0.8,
     },
     {
         layer: 'boundary',


### PR DESCRIPTION
Small fix that sets thematic layer (most used) first in the add layer dialog:  

![skjermbilde 2018-11-14 kl 15 19 29](https://user-images.githubusercontent.com/548708/48488384-f150c500-e820-11e8-9040-a4f63f7892a1.png)

https://jira.dhis2.org/browse/DHIS2-4224