### PR TITLE
Support different date formats/locales and improved time handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
         "d2-utilizr": "^0.2.15",
         "d3-color": "^1.2.3",
         "d3-format": "^1.3.2",
-        "d3-time-format": "^2.1.3",
         "file-saver": "^1.3.3",
         "lodash": "^4.17.5",
         "loglevel": "^1.6.1",

--- a/src/components/core/DatePicker.js
+++ b/src/components/core/DatePicker.js
@@ -2,9 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
-import { timeFormat } from 'd3-time-format';
-
-const formatTime = timeFormat('%Y-%m-%d');
+import { formatDate } from '../../util/time';
 
 const styles = {
     root: {
@@ -12,15 +10,13 @@ const styles = {
     },
 };
 
-// react-dom.development.js:3337 The specified value "2018-10-17T00:00:00.000" does not conform to the required format, "yyyy-MM-dd".
-
 // DatePicker not yet supported in Material-UI: https://github.com/mui-org/material-ui/issues/4787
 // Fallback on browser native
 const DatePicker = ({ label, value, onChange, classes, style }) => (
     <TextField
         type="date"
         label={label}
-        defaultValue={formatTime(new Date(value))}
+        defaultValue={formatDate(value)}
         onChange={event => onChange(event.target.value)}
         style={style}
         classes={classes}

--- a/src/components/edit/EventDialog.js
+++ b/src/components/edit/EventDialog.js
@@ -49,7 +49,7 @@ import {
     getOrgUnitNodesFromRows,
     getUserOrgUnitsFromRows,
 } from '../../util/analytics';
-import { getStartEndDateError } from '../../util/helpers';
+import { getStartEndDateError } from '../../util/time';
 import { cssColor } from '../../util/colors';
 
 // TODO: Don't use inline styles!

--- a/src/components/edit/TrackedEntityDialog.js
+++ b/src/components/edit/TrackedEntityDialog.js
@@ -43,7 +43,7 @@ import {
     getOrgUnitsFromRows,
     getOrgUnitNodesFromRows,
 } from '../../util/analytics';
-import { getStartEndDateError } from '../../util/helpers';
+import { getStartEndDateError } from '../../util/time';
 
 const styles = {
     ...layerDialogStyles,

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -70,7 +70,7 @@ import {
     getPeriodFromFilters,
     getUserOrgUnitsFromRows,
 } from '../../../util/analytics';
-import { getStartEndDateError } from '../../../util/helpers';
+import { getStartEndDateError } from '../../../util/time';
 
 // TODO: Don't use inline styles!
 const styles = {

--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -163,8 +163,6 @@ class Map extends Component {
 
     render() {
         const {
-            name,
-            interpretationDate,
             basemap,
             basemaps,
             mapViews,
@@ -204,12 +202,7 @@ class Map extends Component {
                     ref={node => (this.node = node)}
                     className={classes.mapContainer}
                 >
-                    {name && showName && (
-                        <MapName
-                            name={name}
-                            interpretationDate={interpretationDate}
-                        />
-                    )}
+                    <MapName />
                     {layers
                         .filter(layer => layer.isLoaded)
                         .map((config, index) => {

--- a/src/components/map/MapName.js
+++ b/src/components/map/MapName.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
 import InterpretationIcon from '../core/InterpretationIcon';
-import { formatDisplayDate } from '../../util/time';
+import { formatLocaleDate } from '../../util/time';
 
 const styles = theme => ({
     root: {
@@ -54,7 +54,7 @@ const MapName = ({ showName, name, interpretationDate, uiLocale, classes }) =>
                     {i18n.t(
                         'Viewing interpretation from {{interpretationDate}}',
                         {
-                            interpretationDate: formatDisplayDate(
+                            interpretationDate: formatLocaleDate(
                                 interpretationDate,
                                 uiLocale
                             ),

--- a/src/components/map/MapName.js
+++ b/src/components/map/MapName.js
@@ -69,6 +69,7 @@ MapName.propTypes = {
     showName: PropTypes.bool,
     name: PropTypes.string,
     interpretationDate: PropTypes.string,
+    uiLocale: PropTypes.string,
     classes: PropTypes.object.isRequired,
 };
 

--- a/src/components/map/MapName.js
+++ b/src/components/map/MapName.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
 import InterpretationIcon from '../core/InterpretationIcon';
-import { timeFormat } from 'd3-time-format';
-
-const formatTime = timeFormat('%b %d, %Y'); // TODO: Support different locales
+import { formatDate } from '../../util/time';
 
 const styles = theme => ({
     root: {
@@ -43,28 +42,39 @@ const styles = theme => ({
     },
 });
 
-const MapName = ({ name, interpretationDate, classes }) => (
-    <div className={classes.root}>
-        <div className={classes.name}>{name}</div>
-        {interpretationDate && (
-            <div className={classes.interpretation}>
-                <div className={classes.interpretationIcon}>
-                    <InterpretationIcon />
+const MapName = ({ showName, name, interpretationDate, uiLocale, classes }) =>
+    showName && name ? (
+        <div className={classes.root}>
+            <div className={classes.name}>{name}</div>
+            {interpretationDate && (
+                <div className={classes.interpretation}>
+                    <div className={classes.interpretationIcon}>
+                        <InterpretationIcon />
+                    </div>
+                    {i18n.t(
+                        'Viewing interpretation from {{interpretationDate}}',
+                        {
+                            interpretationDate: formatDate(
+                                interpretationDate,
+                                uiLocale
+                            ),
+                        }
+                    )}
                 </div>
-                {i18n.t('Viewing interpretation from {{interpretationDate}}', {
-                    interpretationDate: formatTime(
-                        new Date(interpretationDate)
-                    ),
-                })}
-            </div>
-        )}
-    </div>
-);
+            )}
+        </div>
+    ) : null;
 
 MapName.propTypes = {
+    showName: PropTypes.bool,
     name: PropTypes.string,
     interpretationDate: PropTypes.string,
     classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(MapName);
+export default connect(({ map, download, userSettings }) => ({
+    name: map.name,
+    interpretationDate: map.interpretationDate,
+    showName: download.showDialog ? download.showName : true,
+    uiLocale: userSettings.keyUiLocale,
+}))(withStyles(styles)(MapName));

--- a/src/components/map/MapName.js
+++ b/src/components/map/MapName.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
 import InterpretationIcon from '../core/InterpretationIcon';
-import { formatDate } from '../../util/time';
+import { formatDisplayDate } from '../../util/time';
 
 const styles = theme => ({
     root: {
@@ -54,7 +54,7 @@ const MapName = ({ showName, name, interpretationDate, uiLocale, classes }) =>
                     {i18n.t(
                         'Viewing interpretation from {{interpretationDate}}',
                         {
-                            interpretationDate: formatDate(
+                            interpretationDate: formatDisplayDate(
                                 interpretationDate,
                                 uiLocale
                             ),

--- a/src/components/periods/PeriodSelect.js
+++ b/src/components/periods/PeriodSelect.js
@@ -9,8 +9,9 @@ import LeftIcon from '@material-ui/icons/ChevronLeft';
 import RightIcon from '@material-ui/icons/ChevronRight';
 import { filterFuturePeriods } from 'd2/period/helpers';
 import { createPeriods } from '../../util/periods';
+import { getYear } from '../../util/time';
 
-const styles = theme => ({
+const styles = () => ({
     select: {
         margin: '12px 0',
         width: 'calc(100% - 60px)',
@@ -42,7 +43,7 @@ class PeriodSelect extends Component {
     };
 
     state = {
-        year: new Date().getFullYear(),
+        year: getYear(),
         periods: null,
     };
 
@@ -89,6 +90,8 @@ class PeriodSelect extends Component {
         if (!periods) {
             return null;
         }
+
+        console.log('##', getYear());
 
         return (
             <div style={{ height: 100, ...style }}>

--- a/src/components/periods/PeriodSelect.js
+++ b/src/components/periods/PeriodSelect.js
@@ -91,8 +91,6 @@ class PeriodSelect extends Component {
             return null;
         }
 
-        console.log('##', getYear());
-
         return (
             <div style={{ height: 100, ...style }}>
                 <SelectField

--- a/src/constants/layers.js
+++ b/src/constants/layers.js
@@ -1,9 +1,9 @@
-import { dateFormat } from '../util/time';
+import { formatDate } from '../util/time';
 
-export const DEFAULT_START_DATE = dateFormat(
+export const DEFAULT_START_DATE = formatDate(
     new Date().setFullYear(new Date().getFullYear() - 1)
 );
-export const DEFAULT_END_DATE = dateFormat(new Date());
+export const DEFAULT_END_DATE = formatDate(new Date());
 
 export const DEFAULT_ORG_UNIT_LEVEL = 2;
 

--- a/src/constants/layers.js
+++ b/src/constants/layers.js
@@ -1,11 +1,9 @@
-import { timeFormat } from 'd3-time-format';
+import { dateFormat } from '../util/time';
 
-const formatTime = timeFormat('%Y-%m-%d');
-
-export const DEFAULT_START_DATE = formatTime(
+export const DEFAULT_START_DATE = dateFormat(
     new Date().setFullYear(new Date().getFullYear() - 1)
 );
-export const DEFAULT_END_DATE = formatTime(new Date());
+export const DEFAULT_END_DATE = dateFormat(new Date());
 
 export const DEFAULT_ORG_UNIT_LEVEL = 2;
 
@@ -38,8 +36,6 @@ export const classificationTypes = [
         name: 'Equal counts',
     },
 ];
-
-export const DATE_FORMAT_SPECIFIER = '%Y-%m-%d';
 
 /* LABEL STYLES */
 export const LABEL_FONT_SIZE = '11px';

--- a/src/epics/earthEngine.js
+++ b/src/epics/earthEngine.js
@@ -143,6 +143,8 @@ export const loadCollection = action$ =>
                 errorActionCreator(types.EARTH_ENGINE_COLLECTION_LOAD_ERROR)
             );
 
+            console.log('i18n', i18n);
+
             if (token && token.status === 'ERROR') {
                 return setAlert(
                     createAlert(

--- a/src/epics/earthEngine.js
+++ b/src/epics/earthEngine.js
@@ -154,7 +154,14 @@ export const loadCollection = action$ =>
             );
 
             if (token && token.status === 'ERROR') {
-                return setAlert(createAlert(i18n.t(token.message), i18n.t('To show this layer you must first sign up for the Earth Engine service at Google. Please check the DHIS 2 documentation.')));
+                return setAlert(
+                    createAlert(
+                        i18n.t(token.message),
+                        i18n.t(
+                            'To show this layer you must first sign up for the Earth Engine service at Google. Please check the DHIS 2 documentation.'
+                        )
+                    )
+                );
             }
 
             setAuthToken(token);

--- a/src/epics/earthEngine.js
+++ b/src/epics/earthEngine.js
@@ -4,7 +4,7 @@ import 'rxjs/add/operator/concatMap';
 import * as types from '../constants/actionTypes';
 import { apiFetch } from '../util/api';
 import { createAlert } from '../util/alerts';
-import { formatStartEndDate } from '../util/time';
+import { getYear, formatStartEndDate } from '../util/time';
 import { setEarthEngineCollection } from '../actions/earthEngine';
 import { errorActionCreator } from '../actions/helpers';
 import { setAlert } from '../actions/alerts';
@@ -47,10 +47,8 @@ const collections = {
                 data.features.map(feature => ({
                     id: feature.id,
                     name: String(
-                        new Date(
-                            feature.properties['system:time_start']
-                        ).getFullYear()
-                    ), // TODO: Support numbers in d2-ui cmp
+                        getYear(feature.properties['system:time_start'])
+                    ),
                 }))
             )
         );
@@ -115,10 +113,8 @@ const collections = {
                 data.features.map(feature => ({
                     id: feature.id,
                     name: String(
-                        new Date(
-                            feature.properties['system:time_start']
-                        ).getFullYear()
-                    ), // TODO: Support numbers in d2-ui cmp
+                        getYear(feature.properties['system:time_start'])
+                    ),
                 }))
             )
         );

--- a/src/epics/earthEngine.js
+++ b/src/epics/earthEngine.js
@@ -143,8 +143,6 @@ export const loadCollection = action$ =>
                 errorActionCreator(types.EARTH_ENGINE_COLLECTION_LOAD_ERROR)
             );
 
-            console.log('i18n', i18n);
-
             if (token && token.status === 'ERROR') {
                 return setAlert(
                     createAlert(

--- a/src/epics/earthEngine.js
+++ b/src/epics/earthEngine.js
@@ -1,10 +1,10 @@
 import i18n from '@dhis2/d2-i18n';
 import { combineEpics } from 'redux-observable';
 import 'rxjs/add/operator/concatMap';
-import { timeFormat } from 'd3-time-format';
 import * as types from '../constants/actionTypes';
 import { apiFetch } from '../util/api';
 import { createAlert } from '../util/alerts';
+import { formatStartEndDate } from '../util/time';
 import { setEarthEngineCollection } from '../actions/earthEngine';
 import { errorActionCreator } from '../actions/helpers';
 import { setAlert } from '../actions/alerts';
@@ -68,15 +68,12 @@ const collections = {
 
         featureCollection.getInfo(data =>
             resolve(
-                data.features.map(feature => ({
-                    id: feature.id,
-                    name:
-                        timeFormat('%-d – ')(
-                            feature.properties['system:time_start']
-                        ) +
-                        timeFormat('%-d %b %Y')(
-                            feature.properties['system:time_end'] - 7200001
-                        ), // Minus 2 hrs to end the day before
+                data.features.map(f => ({
+                    id: f.id,
+                    name: formatStartEndDate(
+                        f.properties['system:time_start'],
+                        f.properties['system:time_end'] - 7200001
+                    ), // Minus 2 hrs to end the day before
                 }))
             )
         );
@@ -93,15 +90,12 @@ const collections = {
 
         featureCollection.getInfo(data =>
             resolve(
-                data.features.map(feature => ({
-                    id: feature.id,
-                    name:
-                        timeFormat('%-d %b – ')(
-                            feature.properties['system:time_start']
-                        ) +
-                        timeFormat('%-d %b %Y')(
-                            feature.properties['system:time_end'] - 7200001
-                        ), // Minus 2 hrs to end the day before
+                data.features.map(f => ({
+                    id: f.id,
+                    name: formatStartEndDate(
+                        f.properties['system:time_start'],
+                        f.properties['system:time_end'] - 7200001
+                    ), // Minus 2 hrs to end the day before
                 }))
             )
         );

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -14,7 +14,7 @@ import {
     getBounds,
 } from '../util/geojson';
 import { EVENT_COLOR, EVENT_RADIUS } from '../constants/layers';
-import { formatTime } from '../util/helpers';
+import { formatDate } from '../util/time';
 import { cssColor } from '../util/colors';
 
 // Server clustering if more than 2000 events
@@ -50,7 +50,7 @@ const eventLoader = async layerConfig => {
         title: config.name,
         period: period
             ? getPeriodNameFromId(period.id)
-            : `${formatTime(startDate)} - ${formatTime(endDate)}`,
+            : `${formatDate(startDate)} - ${formatDate(endDate)}`,
         items: [],
     };
 

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -14,7 +14,7 @@ import {
     getBounds,
 } from '../util/geojson';
 import { EVENT_COLOR, EVENT_RADIUS } from '../constants/layers';
-import { formatDate } from '../util/time';
+import { formatLocaleDate } from '../util/time';
 import { cssColor } from '../util/colors';
 
 // Server clustering if more than 2000 events
@@ -50,7 +50,7 @@ const eventLoader = async layerConfig => {
         title: config.name,
         period: period
             ? getPeriodNameFromId(period.id)
-            : `${formatDate(startDate)} - ${formatDate(endDate)}`,
+            : `${formatLocaleDate(startDate)} - ${formatLocaleDate(endDate)}`,
         items: [],
     };
 

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -18,7 +18,7 @@ import {
     getApiResponseNames,
 } from '../util/analytics';
 import { createAlert } from '../util/alerts';
-import { formatDate } from '../util/helpers';
+import { formatLocaleDate } from '../util/helpers';
 
 const thematicLoader = async config => {
     let error;
@@ -70,7 +70,9 @@ const thematicLoader = async config => {
         title: name,
         period: period
             ? names[data.metaData.dimensions.pe[0]]
-            : `${formatDate(config.startDate)} - ${formatDate(config.endDate)}`,
+            : `${formatLocaleDatee(config.startDate)} - ${formatLocaleDate(
+                  config.endDate
+              )}`,
         items: legendSet
             ? getPredefinedLegendItems(legendSet)
             : getAutomaticLegendItems(

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -18,7 +18,7 @@ import {
     getApiResponseNames,
 } from '../util/analytics';
 import { createAlert } from '../util/alerts';
-import { formatTime } from '../util/helpers';
+import { formatDate } from '../util/helpers';
 
 const thematicLoader = async config => {
     let error;
@@ -70,7 +70,7 @@ const thematicLoader = async config => {
         title: name,
         period: period
             ? names[data.metaData.dimensions.pe[0]]
-            : `${formatTime(config.startDate)} - ${formatTime(config.endDate)}`,
+            : `${formatDate(config.startDate)} - ${formatDate(config.endDate)}`,
         items: legendSet
             ? getPredefinedLegendItems(legendSet)
             : getAutomaticLegendItems(

--- a/src/loaders/trackedEntityLoader.js
+++ b/src/loaders/trackedEntityLoader.js
@@ -3,7 +3,7 @@ import { apiFetch } from '../util/api';
 import { getOrgUnitsFromRows } from '../util/analytics';
 import { TEI_COLOR, TEI_RADIUS } from '../constants/layers';
 import { createAlert } from '../util/alerts';
-import { formatDate } from '../util/helpers';
+import { formatLocaleDate } from '../util/helpers';
 
 const fields = [
     'trackedEntityInstance~rename(id)',
@@ -40,7 +40,7 @@ const trackedEntityLoader = async config => {
     const name = program ? program.name : i18n.t('Tracked entity');
 
     const legend = {
-        period: `${formatDate(startDate)} - ${formatDate(endDate)}`,
+        period: `${formatLocaleDate(startDate)} - ${formatLocaleDate(endDate)}`,
         items: [
             {
                 name:

--- a/src/loaders/trackedEntityLoader.js
+++ b/src/loaders/trackedEntityLoader.js
@@ -3,7 +3,7 @@ import { apiFetch } from '../util/api';
 import { getOrgUnitsFromRows } from '../util/analytics';
 import { TEI_COLOR, TEI_RADIUS } from '../constants/layers';
 import { createAlert } from '../util/alerts';
-import { formatTime } from '../util/helpers';
+import { formatDate } from '../util/helpers';
 
 const fields = [
     'trackedEntityInstance~rename(id)',
@@ -40,7 +40,7 @@ const trackedEntityLoader = async config => {
     const name = program ? program.name : i18n.t('Tracked entity');
 
     const legend = {
-        period: `${formatTime(startDate)} - ${formatTime(endDate)}`,
+        period: `${formatDate(startDate)} - ${formatDate(endDate)}`,
         items: [
             {
                 name:
@@ -83,7 +83,8 @@ const trackedEntityLoader = async config => {
 
     const instances = data.trackedEntityInstances.filter(
         instance =>
-            geometryTypes.indexOf(instance.featureType) >= 0 && instance.coordinates
+            geometryTypes.indexOf(instance.featureType) >= 0 &&
+            instance.coordinates
     );
 
     const features = toGeoJson(instances);

--- a/src/util/__tests__/time.spec.js
+++ b/src/util/__tests__/time.spec.js
@@ -1,0 +1,69 @@
+import {
+    toDate,
+    isValidDateFormat,
+    formatDate,
+    formatLocaleDate,
+    formatStartEndDate,
+    getStartEndDateError,
+} from '../time';
+
+const validDateString = '2018-12-17T12:00:00';
+const invalidDateString = '2018-13-17T12:00:00';
+const invalidDateStringFormat = '2018-13-7T12:00:00';
+const validTimestamp = 1545044966178;
+const invalidTimestamp = 15450221323142342;
+const validDate = new Date('2018-12-17T12:00:00');
+const invalidDate = new Date('2018-13-17T12:00:00');
+
+// https://stackoverflow.com/questions/1353684/detecting-an-invalid-date-date-instance-in-javascript
+const isValidDate = d => d instanceof Date && !isNaN(d.getTime());
+
+describe('time utils', () => {
+    it('toDate should return a date object from a valid date string, timestamp or date object', () => {
+        expect(isValidDate(toDate(validDateString))).toBeTruthy();
+        expect(isValidDate(toDate(invalidDateString))).toBeFalsy();
+        expect(isValidDate(toDate(validTimestamp))).toBeTruthy();
+        expect(isValidDate(toDate(invalidTimestamp))).toBeFalsy();
+        expect(isValidDate(toDate(validDate))).toBeTruthy();
+        expect(isValidDate(toDate(invalidDate))).toBeFalsy();
+    });
+
+    it('isValidDateFormat should return true if date string is formatted as yyyy-mm-dd', () => {
+        expect(isValidDateFormat(validDateString)).toBeTruthy();
+        expect(isValidDateFormat(invalidDateString)).toBeTruthy(); // Date is invalid, but format is still valid
+        expect(isValidDateFormat(invalidDateStringFormat)).toBeFalsy();
+    });
+
+    it('formatDate should return a formatted date string if valid', () => {
+        expect(isValidDateFormat(formatDate(validDate))).toBeTruthy();
+        expect(isValidDateFormat(formatDate(invalidDate))).toBeFalsy();
+    });
+
+    // Node only support a limited set of locales by default:
+    // https://stackoverflow.com/questions/49052731/jest-test-intl-datetimeformat
+    it('formatLocaleDate should format date string according to locale', () => {
+        expect(formatLocaleDate(validDateString)).toEqual('Dec 17, 2018');
+        expect(formatLocaleDate(validDateString, 'en')).toEqual('Dec 17, 2018');
+    });
+
+    // Node only support a limited set of locales by default:
+    // https://stackoverflow.com/questions/49052731/jest-test-intl-datetimeformat
+    it('ormatStartEndDate should format date range according to locale', () => {
+        expect(formatStartEndDate('2018-12-17', '2018-12-18', 'en')).toEqual(
+            'Dec 17, 2018 - Dec 18, 2018'
+        );
+    });
+
+    it('formatLocaleDate should format date string according to locale', () => {
+        expect(getStartEndDateError('2018-12-17', '2018-12-18')).toBeNull();
+        expect(getStartEndDateError('2018-12-17', '2018-12-16')).toEqual(
+            'End date cannot be earlier than start date'
+        );
+        expect(getStartEndDateError('2018-12-7', '2018-12-16')).toEqual(
+            'Start date is invalid'
+        );
+        expect(getStartEndDateError('2018-12-17', '2018-2-16')).toEqual(
+            'End date is invalid'
+        );
+    });
+});

--- a/src/util/__tests__/time.spec.js
+++ b/src/util/__tests__/time.spec.js
@@ -5,6 +5,7 @@ import {
     formatLocaleDate,
     formatStartEndDate,
     getStartEndDateError,
+    getYear,
 } from '../time';
 
 const validDateString = '2018-12-17T12:00:00';
@@ -14,6 +15,7 @@ const validTimestamp = 1545044966178;
 const invalidTimestamp = 15450221323142342;
 const validDate = new Date('2018-12-17T12:00:00');
 const invalidDate = new Date('2018-13-17T12:00:00');
+const currentYear = new Date().getFullYear();
 
 // https://stackoverflow.com/questions/1353684/detecting-an-invalid-date-date-instance-in-javascript
 const isValidDate = d => d instanceof Date && !isNaN(d.getTime());
@@ -65,5 +67,12 @@ describe('time utils', () => {
         expect(getStartEndDateError('2018-12-17', '2018-2-16')).toEqual(
             'End date is invalid'
         );
+    });
+
+    it('getYear should return the year from a date, or the current year', () => {
+        expect(getYear()).toEqual(currentYear);
+        expect(getYear(validDateString)).toEqual(2018);
+        expect(getYear(validTimestamp)).toEqual(2018);
+        expect(getYear(validDate)).toEqual(2018);
     });
 });

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -1,7 +1,4 @@
 import { getInstance as getD2 } from 'd2';
-import { timeParse, timeFormat } from 'd3-time-format';
-import i18n from '@dhis2/d2-i18n';
-import { DATE_FORMAT_SPECIFIER } from '../constants/layers';
 
 const propertyMap = {
     name: 'name',
@@ -119,23 +116,6 @@ export const addOrgUnitPaths = mapViews =>
               }
             : view
     );
-
-export const parseTime = date => timeParse(DATE_FORMAT_SPECIFIER)(date);
-export const formatTime = date =>
-    timeFormat(DATE_FORMAT_SPECIFIER)(new Date(date));
-
-export const getStartEndDateError = (startDate, endDate) => {
-    const start = parseTime(startDate.substring(0, 10)); // Only check date part
-    const end = parseTime(endDate.substring(0, 10)); // Only check date part
-    if (!start) {
-        return i18n.t('Start date is invalid');
-    } else if (!end) {
-        return i18n.t('End date is invalid');
-    } else if (end < start) {
-        return i18n.t('End date cannot be earlier than start date');
-    }
-    return null;
-};
 
 // Remove line breaks from text (not displayed corrently in map downloads)
 // https://stackoverflow.com/questions/10805125/how-to-remove-all-line-breaks-from-a-string/10805292#10805292

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -3,6 +3,7 @@ import i18n from '@dhis2/d2-i18n';
 
 // The date format uses by the Web API and by <input> date fields
 const DATE_FORMAT_SPECIFIER = '%Y-%m-%d';
+const DATE_DEFAULT_LOCALE = 'en';
 
 /**
  * Formats a date object using the above format.
@@ -26,27 +27,59 @@ export const formatDate = value => dateFormat(new Date(value));
 export const parseTime = date => timeParse(DATE_FORMAT_SPECIFIER)(date);
 
 /**
- * Formats a date string to the default display format: 13 Aug 2018 (en locale)
+ * Simple fallback date format if Intl is not supported
  * @param {String} date
- * @param {String} uiLocale
  * @returns {String}
  */
-export const formatDisplayDate = (date, uiLocale = 'en') => {
-    if (typeof global.Intl !== 'undefined' && Intl.DateTimeFormat) {
-        return new Intl.DateTimeFormat(uiLocale, {
-            year: 'numeric',
-            month: 'short',
-            day: 'numeric',
-        }).format(new Date(date));
-    }
+export const fallbackDateFormat = date => date.substr(0, 19).replace('T', ' ');
 
-    return date.substr(0, 19).replace('T', ' ');
-};
+/**
+ * Returns true if the Internationalization API is supported
+ * @returns {Boolean}
+ */
+export const hasIntlSupport =
+    typeof global.Intl !== 'undefined' && Intl.DateTimeFormat;
+
+/**
+ * Formats a date string to the default locale date format
+ * @param {String} date
+ * @param {String} locale
+ * @returns {String}
+ */
+export const formatDefaultDate = (date, locale = DATE_DEFAULT_LOCALE) =>
+    hasIntlSupport
+        ? new Intl.DateTimeFormat(locale).format(new Date(date))
+        : fallbackDateFormat(date);
+
+/**
+ * Formats a date string to the default display format: 13 Aug 2018 (en locale)
+ * @param {String} date
+ * @param {String} locale
+ * @returns {String}
+ */
+export const formatDisplayDate = (date, locale = DATE_DEFAULT_LOCALE) =>
+    hasIntlSupport
+        ? new Intl.DateTimeFormat(locale, {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+          }).format(new Date(date))
+        : fallbackDateFormat(date);
+
+export const formatStartEndDate = (
+    startDate,
+    endDate,
+    locale = DATE_DEFAULT_LOCALE
+) =>
+    `${formatDisplayDate(startDate, locale)} - ${formatDisplayDate(
+        endDate,
+        locale
+    )}`;
 
 /**
  * Checks for errors for start and end date strings
- * @param {String} startDate
- * @param {String} endDate
+ * @param {String|Number} startDate
+ * @param {String|Number} endDate
  * @returns {String|null}
  */
 export const getStartEndDateError = (startDate, endDate) => {

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -38,7 +38,7 @@ export const formatDate = date => {
  * @param {String} dateString
  * @returns {String}
  */
-export const fallbackDateFormat = dateString => dateString.substr(0, 10);
+const fallbackDateFormat = dateString => dateString.substr(0, 10);
 
 /**
  * Returns true if the Internationalization API is supported
@@ -49,18 +49,18 @@ export const hasIntlSupport =
 
 /**
  * Formats a date string or timestamp to the default display format: 13 Aug 2018 (en locale)
- * @param {String|Number} date
+ * @param {String} dateString
  * @param {String} locale
  * @returns {String}
  */
-export const formatLocaleDate = (date, locale = DEFAULT_LOCALE) =>
+export const formatLocaleDate = (dateString, locale = DEFAULT_LOCALE) =>
     hasIntlSupport
         ? new Intl.DateTimeFormat(locale, {
               year: 'numeric',
               month: 'short',
               day: 'numeric',
-          }).format(new Date(date))
-        : fallbackDateFormat(date);
+          }).format(toDate(dateString))
+        : fallbackDateFormat(dateString);
 
 /**
  * Formats a date range

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -53,9 +53,9 @@ export const hasIntlSupport =
  * @param {String} locale
  * @returns {String}
  */
-export const formatLocaleDate = (dateString, locale = DEFAULT_LOCALE) =>
+export const formatLocaleDate = (dateString, locale) =>
     hasIntlSupport
-        ? new Intl.DateTimeFormat(locale, {
+        ? new Intl.DateTimeFormat(locale || i18n.language || DEFAULT_LOCALE, {
               year: 'numeric',
               month: 'short',
               day: 'numeric',
@@ -69,15 +69,13 @@ export const formatLocaleDate = (dateString, locale = DEFAULT_LOCALE) =>
  * @param {String} locale
  * @returns {String}
  */
-export const formatStartEndDate = (
-    startDate,
-    endDate,
-    locale = DEFAULT_LOCALE
-) =>
-    `${formatLocaleDate(startDate, locale)} - ${formatLocaleDate(
+export const formatStartEndDate = (startDate, endDate, locale) => {
+    const loc = locale || i18n.language || DEFAULT_LOCALE;
+    return `${formatLocaleDate(startDate, loc)} - ${formatLocaleDate(
         endDate,
         locale
     )}`;
+};
 
 /**
  * Checks for errors for start and end date strings or timestamps

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -1,21 +1,64 @@
+import { timeFormat, timeParse } from 'd3-time-format';
+import i18n from '@dhis2/d2-i18n';
+
+// The date format uses by the Web API and by <input> date fields
+const DATE_FORMAT_SPECIFIER = '%Y-%m-%d';
+
 /**
- *
- * @param {Date} value Javascript date
+ * Formats a date object using the above format.
+ * @param {Date} date
+ * @returns {String}
+ */
+export const dateFormat = timeFormat(DATE_FORMAT_SPECIFIER);
+
+/**
+ * Formats a date string using the above format.
+ * @param {String} date
+ * @returns {String}
+ */
+export const formatDate = value => dateFormat(new Date(value));
+
+/**
+ * Converts a date string of the the above format to a date object.
+ * @param {String} date
+ * @returns {Date}
+ */
+export const parseTime = date => timeParse(DATE_FORMAT_SPECIFIER)(date);
+
+/**
+ * Formats a date string to the default display format: 13 Aug 2018 (en locale)
+ * @param {String} date
  * @param {String} uiLocale
  * @returns {String}
- *
- * Copied from data-visualizer-app:
- * https://github.com/dhis2/data-visualizer-app/blob/master/packages/app/src/modules/formatDate.js
- * TODO: Keep functions like this in a shared analytics repo
  */
-export const formatDate = (value = '', uiLocale = 'en') => {
+export const formatDisplayDate = (date, uiLocale = 'en') => {
     if (typeof global.Intl !== 'undefined' && Intl.DateTimeFormat) {
         return new Intl.DateTimeFormat(uiLocale, {
             year: 'numeric',
             month: 'short',
             day: 'numeric',
-        }).format(new Date(value));
+        }).format(new Date(date));
     }
 
-    return value.substr(0, 19).replace('T', ' ');
+    return date.substr(0, 19).replace('T', ' ');
+};
+
+/**
+ * Checks for errors for start and end date strings
+ * @param {String} startDate
+ * @param {String} endDate
+ * @returns {String|null}
+ */
+export const getStartEndDateError = (startDate, endDate) => {
+    const start = parseTime(startDate.substring(0, 10)); // Only check date part
+    const end = parseTime(endDate.substring(0, 10)); // Only check date part
+
+    if (!start) {
+        return i18n.t('Start date is invalid');
+    } else if (!end) {
+        return i18n.t('End date is invalid');
+    } else if (end < start) {
+        return i18n.t('End date cannot be earlier than start date');
+    }
+    return null;
 };

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -1,0 +1,21 @@
+/**
+ *
+ * @param {Date} value Javascript date
+ * @param {String} uiLocale
+ * @returns {String}
+ *
+ * Copied from data-visualizer-app:
+ * https://github.com/dhis2/data-visualizer-app/blob/master/packages/app/src/modules/formatDate.js
+ * TODO: Keep functions like this in a shared analytics repo
+ */
+export const formatDate = (value = '', uiLocale = 'en') => {
+    if (typeof global.Intl !== 'undefined' && Intl.DateTimeFormat) {
+        return new Intl.DateTimeFormat(uiLocale, {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+        }).format(new Date(value));
+    }
+
+    return value.substr(0, 19).replace('T', ' ');
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3479,7 +3479,7 @@ d3-scale@^2.1.2:
     d3-time "1"
     d3-time-format "2"
 
-d3-time-format@2, d3-time-format@^2.1.3:
+d3-time-format@2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.1.3.tgz#ae06f8e0126a9d60d6364eac5b1533ae1bac826b"
   integrity sha512-6k0a2rZryzGm5Ihx+aFMuO1GgelgIz+7HhB4PH4OEndD5q2zGn1mDfRdNrulspOfR6JXkb2sThhDK41CSK85QA==


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-5498

This PR cleans up the time handlng in the Maps app:
- All times shown in the interface are in a localised format 
- All time functions in one file (util/time.js) with unit tests
- Switch from d3-time-format to Intl (browser native)

The redux store is also connected to the MapName component as this got more complex with the interpretation time handling.