### PR TITLE
Increase LayerCard more menu divider spacing

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2018-11-30T19:27:42.919Z\n"
-"PO-Revision-Date: 2018-11-30T19:27:42.919Z\n"
+"POT-Creation-Date: 2018-12-05T09:55:15.234Z\n"
+"PO-Revision-Date: 2018-12-05T09:55:15.234Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -443,6 +443,9 @@ msgid "Event time"
 msgstr ""
 
 msgid "Groups"
+msgstr ""
+
+msgid "Viewing interpretation from {{interpretationDate}}"
 msgstr ""
 
 msgid "Last updated"

--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -17,14 +17,17 @@ import ViewListIcon from '@material-ui/icons/ViewList';
 import DeleteIcon from '@material-ui/icons/Delete';
 import SaveIcon from '@material-ui/icons/SaveAlt';
 
-const styles = {
+const styles = theme => ({
     button: {
         float: 'left',
         padding: 4,
         width: 32,
         height: 32,
     },
-};
+    divider: {
+        margin: `${theme.spacing.unit}px 0`,
+    },
+});
 
 export class LayerToolbarMoreMenu extends Component {
     state = {
@@ -125,7 +128,9 @@ export class LayerToolbarMoreMenu extends Component {
                             <ListItemText primary={i18n.t('Download data')} />
                         </MenuItem>
                     )}
-                    {showDivider && <Divider light />}
+                    {showDivider && (
+                        <Divider className={classes.divider} light />
+                    )}
                     {onEdit && (
                         <MenuItem onClick={this.handleEditBtnClick}>
                             <ListItemIcon>


### PR DESCRIPTION
Before:

<img width="220" alt="screen shot 2018-12-05 at 10 21 42 am" src="https://user-images.githubusercontent.com/947888/49507063-989ca700-f877-11e8-9783-39a7be8022e1.png">

After:

<img width="218" alt="screen shot 2018-12-05 at 10 14 41 am" src="https://user-images.githubusercontent.com/947888/49507010-77d45180-f877-11e8-9cc3-503ec9d75052.png">

**NB**  The FileMenu dividers are also pretty compressed, but it is a bit less straightforward to fix that (since it's a much longer menu).  Will wait for Joe before making this a generic solution.

* Also add missing interpretation time travel translations