### PR TITLE
Fix issues with filter and style by data element

### DIFF
--- a/src/components/filter/FilterSelect.js
+++ b/src/components/filter/FilterSelect.js
@@ -31,7 +31,7 @@ const styles = {
 
 export class FilterSelect extends Component {
     static propTypes = {
-        valueType: PropTypes.string.isRequired,
+        valueType: PropTypes.string,
         filter: PropTypes.string,
         optionSet: PropTypes.object,
         optionSets: PropTypes.object,

--- a/src/components/layers/legend/legendStyle.js
+++ b/src/components/layers/legend/legendStyle.js
@@ -1,6 +1,6 @@
 export default {
-    paddingBottom: 16,
-    margin: 0,
+    margin: '0 8px 16px 0',
+    lineHeight: '18px',
     '& table': {
         borderCollapse: 'collapse',
         borderSpacing: 0,

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -172,6 +172,7 @@ export const loadData = async (request, config = {}) => {
     const response = await d2.analytics.events.getQuery(request);
 
     const { data, names } = createEventFeatures(response, config);
+
     return {
         data,
         names,
@@ -202,7 +203,7 @@ const getFilterOptionNames = async (filters, headers) => {
         optionSets.map(id =>
             d2.models.optionSets
                 .get(id, {
-                    fields: 'options[code,displayName~rename(name)]',
+                    fields: 'options[id,code,displayName~rename(name)]',
                 })
                 .then(model => model.options)
                 .then(options =>
@@ -225,7 +226,8 @@ const getFilterOptionNames = async (filters, headers) => {
 };
 
 // Empty filter sometimes returned for saved maps
-const isValidDimension = ({ dimension, items }) =>
-    Boolean(dimension && (!items || items.length));
+// Dimension without filter and empty items array returns false
+const isValidDimension = ({ dimension, filter, items }) =>
+    Boolean(dimension && (filter || (!items || items.length)));
 
 export default eventLoader;

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -203,7 +203,7 @@ const getFilterOptionNames = async (filters, headers) => {
         optionSets.map(id =>
             d2.models.optionSets
                 .get(id, {
-                    fields: 'options[id,code,displayName~rename(name)]',
+                    fields: 'options[code,displayName~rename(name)]',
                 })
                 .then(model => model.options)
                 .then(options =>

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -228,6 +228,6 @@ const getFilterOptionNames = async (filters, headers) => {
 // Empty filter sometimes returned for saved maps
 // Dimension without filter and empty items array returns false
 const isValidDimension = ({ dimension, filter, items }) =>
-    Boolean(dimension && (filter || (!items || items.length)));
+    Boolean(dimension && (filter || !items || items.length));
 
 export default eventLoader;

--- a/src/util/__tests__/geojson.spec.js
+++ b/src/util/__tests__/geojson.spec.js
@@ -1,5 +1,13 @@
 import FileSaver from 'file-saver';
-import { createGeoJsonBlob, downloadGeoJson, getBounds, addStyleDataItem, createEventFeature, buildEventCoordinateGetter, createEventFeatures } from '../geojson';
+import {
+    createGeoJsonBlob,
+    downloadGeoJson,
+    getBounds,
+    addStyleDataItem,
+    createEventFeature,
+    buildEventCoordinateGetter,
+    createEventFeatures,
+} from '../geojson';
 
 // Since we're not in a browser environment we unfortunately have to mock FileSaver and Blob
 jest.mock('file-saver', () => ({ saveAs: jest.fn() }));
@@ -64,22 +72,21 @@ describe('geojson utils', () => {
     });
 
     describe('createEventFeature', () => {
-        const headers = [
-            { name: 'C1' },
-            { name: 'C2' },
-        ]
+        const headers = [{ name: 'C1' }, { name: 'C2' }];
         const dummyID = 'IAmAnID';
         const dummyEventRow = ['What is the question?', 42];
         const dummyCoordinates = [0, 0];
         const dummyGetCoordinates = jest.fn(x => dummyCoordinates.map(String)); // Stringify
         it('Should create a single feature from a single event with no Names passed', () => {
-            expect(createEventFeature(
-                headers,
-                {},
-                dummyEventRow,
-                dummyID,
-                dummyGetCoordinates
-            )).toEqual({
+            expect(
+                createEventFeature(
+                    headers,
+                    {},
+                    dummyEventRow,
+                    dummyID,
+                    dummyGetCoordinates
+                )
+            ).toEqual({
                 type: 'Feature',
                 id: dummyID,
                 properties: {
@@ -91,26 +98,32 @@ describe('geojson utils', () => {
                     coordinates: dummyCoordinates,
                 },
             });
-        })
+        });
 
         it('Should convert property names when they match passed names', () => {
             const names = {
                 [headers[0].name]: 'Column #1',
             };
-            expect(createEventFeature(headers, names, dummyEventRow, dummyID, dummyGetCoordinates)).toEqual(
-                {
-                    type: 'Feature',
-                    id: dummyID,
-                    properties: {
-                        [names[headers[0].name]]: dummyEventRow[0],
-                        [headers[1].name]: dummyEventRow[1],
-                    },
-                    geometry: {
-                        type: 'Point',
-                        coordinates: dummyCoordinates,
-                    },
-                }
-            );
+            expect(
+                createEventFeature(
+                    headers,
+                    names,
+                    dummyEventRow,
+                    dummyID,
+                    dummyGetCoordinates
+                )
+            ).toEqual({
+                type: 'Feature',
+                id: dummyID,
+                properties: {
+                    [names[headers[0].name]]: dummyEventRow[0],
+                    [headers[1].name]: dummyEventRow[1],
+                },
+                geometry: {
+                    type: 'Point',
+                    coordinates: dummyCoordinates,
+                },
+            });
         });
     });
 
@@ -123,7 +136,7 @@ describe('geojson utils', () => {
             { name: 'SomeField' },
             { name: 'myArrayCoordinates' },
             { name: 'SomeOtherField' },
-        ]
+        ];
         const coords = [12.9, 5.4];
         const stringCoords = [9, 14.3];
         const arrayCoords = [21.1, 42.2];
@@ -134,20 +147,26 @@ describe('geojson utils', () => {
             coords[0],
             54321,
             arrayCoords,
-            1234
-        ]
+            1234,
+        ];
         it('Should default to fetching longitude and latitude columns', () => {
             const getter = buildEventCoordinateGetter(headers);
             expect(getter(dummyEvent)).toEqual(coords);
         });
 
         it('Should parse a string coordinate', () => {
-            const getter = buildEventCoordinateGetter(headers, 'myStringCoordinates');
+            const getter = buildEventCoordinateGetter(
+                headers,
+                'myStringCoordinates'
+            );
             expect(getter(dummyEvent)).toEqual(stringCoords);
         });
 
         it('Should parse a coordinate array', () => {
-            const getter = buildEventCoordinateGetter(headers, 'myArrayCoordinates');
+            const getter = buildEventCoordinateGetter(
+                headers,
+                'myArrayCoordinates'
+            );
             expect(getter(dummyEvent)).toEqual(arrayCoords);
         });
 
@@ -155,7 +174,7 @@ describe('geojson utils', () => {
             const getter = buildEventCoordinateGetter(headers, 'SomeField');
             expect(getter(dummyEvent)).toEqual([]);
         });
-        
+
         it('Should return an empty array on invalid string value', () => {
             const getter = buildEventCoordinateGetter(headers, 'id');
             expect(getter(dummyEvent)).toEqual([]);
@@ -172,12 +191,15 @@ describe('geojson utils', () => {
             { name: 'SomeOtherField', column: 'SomeOtherField Column' },
         ];
         const metaData = {
-            items: headers.reduce((out, header) => ({
-                ...out,
-                [header.name]: header.name + 'META',
-            }), {}),
+            items: headers.reduce(
+                (out, header) => ({
+                    ...out,
+                    [header.name]: header.name + 'META',
+                }),
+                {}
+            ),
         };
-        
+
         const rows = [
             ['ping', 'psi0', 'id0', 21.1, 42.2, 'pong'],
             ['foo', 'psi1', 'id1', 21.2, 42.3, 'bar'],
@@ -187,7 +209,7 @@ describe('geojson utils', () => {
         const response = {
             headers,
             rows,
-            metaData
+            metaData,
         };
 
         const defaultNames = headers.reduce(
@@ -200,47 +222,55 @@ describe('geojson utils', () => {
 
         it('Should create an array of features with the proper field mappings', () => {
             const out = createEventFeatures(response);
-            expect(out.names).toEqual(defaultNames)
-            expect(out.data).toEqual(rows.map(row => ({
-                type: 'Feature',
-                id: row[1],
-                properties: headers.reduce((out, header, i) => ({
-                    ...out,
-                    [header.column]: row[i],
-                }), {}),
-                geometry: {
-                    type: 'Point',
-                    coordinates: [row[4], row[3]],
-                },
-            })));
-        })
+            expect(out.names).toEqual(defaultNames);
+            expect(out.data).toEqual(
+                rows.map(row => ({
+                    type: 'Feature',
+                    id: row[1],
+                    properties: headers.reduce(
+                        (out, header, i) => ({
+                            ...out,
+                            [header.column]: row[i],
+                        }),
+                        {}
+                    ),
+                    geometry: {
+                        type: 'Point',
+                        coordinates: [row[4], row[3]],
+                    },
+                }))
+            );
+        });
 
         it('Should use alternative ID column', () => {
             const out = createEventFeatures(response, { idCol: 'TheRealID' });
             expect(out.names).toEqual(defaultNames);
-            expect(out.data).toEqual(rows.map(row => ({
-                type: 'Feature',
-                id: row[2],
-                properties: headers.reduce(
-                    (out, header, i) => ({
-                        ...out,
-                        [header.column]: row[i],
-                    }),
-                    {}
-                ),
-                geometry: {
-                    type: 'Point',
-                    coordinates: [row[4], row[3]],
-                },
-            })));
+            expect(out.data).toEqual(
+                rows.map(row => ({
+                    type: 'Feature',
+                    id: row[2],
+                    properties: headers.reduce(
+                        (out, header, i) => ({
+                            ...out,
+                            [header.column]: row[i],
+                        }),
+                        {}
+                    ),
+                    geometry: {
+                        type: 'Point',
+                        coordinates: [row[4], row[3]],
+                    },
+                }))
+            );
         });
 
         it('Should use ID output scheme', () => {
             const out = createEventFeatures(response, {
                 outputIdScheme: 'ID',
             });
-            expect(out.names).toEqual({});
-            expect(out.data).toEqual(rows.map(row => ({
+            // expect(out.names).toEqual({});
+            expect(out.data).toEqual(
+                rows.map(row => ({
                     type: 'Feature',
                     id: row[1],
                     properties: headers.reduce(
@@ -254,35 +284,41 @@ describe('geojson utils', () => {
                         type: 'Point',
                         coordinates: [row[4], row[3]],
                     },
-                })));
+                }))
+            );
         });
 
         it('Should use custom name mappings', () => {
-            const columnNames = headers.reduce((out, header) => ({
-                ...out,
-                [header.name]: `${header.name} CUSTOM`,
-            }), {});
+            const columnNames = headers.reduce(
+                (out, header) => ({
+                    ...out,
+                    [header.name]: `${header.name} CUSTOM`,
+                }),
+                {}
+            );
             const out = createEventFeatures(response, {
-                columnNames
+                columnNames,
             });
             expect(out.names).toEqual(columnNames);
-            expect(out.data).toEqual(rows.map(row => ({
-                type: 'Feature',
-                id: row[1],
-                properties: headers.reduce(
-                    (out, header, i) => ({
-                        ...out,
-                        [`${header.name} CUSTOM`]: row[i],
-                    }),
-                    {}
-                ),
-                geometry: {
-                    type: 'Point',
-                    coordinates: [row[4], row[3]],
-                },
-            })));
+            expect(out.data).toEqual(
+                rows.map(row => ({
+                    type: 'Feature',
+                    id: row[1],
+                    properties: headers.reduce(
+                        (out, header, i) => ({
+                            ...out,
+                            [`${header.name} CUSTOM`]: row[i],
+                        }),
+                        {}
+                    ),
+                    geometry: {
+                        type: 'Point',
+                        coordinates: [row[4], row[3]],
+                    },
+                }))
+            );
         });
-    })
+    });
 
     describe('addStyleDataItem', () => {
         const dummyDataItems = ['test', 'copy', 42]; // Types shouldn't be coerced
@@ -303,17 +339,16 @@ describe('geojson utils', () => {
                 dimension: newItem.id,
                 name: newItem.name,
             });
-        })
+        });
     });
 
     describe('getBounds', () => {
         it('Should return null when passed null', () => {
             expect(getBounds()).toBeNull();
-        })
+        });
         it('Should correctly parse a simple bounding box', () => {
             const bbox = getBounds('[0][1][2][3]');
-            expect(bbox).toEqual([ ['1','0'], ['3','2'] ]);
-        })
+            expect(bbox).toEqual([['1', '0'], ['3', '2']]);
+        });
     });
-
 });

--- a/src/util/__tests__/geojson.spec.js
+++ b/src/util/__tests__/geojson.spec.js
@@ -268,7 +268,7 @@ describe('geojson utils', () => {
             const out = createEventFeatures(response, {
                 outputIdScheme: 'ID',
             });
-            // expect(out.names).toEqual({});
+            expect(out.names).toEqual(defaultNames);
             expect(out.data).toEqual(
                 rows.map(row => ({
                     type: 'Feature',

--- a/src/util/geojson.js
+++ b/src/util/geojson.js
@@ -86,20 +86,6 @@ export const buildEventCoordinateGetter = (headers, eventCoordinateField) => {
 
 export const createEventFeatures = (response, config = {}) => {
     const names = {
-        ...(config.outputIdScheme !== 'ID'
-            ? response.headers.reduce(
-                  (names, header) => ({
-                      ...names,
-                      [header.name]: header.column,
-                  }),
-                  {}
-              )
-            : null),
-        ...config.columnNames,
-    }; // TODO: Pass this through the the request to support ID/NAME/CODE output natively.  Server bugfix needed.
-
-    /*
-    const names = {
         ...response.headers.reduce(
             (names, header) => ({
                 ...names,
@@ -107,8 +93,8 @@ export const createEventFeatures = (response, config = {}) => {
             }),
             {}
         ),
+        ...config.columnNames,
     };
-    */
 
     const idColName = config.idCol || 'psi';
     const idCol = findIndex(response.headers, h => h.name === idColName);
@@ -120,7 +106,7 @@ export const createEventFeatures = (response, config = {}) => {
         .map(row =>
             createEventFeature(
                 response.headers,
-                names,
+                config.outputIdScheme !== 'ID' ? names : {},
                 row,
                 row[idCol],
                 getCoordinates

--- a/src/util/geojson.js
+++ b/src/util/geojson.js
@@ -98,6 +98,18 @@ export const createEventFeatures = (response, config = {}) => {
         ...config.columnNames,
     }; // TODO: Pass this through the the request to support ID/NAME/CODE output natively.  Server bugfix needed.
 
+    /*
+    const names = {
+        ...response.headers.reduce(
+            (names, header) => ({
+                ...names,
+                [header.name]: header.column,
+            }),
+            {}
+        ),
+    };
+    */
+
     const idColName = config.idCol || 'psi';
     const idCol = findIndex(response.headers, h => h.name === idColName);
     const getCoordinates = buildEventCoordinateGetter(
@@ -119,9 +131,10 @@ export const createEventFeatures = (response, config = {}) => {
     return { data, names };
 };
 
-// Include column for data element used for styling
+// Include column for data element used for styling (if not already used in filter)
 export const addStyleDataItem = (dataItems, styleDataItem) =>
-    styleDataItem
+    styleDataItem &&
+    !dataItems.find(item => item.dimension === styleDataItem.id)
         ? [
               ...dataItems,
               {

--- a/src/util/geojson.js
+++ b/src/util/geojson.js
@@ -93,7 +93,7 @@ export const createEventFeatures = (response, config = {}) => {
             }),
             {}
         ),
-        ...config.columnNames,
+        ...config.columnNames, // TODO: Check if columnNames is still needed
     };
 
     const idColName = config.idCol || 'psi';

--- a/src/util/styleByDataItem.js
+++ b/src/util/styleByDataItem.js
@@ -130,8 +130,6 @@ export const styleByNumeric = async config => {
 
     // Add style data value and color to each feature
     config.data = config.data.map(feature => {
-        console.log(feature.properties, styleDataItem.id);
-
         const value = Number(feature.properties[styleDataItem.id]);
         const legendItem = getLegendItem(value);
 

--- a/src/util/styleByDataItem.js
+++ b/src/util/styleByDataItem.js
@@ -130,6 +130,8 @@ export const styleByNumeric = async config => {
 
     // Add style data value and color to each feature
     config.data = config.data.map(feature => {
+        console.log(feature.properties, styleDataItem.id);
+
         const value = Number(feature.properties[styleDataItem.id]);
         const legendItem = getLegendItem(value);
 


### PR DESCRIPTION
This PR fixes various issues with event layers filters and styling by data element:
- Added right padding to event legend 
- Allow dimensions to have empty items array if it contains a filter (issue with saved maps)
- Fix issue with header names needed for legend
- Don't include styleDataItem as a dimension if it's already included in a filter

Related issue: https://jira.dhis2.org/browse/DHIS2-5397

Sorry that the tests got reformatted when I edited them :-)