### PR TITLE
Google maps download fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "31.0.14",
+    "version": "31.0.15",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {
@@ -43,7 +43,7 @@
         "@dhis2/d2-ui-interpretations": "^5.0.3",
         "@dhis2/d2-ui-org-unit-dialog": "^5.0.3",
         "@dhis2/d2-ui-org-unit-tree": "^5.0.3",
-        "@dhis2/gis-api": "^31.0.4",
+        "@dhis2/gis-api": "^31.0.6",
         "@material-ui/core": "^3.4.0",
         "@material-ui/icons": "^3.0.1",
         "@material-ui/lab": "^3.0.0-alpha.23",

--- a/src/util/dom-to-image.js
+++ b/src/util/dom-to-image.js
@@ -388,9 +388,9 @@ function newUtil() {
 
     function mimes() {
         /*
-              * Only WOFF and EOT mime types for fonts are 'real'
-              * see http://www.iana.org/assignments/media-types/media-types.xhtml
-              */
+         * Only WOFF and EOT mime types for fonts are 'real'
+         * see http://www.iana.org/assignments/media-types/media-types.xhtml
+         */
         const WOFF = 'application/font-woff';
         const JPEG = 'image/jpeg';
 
@@ -483,7 +483,9 @@ function newUtil() {
                 resolve(image);
             };
             image.onerror = reject;
-            image.src = uri;
+            // Applied fix to fix issue with Google Maps
+            // https://github.com/tsayen/dom-to-image/issues/243#issuecomment-414955354
+            image.src = encodeURI(uri);
         });
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -295,10 +295,10 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/gis-api@^31.0.4":
-  version "31.0.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/gis-api/-/gis-api-31.0.4.tgz#83dbad7ea3ce433f6058f12e32632c95e746d226"
-  integrity sha512-ydBzf6la0cIxTptnPBFXXyx3S6qAcAmsJ4hNmTXxmSBpTCSctDGXGxiUpF8LIAaNpUdPZJaOLN4NEujElW8YGg==
+"@dhis2/gis-api@^31.0.6":
+  version "31.0.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/gis-api/-/gis-api-31.0.6.tgz#99abd41b5da14573d907aa227f9ebfa5a1dabe9d"
+  integrity sha512-KZiCzQBQmHB9m9WWhGtlnlonRfGGaLvFiFfrM2uO2nS/3r9J+fx0jdSR707mged1TJKo7E5qsCsgxs6zDSJwpw==
   dependencies:
     "@turf/buffer" "^5.1.5"
     d3-color "^1.2.3"


### PR DESCRIPTION
This PR will fix an issue where downloading a map using Googe Maps was failing. It also includes a newer version of the GIS API where Google Maps is always loaded using https. 