### PR TITLE
Fix flashing tooltip

### DIFF
--- a/src/components/layers/toolbar/LayerToolbar.js
+++ b/src/components/layers/toolbar/LayerToolbar.js
@@ -16,12 +16,12 @@ const styles = theme => ({
         position: 'relative',
         height: 32,
         minHeight: 32,
-        padding: '0 8px',
+        padding: `0 ${theme.spacing.unit}px`,
         backgroundColor: theme.palette.background.paper,
         borderTop: `1px solid ${theme.palette.divider}`,
     },
     spacer: {
-        marginRight: 16,
+        marginRight: theme.spacing.unit * 2,
     },
     button: {
         float: 'left',
@@ -34,7 +34,7 @@ const styles = theme => ({
         height: 32,
         padding: 4,
         position: 'absolute',
-        right: 4,
+        right: theme.spacing.unit / 2,
         top: 0,
     },
     sliderContainer: {

--- a/src/components/layers/toolbar/LayerToolbar.js
+++ b/src/components/layers/toolbar/LayerToolbar.js
@@ -37,6 +37,14 @@ const styles = theme => ({
         right: 4,
         top: 0,
     },
+    sliderContainer: {
+        marginLeft: 4,
+    },
+    sliderRoot: {
+        paddingLeft: 0,
+        paddingTop: 8,
+        paddingBottom: 8,
+    },
 });
 
 export const LayerToolbar = ({
@@ -69,14 +77,19 @@ export const LayerToolbar = ({
                     {isVisible ? <VisibilityIcon /> : <VisibilityOffIcon />}
                 </IconButton>
             </Tooltip>
-            <Tooltip title={i18n.t('Set layer opacity')}>
-                <div>
-                    <OpacitySlider
-                        opacity={opacity}
-                        onChange={onOpacityChange}
-                    />
-                </div>
-            </Tooltip>
+            <div className={classes.sliderContainer}>
+                <Tooltip title={i18n.t('Set layer opacity')}>
+                    <div>
+                        <OpacitySlider
+                            classes={{
+                                root: classes.sliderRoot,
+                            }}
+                            opacity={opacity}
+                            onChange={onOpacityChange}
+                        />
+                    </div>
+                </Tooltip>
+            </div>
             <LayerToolbarMoreMenu
                 classes={{ button: classes.moreMenuButton }}
                 {...expansionMenuProps}

--- a/src/components/layers/toolbar/LayerToolbar.js
+++ b/src/components/layers/toolbar/LayerToolbar.js
@@ -38,7 +38,7 @@ const styles = theme => ({
         top: 0,
     },
     sliderContainer: {
-        marginLeft: 4,
+        marginLeft: theme.spacing.unit / 2,
     },
     sliderRoot: {
         paddingLeft: 0,

--- a/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbar.spec.js.snap
+++ b/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbar.spec.js.snap
@@ -22,16 +22,23 @@ exports[`LayerToolbar Should match toolbar snapshot WITH Edit button 1`] = `
       <pure(VisibilityIcon) />
     </WithStyles(IconButton)>
   </WithStyles(Tooltip)>
-  <WithStyles(Tooltip)
-    title="Set layer opacity"
-  >
-    <div>
-      <WithStyles(OpacitySlider)
-        onChange={[Function]}
-        opacity={0}
-      />
-    </div>
-  </WithStyles(Tooltip)>
+  <div>
+    <WithStyles(Tooltip)
+      title="Set layer opacity"
+    >
+      <div>
+        <WithStyles(OpacitySlider)
+          classes={
+            Object {
+              "root": undefined,
+            }
+          }
+          onChange={[Function]}
+          opacity={0}
+        />
+      </div>
+    </WithStyles(Tooltip)>
+  </div>
   <WithStyles(LayerToolbarMoreMenu)
     classes={
       Object {
@@ -54,16 +61,23 @@ exports[`LayerToolbar Should match toolbar snapshot without Edit button 1`] = `
       <pure(VisibilityIcon) />
     </WithStyles(IconButton)>
   </WithStyles(Tooltip)>
-  <WithStyles(Tooltip)
-    title="Set layer opacity"
-  >
-    <div>
-      <WithStyles(OpacitySlider)
-        onChange={[Function]}
-        opacity={0}
-      />
-    </div>
-  </WithStyles(Tooltip)>
+  <div>
+    <WithStyles(Tooltip)
+      title="Set layer opacity"
+    >
+      <div>
+        <WithStyles(OpacitySlider)
+          classes={
+            Object {
+              "root": undefined,
+            }
+          }
+          onChange={[Function]}
+          opacity={0}
+        />
+      </div>
+    </WithStyles(Tooltip)>
+  </div>
   <WithStyles(LayerToolbarMoreMenu)
     classes={
       Object {


### PR DESCRIPTION
Fix the occasional rapid flashing of the tooltip when hovering the mouse close to the opacity slider.  To do this I've increased the "active" width of the tooltip click surface to be 16px high, matching the height of the slider tab button.  This also makes it easier to click somewhere along the slider tail and set the opacity without dragging.