### PR TITLE
Show relative period data from interpretations

### DIFF
--- a/src/components/core/InterpretationIcon.js
+++ b/src/components/core/InterpretationIcon.js
@@ -1,0 +1,89 @@
+import React from 'react';
+
+// Copied from https://github.com/dhis2/data-visualizer-app/blob/master/packages/app/src/assets/InterpretationIcon.js
+// TODO: Should be from a shared repo
+const InterpretationIcon = () => {
+    return (
+        <svg
+            width="16px"
+            height="16px"
+            viewBox="0 0 16 16"
+            version="1.1"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <g
+                id="Exp"
+                stroke="none"
+                strokeWidth="1"
+                fill="none"
+                fillRule="evenodd"
+            >
+                <g
+                    id="2---Home-+-Selected-Intp."
+                    transform="translate(-522.000000, -169.000000)"
+                >
+                    <rect
+                        fill="#F4F6F8"
+                        x="0"
+                        y="0"
+                        width="1280"
+                        height="850"
+                    />
+                    <g
+                        id="title-area"
+                        transform="translate(298.000000, 165.000000)"
+                    >
+                        <g
+                            id="name-badge"
+                            transform="translate(220.000000, 0.000000)"
+                        >
+                            <rect
+                                id="Rectangle-4"
+                                fill="#FFFFFF"
+                                opacity="0.700613839"
+                                x="0"
+                                y="0"
+                                width="260"
+                                height="24"
+                                rx="4"
+                            />
+                            <g
+                                id="undo"
+                                transform="translate(4.000000, 4.000000)"
+                            >
+                                <rect
+                                    id="frame"
+                                    x="0"
+                                    y="0"
+                                    width="16"
+                                    height="16"
+                                />
+                                <polyline
+                                    id="Path"
+                                    stroke="#494949"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    points="2.375 2.374 2.375 6.124 6.125 6.124"
+                                />
+                                <path
+                                    d="M8,13.624 C10.8610015,13.6256787 13.2674888,11.4795583 13.5919996,8.63701982 C13.9165103,5.79448132 12.0556517,3.16119082 9.2678875,2.51799333 C6.48012327,1.87479584 3.65366782,3.42662163 2.7,6.124"
+                                    id="Path"
+                                    stroke="#494949"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                />
+                                <path
+                                    d="M9,7.29289322 L11.1819805,9.47487373 C11.3772427,9.67013588 11.3772427,9.98671837 11.1819805,10.1819805 C10.9867184,10.3772427 10.6701359,10.3772427 10.4748737,10.1819805 L8.01023174,7.71733852 L8,7.7144165 L8,5.5 C8,5.22385763 8.22385763,5 8.5,5 C8.77614237,5 9,5.22385763 9,5.5 L9,7.29289322 Z"
+                                    id="Combined-Shape"
+                                    fill="#494949"
+                                />
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </svg>
+    );
+};
+
+export default InterpretationIcon;

--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -164,6 +164,7 @@ class Map extends Component {
     render() {
         const {
             name,
+            interpretationDate,
             basemap,
             basemaps,
             mapViews,
@@ -203,7 +204,12 @@ class Map extends Component {
                     ref={node => (this.node = node)}
                     className={classes.mapContainer}
                 >
-                    {name && showName && <MapName name={name} />}
+                    {name && showName && (
+                        <MapName
+                            name={name}
+                            interpretationDate={interpretationDate}
+                        />
+                    )}
                     {layers
                         .filter(layer => layer.isLoaded)
                         .map((config, index) => {

--- a/src/components/map/MapName.js
+++ b/src/components/map/MapName.js
@@ -1,28 +1,69 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
+import i18n from '@dhis2/d2-i18n';
+import InterpretationIcon from '../core/InterpretationIcon';
+import { timeFormat } from 'd3-time-format';
+
+const formatTime = timeFormat('%b %d, %Y'); // TODO: Support different locales
 
 const styles = theme => ({
-    name: {
+    root: {
+        display: 'flex',
+        justifyContent: 'center',
         position: 'absolute',
-        top: theme.spacing.unit,
-        left: '50%',
-        transform: 'translateX(-50%)',
+        maxWidth: 'calc(100% - 100px)',
+        top: 0,
+        left: 0,
+        right: 0,
+        margin: '0 auto',
         zIndex: 999,
-        padding: '6px 8px',
-        backgroundColor: 'rgba(255,255,255,0.9)',
-        boxShadow: theme.shadows[1],
-        borderRadius: theme.shape.borderRadius,
         fontSize: theme.typography.fontSize,
+        '& > div': {
+            backgroundColor: 'rgba(255,255,255,0.9)',
+            boxShadow: theme.shadows[1],
+            borderRadius: theme.shape.borderRadius,
+            margin: 8,
+        },
+    },
+    name: {
+        padding: '6px 8px',
+        lineHeight: '17px',
+    },
+    interpretation: {
+        position: 'relative',
+        padding: '7px 8px 7px 28px',
+        fontSize: 12,
+        lineHeight: '15px',
+    },
+    interpretationIcon: {
+        position: 'absolute',
+        left: theme.spacing.unit,
+        top: 7,
     },
 });
 
-const MapName = ({ name, classes }) => (
-    <div className={classes.name}>{name}</div>
+const MapName = ({ name, interpretationDate, classes }) => (
+    <div className={classes.root}>
+        <div className={classes.name}>{name}</div>
+        {interpretationDate && (
+            <div className={classes.interpretation}>
+                <div className={classes.interpretationIcon}>
+                    <InterpretationIcon />
+                </div>
+                {i18n.t('Viewing interpretation from {{interpretationDate}}', {
+                    interpretationDate: formatTime(
+                        new Date(interpretationDate)
+                    ),
+                })}
+            </div>
+        )}
+    </div>
 );
 
 MapName.propTypes = {
     name: PropTypes.string,
+    interpretationDate: PropTypes.string,
     classes: PropTypes.object.isRequired,
 };
 

--- a/src/components/map/MapName.js
+++ b/src/components/map/MapName.js
@@ -23,7 +23,7 @@ const styles = theme => ({
             backgroundColor: 'rgba(255,255,255,0.9)',
             boxShadow: theme.shadows[1],
             borderRadius: theme.shape.borderRadius,
-            margin: 8,
+            margin: theme.spacing.unit,
         },
     },
     name: {

--- a/src/components/map/plugin/PluginLegend.js
+++ b/src/components/map/plugin/PluginLegend.js
@@ -55,9 +55,9 @@ class PluginLegend extends PureComponent {
     // Contents is rendered to a hidden div
     render() {
         const { layers, classes } = this.props;
-        const legendLayers = layers.filter(
-            layer => layer.legend || layer.alerts
-        );
+        const legendLayers = layers
+            .filter(layer => layer.legend || layer.alerts)
+            .reverse(); // Show top layer first
 
         // Alerts are added to legend to be less intrusive
         return (

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -311,6 +311,12 @@ const map = (state = defaultState, action) => {
                 mapViews: state.mapViews.map(l => layer(l, action)),
             };
 
+        case types.MAP_RELATIVE_PERIOD_DATE_SET:
+            return {
+                ...state,
+                relativePeriodDate: action.payload,
+            };
+
         default:
             return state;
     }

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -314,7 +314,7 @@ const map = (state = defaultState, action) => {
         case types.MAP_RELATIVE_PERIOD_DATE_SET:
             return {
                 ...state,
-                relativePeriodDate: action.payload,
+                interpretationDate: action.payload,
             };
 
         default:


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-5477

This PR displays the time of the selected interpretation on the map:

![skjermbilde 2018-12-05 kl 10 25 46](https://user-images.githubusercontent.com/548708/49503960-f54c9180-f878-11e8-9bfe-baadea1f1c41.png)

The PR also includes a fix for map legends on dashboard maps: the layers are reorders so the top layer is shown first. 

We don't support different date formats/locales in the Maps app. I've created a separate issue for this task: https://jira.dhis2.org/browse/DHIS2-5498

For later: 
- Shared repo for app icons