### PR TITLE
Add program id to tracked entity attributes

### DIFF
--- a/src/components/dataItem/EventDataItemSelect.js
+++ b/src/components/dataItem/EventDataItemSelect.js
@@ -77,7 +77,13 @@ export class EventDataItemSelect extends Component {
             dataElements[program.id],
             null,
             excludeValueTypes
-        );
+        ).map(item => ({
+            ...item,
+            id:
+                item.id.indexOf('.') === -1
+                    ? `${program.id}.${item.id}`
+                    : item.id, // Add program id to tracked entity attributes
+        }));
 
         return (
             <SelectField


### PR DESCRIPTION
Fixes issue: https://jira.dhis2.org/browse/DHIS2-5457

@larshelge, are Program Tracked Entity Attributes supposed to work as an event data item for thematic layers? 

I saw that we get an error if we select an tracked entitiy attribute in the Maps app:

![skjermbilde 2018-12-05 kl 15 35 28](https://user-images.githubusercontent.com/548708/49520416-820c4500-f8a3-11e8-939c-b84584e78dc4.png)

https://play.dhis2.org/2.31/api/31/analytics.json?dimension=ou:LEVEL-2&dimension=dx:lw1SqmMlnfh&filter=pe:2018&displayProperty=SHORTNAME

Returns error: "Dimension dx is present in query without any valid dimension options"

The reason is that the program id is not included in the dx dimension as for program data elements. This PR adds it: 

https://play.dhis2.org/2.31/api/31/analytics.json?dimension=ou:LEVEL-2&dimension=dx:uy2gU8kT1jF.lw1SqmMlnfh&filter=pe:2018&displayProperty=SHORTNAME

It avoids the error, but I get no data (rows) back.

![skjermbilde 2018-12-05 kl 15 29 09](https://user-images.githubusercontent.com/548708/49521005-bf250700-f8a4-11e8-9018-cb0e848c660c.png)

Is this meant to work and is the syntax differently for  tracked entitiy attributes?

PS! I cheked the old GIS app, and selecting a tracked entitiy attribute don't to work there either, as no api request is generated. 