### PR TITLE
Bug fixes for empty dimensions and period validation

### DIFF
--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -219,6 +219,6 @@ const getFilterOptionNames = async (filters, headers) => {
 
 // Empty filter sometimes returned for saved maps
 const isValidDimension = ({ dimension, items }) =>
-    Boolean(dimension && !(items && !items.length));
+    Boolean(dimension && (!items || items.length));
 
 export default eventLoader;

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -142,7 +142,7 @@ export const getAnalyticsRequest = async ({
 
     if (dataItems) {
         dataItems.forEach(item => {
-            if (item.dimension) {
+            if (isValidDimension(item)) {
                 analyticsRequest = analyticsRequest.addDimension(
                     item.dimension,
                     item.filter
@@ -216,5 +216,9 @@ const getFilterOptionNames = async (filters, headers) => {
         ))
     );
 };
+
+// Empty filter sometimes returned for saved maps
+const isValidDimension = ({ dimension, filter, items }) =>
+    Boolean(dimension && ((items && items.length) || filter));
 
 export default eventLoader;

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -218,7 +218,7 @@ const getFilterOptionNames = async (filters, headers) => {
 };
 
 // Empty filter sometimes returned for saved maps
-const isValidDimension = ({ dimension, filter, items }) =>
-    Boolean(dimension && ((items && items.length) || filter));
+const isValidDimension = ({ dimension, items }) =>
+    Boolean(dimension && !(items && !items.length));
 
 export default eventLoader;

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -125,8 +125,8 @@ export const formatTime = date =>
     timeFormat(DATE_FORMAT_SPECIFIER)(new Date(date));
 
 export const getStartEndDateError = (startDate, endDate) => {
-    const start = parseTime(startDate);
-    const end = parseTime(endDate);
+    const start = parseTime(startDate.substring(0, 10)); // Only check date part
+    const end = parseTime(endDate.substring(0, 10)); // Only check date part
     if (!start) {
         return i18n.t('Start date is invalid');
     } else if (!end) {


### PR DESCRIPTION
This PR fixes two bugs: 
- Invalid data dimensions (dx) with empty item array is not passed on to web api
- Older map objects (filters) includes dates with hours, and this fix only checks the validity of the date part which we currently support in the event dialog. 