### PR TITLE
Improved error handling for failing map layers

### DIFF
--- a/plugin.html
+++ b/plugin.html
@@ -25,7 +25,7 @@
     <div id="savedMapPicker" class="savedMapPicker">
         <div>
             <label>Saved Map ID</label>
-            <input type="text" id="inputMapID" value="zDP78aJU8nX" />
+            <input type="text" id="inputMapID" value="voX07ulo2Bq" />
         </div>
         <div>
             <label>User Org Unit</label>

--- a/src/components/map/plugin/PluginLegend.js
+++ b/src/components/map/plugin/PluginLegend.js
@@ -1,7 +1,6 @@
-import React, { PureComponent } from 'react';
+import React, { PureComponent, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
-import i18n from '@dhis2/d2-i18n';
 import Legend from '../../layers/legend/Legend';
 
 const styles = theme => ({
@@ -16,8 +15,8 @@ const styles = theme => ({
         display: 'block',
         fontWeight: 'normal',
     },
-    nodata: {
-        fontStyle: 'italic',
+    alert: {
+        paddingBottom: 8,
     },
 });
 
@@ -56,12 +55,15 @@ class PluginLegend extends PureComponent {
     // Contents is rendered to a hidden div
     render() {
         const { layers, classes } = this.props;
-        const legendLayers = layers.filter(layer => layer.legend);
+        const legendLayers = layers.filter(
+            layer => layer.legend || layer.alerts
+        );
 
+        // Alerts are added to legend to be less intrusive
         return (
             <div ref={el => (this.container = el)} style={{ display: 'none' }}>
                 {legendLayers.map(
-                    ({ id, layer, legend, serverCluster, data }) => {
+                    ({ id, layer, legend, serverCluster, data, alerts }) => {
                         const hasData =
                             (Array.isArray(data) && data.length > 0) ||
                             serverCluster ||
@@ -69,19 +71,27 @@ class PluginLegend extends PureComponent {
 
                         return (
                             <div key={id}>
-                                <h2 className={classes.title}>
-                                    {legend.title}{' '}
-                                    <span className={classes.period}>
-                                        {legend.period}
-                                    </span>
-                                </h2>
-                                {hasData ? (
-                                    <Legend {...legend} />
-                                ) : (
-                                    <div className={classes.nodata}>
-                                        {i18n.t('No data found')}
-                                    </div>
+                                {legend && (
+                                    <Fragment>
+                                        <h2 className={classes.title}>
+                                            {legend.title}{' '}
+                                            <span className={classes.period}>
+                                                {legend.period}
+                                            </span>
+                                        </h2>
+                                        {hasData && <Legend {...legend} />}
+                                    </Fragment>
                                 )}
+                                {alerts &&
+                                    alerts.map(alert => (
+                                        <div
+                                            key={alert.id}
+                                            className={classes.alert}
+                                        >
+                                            <strong>{alert.title}</strong>:{' '}
+                                            {alert.description}
+                                        </div>
+                                    ))}
                             </div>
                         );
                     }

--- a/src/components/map/plugin/PluginMap.js
+++ b/src/components/map/plugin/PluginMap.js
@@ -29,14 +29,6 @@ const styles = {
         width: '100%',
         height: '100%',
     },
-    alerts: {
-        padding: 20,
-        fontSize: 12,
-    },
-    alert: {
-        lineHeight: '16px',
-        paddingBottom: 8,
-    },
 };
 
 // TODO: Reuse code from Map.js
@@ -166,8 +158,8 @@ class PluginMap extends Component {
             const newLayer = await fetchLayer(newConfig);
 
             this.setState({
-                mapViews: mapViews.map(
-                    layer => (layer.id === layerId ? newLayer : layer)
+                mapViews: mapViews.map(layer =>
+                    layer.id === layerId ? newLayer : layer
                 ),
                 position: null,
                 feature: null,
@@ -179,11 +171,7 @@ class PluginMap extends Component {
         const { basemap = { id: 'osmLight' } } = this.props;
         const { mapViews, position, feature } = this.state;
 
-        // Disabled alerts as one layer without data will result in no map
-        // No data warning added to legend instead
-        const alerts = []; // getMapAlerts(this.props); // ADDED
-
-        return !alerts.length ? (
+        return (
             <div ref={node => (this.node = node)} style={styles.map}>
                 {mapViews
                     .filter(layer => layer.isLoaded)
@@ -213,14 +201,6 @@ class PluginMap extends Component {
                     onDrillDown={() => this.onDrill('down')}
                     onDrillUp={() => this.onDrill('up')}
                 />
-            </div>
-        ) : (
-            <div style={styles.alerts}>
-                {alerts.map(alert => (
-                    <div key={alert.id} style={styles.alert}>
-                        <strong>{alert.title}</strong>: {alert.description}
-                    </div>
-                ))}
             </div>
         );
     }

--- a/src/epics/layers.js
+++ b/src/epics/layers.js
@@ -23,9 +23,8 @@ export const loadLayerEpic = action$ =>
     action$.ofType(types.LAYER_LOAD).concatMap(action =>
         fetchLayer(action.payload)
             .then(increaseEditCounter)
-            .then(
-                config =>
-                    isNewLayer(config) ? addLayer(config) : updateLayer(config)
+            .then(config =>
+                isNewLayer(config) ? addLayer(config) : updateLayer(config)
             )
             .catch(errorActionCreator(types.LAYER_LOAD_ERROR))
     );

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -35,6 +35,7 @@ const thematicLoader = async config => {
                       alerts: [createAlert(i18n.t('Error'), error.message)],
                   }
                 : {}),
+            isLoaded: true,
             isVisible: true,
         };
     }

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -35,7 +35,6 @@ const thematicLoader = async config => {
                       alerts: [createAlert(i18n.t('Error'), error.message)],
                   }
                 : {}),
-            isLoaded: true,
             isVisible: true,
         };
     }
@@ -209,11 +208,9 @@ const loadData = async config => {
         .displayProperty(displayPropertyUpper)
         .getAll(geoFeaturesParams)
         .then(toGeoJson);
-    // .catch(console.log);
 
     // Data request
     const dataReq = d2.analytics.aggregate.get(analyticsRequest);
-    // .catch(console.log);
 
     // Return promise with both requests
     return Promise.all([orgUnitReq, dataReq]);


### PR DESCRIPTION
This PR checks for errors when loading thematic layers, and displays this error in a snackbar (Maps app) or in the legend (Dashboard)

Partly fixes: https://jira.dhis2.org/browse/DHIS2-5412
We could add a similar fix for event layers. 

Previously we showed alerts instead of the map on the dashboard, but we decided to change this as some layers might work. 

![skjermbilde 2018-11-28 kl 20 37 01](https://user-images.githubusercontent.com/548708/49177384-66f28000-f34d-11e8-8472-5121764ce928.png)

![skjermbilde 2018-11-28 kl 20 28 47](https://user-images.githubusercontent.com/548708/49177390-6c4fca80-f34d-11e8-95e2-a002bc446406.png)

