### PR TITLE
Add loading text to layer card

### DIFF
--- a/src/components/layers/layers/LayerCard.js
+++ b/src/components/layers/layers/LayerCard.js
@@ -114,7 +114,7 @@ const LayerCard = ({
                     title: classes.title,
                     subheader: classes.subheader,
                 }}
-                title={isLoaded ? name : i18n.t('Layer is loading')}
+                title={isLoaded ? name : i18n.t('Loading layer') + '...'}
                 subheader={
                     isLoaded && legend && legend.period ? legend.period : null
                 }

--- a/src/components/layers/layers/LayerCard.js
+++ b/src/components/layers/layers/LayerCard.js
@@ -99,6 +99,7 @@ const LayerCard = ({
         opacity,
         isVisible,
         layer: layerType,
+        isLoaded,
     } = layer;
 
     const canEdit = layerType !== 'external';
@@ -113,8 +114,10 @@ const LayerCard = ({
                     title: classes.title,
                     subheader: classes.subheader,
                 }}
-                title={name}
-                subheader={legend && legend.period ? legend.period : null}
+                title={isLoaded ? name : i18n.t('Layer is loading')}
+                subheader={
+                    isLoaded && legend && legend.period ? legend.period : null
+                }
                 action={[
                     <SortableHandle key="handle" />,
                     <Tooltip key="expand" title={i18n.t('Collapse')}>


### PR DESCRIPTION
Add "Layer is loading" message to the layer card, and avoids displaying the layer id as a name. 