### PR TITLE
Correct event colors from older map favorites

### DIFF
--- a/src/components/classification/Classification.js
+++ b/src/components/classification/Classification.js
@@ -13,7 +13,7 @@ import {
     defaultColorScale,
     getColorPalette,
     getColorScale,
-} from '../../util/colorscale';
+} from '../../util/colors';
 import { CLASSIFICATION_EQUAL_INTERVALS } from '../../constants/layers';
 
 const styles = {

--- a/src/components/core/ColorScaleSelect.js
+++ b/src/components/core/ColorScaleSelect.js
@@ -3,11 +3,7 @@ import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Popover from '@material-ui/core/Popover';
 import ColorScale from './ColorScale';
-import {
-    colorScales,
-    getColorScale,
-    getColorPalette,
-} from '../../util/colorscale';
+import { colorScales, getColorScale, getColorPalette } from '../../util/colors';
 
 const styles = {
     scale: {
@@ -41,8 +37,7 @@ class ColorScaleSelect extends Component {
     }
 
     // Show popover with allowed color scales
-    showColorScales = (event) => {
-
+    showColorScales = event => {
         this.setState({
             open: true,
             anchorEl: event.currentTarget,
@@ -56,7 +51,7 @@ class ColorScaleSelect extends Component {
     }
 
     // Called when a new color scale is selected in the popover
-    onColorScaleSelect = (scale) => {
+    onColorScaleSelect = scale => {
         const { palette, onChange } = this.props;
         const classes = palette.split(',').length;
 
@@ -91,7 +86,9 @@ class ColorScaleSelect extends Component {
                             scale={scale}
                             bins={bins}
                             style={styles.scaleItem}
-                            onClick={(event, scale) => this.onColorScaleSelect(scale)}
+                            onClick={(event, scale) =>
+                                this.onColorScaleSelect(scale)
+                            }
                             width={width || 260}
                         />
                     ))}

--- a/src/components/edit/EarthEngineDialog.js
+++ b/src/components/edit/EarthEngineDialog.js
@@ -10,7 +10,7 @@ import ColorScaleSelect from '../core/ColorScaleSelect';
 import Collection from '../earthengine/Collection';
 import LegendItem from '../layers/legend/LegendItem';
 import { setParams, setFilter, setPeriodName } from '../../actions/layerEdit';
-import { getColorScale, getColorPalette } from '../../util/colorscale';
+import { getColorScale, getColorPalette } from '../../util/colors';
 import { createLegend } from '../../loaders/earthEngineLoader';
 import { layerDialogStyles } from './LayerDialogStyles';
 import legendStyle from '../layers/legend/legendStyle';

--- a/src/components/edit/EventDialog.js
+++ b/src/components/edit/EventDialog.js
@@ -50,6 +50,7 @@ import {
     getUserOrgUnitsFromRows,
 } from '../../util/analytics';
 import { getStartEndDateError } from '../../util/helpers';
+import { cssColor } from '../../util/colors';
 
 // TODO: Don't use inline styles!
 const styles = {
@@ -337,7 +338,10 @@ export class EventDialog extends Component {
                                 <div style={styles.flexInnerColumnFlow}>
                                     <ColorPicker
                                         label={i18n.t('Color')}
-                                        color={eventPointColor || EVENT_COLOR}
+                                        color={
+                                            cssColor(eventPointColor) ||
+                                            EVENT_COLOR
+                                        }
                                         onChange={setEventPointColor}
                                         style={styles.flexInnerColumn}
                                     />

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -15,6 +15,7 @@ import {
 } from '../util/geojson';
 import { EVENT_COLOR, EVENT_RADIUS } from '../constants/layers';
 import { formatTime } from '../util/helpers';
+import { cssColor } from '../util/colors';
 
 // Server clustering if more than 2000 events
 const useServerCluster = count => count > 2000; // TODO: Use constant
@@ -75,7 +76,7 @@ const eventLoader = async layerConfig => {
                 config.legend.items = [
                     {
                         name: i18n.t('Event'),
-                        color: eventPointColor || EVENT_COLOR,
+                        color: cssColor(eventPointColor) || EVENT_COLOR,
                         radius: eventPointRadius || EVENT_RADIUS,
                     },
                 ];

--- a/src/util/colors.js
+++ b/src/util/colors.js
@@ -1,3 +1,4 @@
+import { isString } from 'lodash/fp';
 import colorbrewer from '../constants/colorbrewer';
 
 // Allowed color scales from ColorBrewer for EE (needs to have at least 9 classes)
@@ -54,3 +55,11 @@ export const defaultColorScale = getColorPalette(
     defaultColorScaleName,
     defaultClasses
 );
+
+// Correct colors not adhering to the css standard (add missing #)
+export const cssColor = color => {
+    if (!isString(color)) {
+        return color;
+    }
+    return (/(^[0-9A-F]{6}$)|(^[0-9A-F]{3}$)/i.test(color) ? '#' : '') + color;
+};

--- a/src/util/legend.js
+++ b/src/util/legend.js
@@ -3,7 +3,7 @@ import { getInstance as getD2 } from 'd2';
 import { sortBy } from 'lodash/fp';
 import { pick } from 'lodash/fp';
 import { getLegendItems } from '../util/classify';
-import { defaultClasses, defaultColorScale } from '../util/colorscale';
+import { defaultClasses, defaultColorScale } from '../util/colors';
 import { CLASSIFICATION_EQUAL_INTERVALS } from '../constants/layers';
 
 export const loadLegendSet = async legendSet => {
@@ -60,11 +60,10 @@ export const getPredefinedLegendItems = legendSet => {
 
     return sortBy('startValue', legendSet.legends)
         .map(pickSome)
-        .map(
-            item =>
-                item.name === `${item.startValue} - ${item.endValue}`
-                    ? { ...item, name: '' } // Clear name if same as startValue - endValue
-                    : item
+        .map(item =>
+            item.name === `${item.startValue} - ${item.endValue}`
+                ? { ...item, name: '' } // Clear name if same as startValue - endValue
+                : item
         );
 };
 

--- a/src/util/styleByDataItem.js
+++ b/src/util/styleByDataItem.js
@@ -13,6 +13,7 @@ import {
     CLASSIFICATION_PREDEFINED,
 } from '../constants/layers';
 import { numberValueTypes } from '../constants/valueTypes';
+import { cssColor } from '../util/colors';
 
 // "Style by data item" handling for event layer
 // Can be reused for TEI layer when the Web API is improved
@@ -30,7 +31,7 @@ export const styleByDataItem = async config => {
 
     config.legend.items.push({
         name: i18n.t('Not set'),
-        color: config.eventPointColor || EVENT_COLOR,
+        color: cssColor(config.eventPointColor) || EVENT_COLOR,
         radius: config.eventPointRadius || EVENT_RADIUS,
     });
 


### PR DESCRIPTION
We now expect all colors to follow the CSS standard. Previously we stored colors without the #. This PR corrects these colors for events layers where we have this problem: https://jira.dhis2.org/browse/DHIS2-5371

The utility file colorscale.js was renamed to colors.js to make it more generic for color handling. 