### PR TITLE
Fix for style issues in download maps

### DIFF
--- a/src/components/download/DownloadLegend.js
+++ b/src/components/download/DownloadLegend.js
@@ -20,6 +20,9 @@ const styles = theme => ({
             color: theme.palette.text.primary,
         },
     },
+    legend: {
+        marginBottom: 16,
+    },
     title: {
         fontSize: 15,
         fontWeight: 500,
@@ -66,7 +69,7 @@ export const DownloadLegend = ({ position, layers, showName, classes }) => {
     return (
         <div className={className}>
             {legends.map((legend, index) => (
-                <div key={index}>
+                <div key={index} className={classes.legend}>
                     <h2 className={classes.title}>
                         {legend.title}
                         <span className={classes.period}>{legend.period}</span>

--- a/src/components/map/EventLayer.js
+++ b/src/components/map/EventLayer.js
@@ -4,7 +4,7 @@ import { apiFetch } from '../../util/api';
 import { getAnalyticsRequest } from '../../loaders/eventLoader';
 import { EVENT_COLOR, EVENT_RADIUS } from '../../constants/layers';
 import Layer from './Layer';
-import { getDisplayPropertyUrl } from '../../util/helpers';
+import { getDisplayPropertyUrl, removeLineBreaks } from '../../util/helpers';
 
 class EventLayer extends Layer {
     createLayer() {
@@ -201,7 +201,7 @@ class EventLayer extends Layer {
               </tbody></table>`;
 
             // Remove all line breaks as it's not working for map download
-            callback(content.replace(/(\r\n\t|\n|\r\t)/gm, ''));
+            callback(removeLineBreaks(content));
         });
     }
 

--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -50,6 +50,10 @@ const styles = {
         },
     },
     mapDownload: {
+        // Roboto font is not loaded by dom-to-image => switch to Arial
+        '& div': {
+            fontFamily: 'Arial,sans-serif!important',
+        },
         '& .leaflet-control-zoom, & .leaflet-control-geocoder, & .leaflet-control-measure, & .leaflet-control-fit-bounds': {
             display: 'none!important',
         },

--- a/src/components/map/MapName.js
+++ b/src/components/map/MapName.js
@@ -5,7 +5,6 @@ import { withStyles } from '@material-ui/core/styles';
 const styles = theme => ({
     name: {
         position: 'absolute',
-        fontFamily: 'Arial, Helvetica, sans-serif!important', // TODO: Fix wrapping problems with Roboto font (download)
         top: theme.spacing.unit,
         left: '50%',
         transform: 'translateX(-50%)',

--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -1,6 +1,7 @@
 import Layer from './Layer';
 import { filterData } from '../../util/filter';
 import { cssColor } from '../../util/colors';
+import { removeLineBreaks } from '../../util/helpers';
 import {
     LABEL_FONT_SIZE,
     LABEL_FONT_STYLE,
@@ -72,7 +73,7 @@ class ThematicLayer extends Layer {
 
         L.popup()
             .setLatLng(evt.latlng)
-            .setContent(content)
+            .setContent(removeLineBreaks(content))
             .openOn(map);
     }
 

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -139,4 +139,4 @@ export const getStartEndDateError = (startDate, endDate) => {
 
 // Remove line breaks from text (not displayed corrently in map downloads)
 // https://stackoverflow.com/questions/10805125/how-to-remove-all-line-breaks-from-a-string/10805292#10805292
-export const removeLineBreaks = text => text.replace(/\r?\n|\r/g, '');
+export const removeLineBreaks = text => text.replace(/\r?\n|\r/g, ' ');

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -138,4 +138,5 @@ export const getStartEndDateError = (startDate, endDate) => {
 };
 
 // Remove line breaks from text (not displayed corrently in map downloads)
-export const removeLineBreaks = text => text.replace(/(\r\n\t|\n|\r\t)/gm, '');
+// https://stackoverflow.com/questions/10805125/how-to-remove-all-line-breaks-from-a-string/10805292#10805292
+export const removeLineBreaks = text => text.replace(/\r?\n|\r/g, '');

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -136,3 +136,6 @@ export const getStartEndDateError = (startDate, endDate) => {
     }
     return null;
 };
+
+// Remove line breaks from text (not displayed corrently in map downloads)
+export const removeLineBreaks = text => text.replace(/(\r\n\t|\n|\r\t)/gm, '');


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-5478

dom-to-image is not loading the Robot font for some reason. A quickfix was to switch to Arial when going into download mode. 

Added removeLineBreaks as a utility method. Used to remove line breaks from html text strings. 

![map-th2ly](https://user-images.githubusercontent.com/548708/49437739-a2150900-f7bc-11e8-9e03-74fa2d809f20.png)
