### PR TITLE
Boundary layer legend

### DIFF
--- a/src/components/edit/BoundaryDialog.js
+++ b/src/components/edit/BoundaryDialog.js
@@ -105,12 +105,6 @@ class BoundaryDialog extends Component {
         const orgUnits = getOrgUnitsFromRows(rows);
         const selectedUserOrgUnits = getUserOrgUnitsFromRows(rows);
 
-        console.log(
-            'getOrgUnitGroupsFromRows',
-            rows,
-            getOrgUnitGroupsFromRows(rows)
-        );
-
         return (
             <div>
                 <Tabs value={tab} onChange={tab => this.setState({ tab })}>

--- a/src/components/edit/BoundaryDialog.js
+++ b/src/components/edit/BoundaryDialog.js
@@ -105,6 +105,12 @@ class BoundaryDialog extends Component {
         const orgUnits = getOrgUnitsFromRows(rows);
         const selectedUserOrgUnits = getUserOrgUnitsFromRows(rows);
 
+        console.log(
+            'getOrgUnitGroupsFromRows',
+            rows,
+            getOrgUnitGroupsFromRows(rows)
+        );
+
         return (
             <div>
                 <Tabs value={tab} onChange={tab => this.setState({ tab })}>
@@ -150,12 +156,11 @@ class BoundaryDialog extends Component {
                                     selected={selectedUserOrgUnits}
                                     onChange={setUserOrgUnits}
                                 />
-                                {!orgUnits.length &&
-                                    orgUnitsError && (
-                                        <div style={styles.error}>
-                                            {orgUnitsError}
-                                        </div>
-                                    )}
+                                {!orgUnits.length && orgUnitsError && (
+                                    <div style={styles.error}>
+                                        {orgUnitsError}
+                                    </div>
+                                )}
                             </div>
                         </div>
                     )}

--- a/src/components/layers/legend/LegendItem.js
+++ b/src/components/layers/legend/LegendItem.js
@@ -5,6 +5,7 @@ const LegendItem = ({
     image,
     color,
     radius,
+    weight,
     name,
     startValue,
     endValue,
@@ -28,7 +29,19 @@ const LegendItem = ({
     return (
         <tr>
             <th>
-                <span style={symbol} />
+                {!weight ? (
+                    // Show image or color
+                    <span style={symbol} />
+                ) : (
+                    // Draw line
+                    <svg viewBox="0 0 24 24">
+                        <path
+                            stroke={color}
+                            strokeWidth={weight}
+                            d="M3.5 18.49l6-6.01 4 4L22 6.92l-1.41-1.41-7.09 7.97-4-4L2 16.99z"
+                        />
+                    </svg>
+                )}
             </th>
             <td>
                 {name}{' '}
@@ -44,6 +57,7 @@ LegendItem.propTypes = {
     image: PropTypes.string,
     color: PropTypes.string,
     radius: PropTypes.number,
+    weight: PropTypes.number,
     name: PropTypes.string,
     startValue: PropTypes.number,
     endValue: PropTypes.number,

--- a/src/loaders/boundaryLoader.js
+++ b/src/loaders/boundaryLoader.js
@@ -78,7 +78,7 @@ const boundaryLoader = async config => {
 // of the analytics requests
 const getOrgUnitLevelNames = async d2 => {
     const orgUnitLevels = await d2.models.organisationUnitLevels.list({
-        fields: `${getDisplayPropertyUrl(d2)},level`,
+        fields: `id,${getDisplayPropertyUrl(d2)},level`,
         pageing: false,
     });
 

--- a/src/loaders/boundaryLoader.js
+++ b/src/loaders/boundaryLoader.js
@@ -3,10 +3,10 @@ import { uniqBy } from 'lodash/fp';
 import { getInstance as getD2 } from 'd2';
 import { toGeoJson } from '../util/map';
 import { getOrgUnitsFromRows } from '../util/analytics';
-import { getDisplayProperty } from '../util/helpers';
+import { getDisplayProperty, getDisplayPropertyUrl } from '../util/helpers';
 
-const colors = ['black', 'blue', 'red', 'green', 'yellow'];
-const weights = [2, 1, 0.75, 0.5, 0.5];
+const colors = ['#111111', '#377eb8', '#a65628', '#984ea3', '#4daf4a'];
+const weights = [2, 1, 0.75, 0.5];
 
 // Returns a promise
 const boundaryLoader = async config => {
@@ -16,6 +16,8 @@ const boundaryLoader = async config => {
 
     const d2 = await getD2();
     const displayProperty = getDisplayProperty(d2).toUpperCase();
+    const layerName = i18n.t('Boundaries');
+    const orgUnitLevelNames = await getOrgUnitLevelNames(d2);
 
     const features = await d2.geoFeatures
         .byOrgUnit(orgUnitParams)
@@ -35,8 +37,8 @@ const boundaryLoader = async config => {
         (obj, level, index) => ({
             ...obj,
             [level]: {
-                color: colors[index],
-                weight: levels.length === 1 ? 1 : weights[index],
+                color: colors[index] || '#333',
+                weight: levels.length === 1 ? 1 : weights[index] || 0.5,
             },
         }),
         {}
@@ -53,26 +55,42 @@ const boundaryLoader = async config => {
         feature.properties.type = feature.geometry.type;
     });
 
-    // console.log(config);
-
     config.legend = {
-        title: config.name,
-        items: levels.map((level, index) => ({
-            name: orgUnits[index].name,
+        title: layerName,
+        items: levels.map(level => ({
+            name: orgUnitLevelNames[level],
             ...levelStyle[level],
         })),
     };
 
-    // console.log('legend', config.legend.items);
-
     return {
         ...config,
         data: features,
-        name: i18n.t('Boundaries'),
+        name: layerName,
         isLoaded: true,
         isExpanded: true,
         isVisible: true,
     };
+};
+
+// This function returns the org unit level names used in the legend
+// TODO: Refacotor when org unit level names are included in the metadata section
+// of the analytics requests
+const getOrgUnitLevelNames = async d2 => {
+    const orgUnitLevels = await d2.models.organisationUnitLevels.list({
+        fields: `${getDisplayPropertyUrl(d2)},level`,
+        pageing: false,
+    });
+
+    return orgUnitLevels
+        ? orgUnitLevels.toArray().reduce(
+              (obj, item) => ({
+                  ...obj,
+                  [item.level]: item.name,
+              }),
+              {}
+          )
+        : {};
 };
 
 export default boundaryLoader;

--- a/src/loaders/boundaryLoader.js
+++ b/src/loaders/boundaryLoader.js
@@ -8,8 +8,8 @@ import { getDisplayProperty } from '../util/helpers';
 const colors = ['black', 'blue', 'red', 'green', 'yellow'];
 const weights = [2, 1, 0.75, 0.5, 0.5];
 
+// Returns a promise
 const boundaryLoader = async config => {
-    // Returns a promise
     const { rows, radiusLow } = config;
     const orgUnits = getOrgUnitsFromRows(rows);
     const orgUnitParams = orgUnits.map(item => item.id);
@@ -24,7 +24,6 @@ const boundaryLoader = async config => {
         .then(toGeoJson);
 
     if (!features.length) {
-        // gis.alert(GIS.i18n.no_valid_coordinates_found); // TODO
         return;
     }
 
@@ -53,6 +52,18 @@ const boundaryLoader = async config => {
         };
         feature.properties.type = feature.geometry.type;
     });
+
+    // console.log(config);
+
+    config.legend = {
+        title: config.name,
+        items: levels.map((level, index) => ({
+            name: orgUnits[index].name,
+            ...levelStyle[level],
+        })),
+    };
+
+    // console.log('legend', config.legend.items);
 
     return {
         ...config,


### PR DESCRIPTION
This PR includes legend support for boundary layers: 

![skjermbilde 2018-11-15 kl 14 00 44](https://user-images.githubusercontent.com/548708/48554787-a5188a00-e8df-11e8-838f-93db3c7d731a.png)

![skjermbilde 2018-11-15 kl 14 01 03](https://user-images.githubusercontent.com/548708/48554565-0e4bcd80-e8df-11e8-8b86-bcf00d9d3336.png)

A separate request is made to the Web API to fetch the org unit level names (should be cached of already loaded). The plan is to add these names in the metadata section of the analytics response in a later version of the Web API. 

A future improvement would also be to allow the user to change the colors and the width of the boundary lines. So far, this has not been requested by the users.