### PR TITLE
Saving and loading og coordinate fields for events

### DIFF
--- a/src/components/dataItem/CoordinateField.js
+++ b/src/components/dataItem/CoordinateField.js
@@ -21,23 +21,12 @@ export class CoordinateField extends Component {
         style: PropTypes.object,
     };
 
+    componentDidMount() {
+        this.loadData();
+    }
+
     componentDidUpdate() {
-        const {
-            program,
-            programStage,
-            programAttributes,
-            dataElements,
-            loadProgramTrackedEntityAttributes,
-            loadProgramStageDataElements,
-        } = this.props;
-
-        if (program && !programAttributes[program.id]) {
-            loadProgramTrackedEntityAttributes(program.id);
-        }
-
-        if (programStage && !dataElements[programStage.id]) {
-            loadProgramStageDataElements(programStage.id);
-        }
+        this.loadData();
     }
 
     render() {
@@ -72,6 +61,25 @@ export class CoordinateField extends Component {
                 style={style}
             />
         );
+    }
+
+    loadData() {
+        const {
+            program,
+            programStage,
+            programAttributes,
+            dataElements,
+            loadProgramTrackedEntityAttributes,
+            loadProgramStageDataElements,
+        } = this.props;
+
+        if (program && !programAttributes[program.id]) {
+            loadProgramTrackedEntityAttributes(program.id);
+        }
+
+        if (programStage && !dataElements[programStage.id]) {
+            loadProgramStageDataElements(programStage.id);
+        }
     }
 }
 

--- a/src/util/favorites.js
+++ b/src/util/favorites.js
@@ -30,6 +30,7 @@ const validLayerProperties = [
     'eventClustering',
     'eventPointColor',
     'eventPointRadius',
+    'eventCoordinateField',
     'filter',
     'filters',
     'followUp',


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-5850

This PR includes "eventCoordinateField" as a valid mapViews field. So far we have not been saving the selected coordinate field when saving events layers. This resulted in a bug where the default event coordinate was used when the map was loaded. 

When a event layer is loaded, the coordinate field is already selected, so we need to trigger loading of program tracked entity attributes and program data elements in both componentDidMount and componentDidUpdate. 

This fix needs to be backported to DHIS2 Maps 2.29, 2.30 and 2.31.