### PR TITLE
import new @dhis2/ui package with header bar and .css style sheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "@dhis2/d2-ui-org-unit-dialog": "5.0.10",
         "@dhis2/d2-ui-org-unit-tree": "5.0.10",
         "@dhis2/gis-api": "^31.0.6",
+        "@dhis2/ui": "^1.0.0-beta.12",
         "@material-ui/core": "^3.4.0",
         "@material-ui/icons": "^3.0.1",
         "@material-ui/lab": "^3.0.0-alpha.23",
@@ -77,7 +78,6 @@
         "redux-observable": "^0.18.0",
         "redux-thunk": "^2.3.0",
         "rxjs": "5.5.6",
-        "ui": "github:d2-ci/ui",
         "url-polyfill": "^1.1.0",
         "whatwg-fetch": "^3.0.0"
     },

--- a/src/components/app/App.css
+++ b/src/components/app/App.css
@@ -1,3 +1,6 @@
+body {
+    font-family: 'Roboto', sans-serif;
+}
 /* Scrollbar width */
 ::-webkit-scrollbar {
     width: 6px;

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -2,8 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
-import UI from 'ui/core/UI';
-import HeaderBar from 'ui/widgets/HeaderBar';
+import HeaderBar from '@dhis2/ui/widgets/HeaderBar';
 import mui3theme from '@dhis2/d2-ui-core/theme/mui3.theme';
 import MapProvider from '../map/MapProvider';
 import AppMenu from './AppMenu';
@@ -18,6 +17,7 @@ import Message from '../message/Message';
 import InterpretationsPanel from '../interpretations/InterpretationsPanel';
 import DataDownloadDialog from '../layers/download/DataDownloadDialog';
 import FatalErrorBoundary from '../errors/FatalErrorBoundary';
+import '@dhis2/ui/defaults/reset.css';
 import './App.css';
 
 const theme = createMuiTheme(mui3theme);
@@ -41,26 +41,24 @@ export class App extends Component {
 
     render() {
         return (
-            <UI>
-                <FatalErrorBoundary>
-                    <HeaderBar appName={i18n.t('Maps')} />
-                    <MuiThemeProvider theme={theme}>
-                        <MapProvider>
-                            <AppMenu />
-                            <InterpretationsPanel />
-                            <LayersPanel />
-                            <LayersToggle />
-                            <Map />
-                            <BottomPanel />
-                            <LayerEdit />
-                            <ContextMenu />
-                            <AlertSnackbar />
-                            <Message />
-                            <DataDownloadDialog />
-                        </MapProvider>
-                    </MuiThemeProvider>
-                </FatalErrorBoundary>
-            </UI>
+            <FatalErrorBoundary>
+                <HeaderBar appName={i18n.t('Maps')} />
+                <MuiThemeProvider theme={theme}>
+                    <MapProvider>
+                        <AppMenu />
+                        <InterpretationsPanel />
+                        <LayersPanel />
+                        <LayersToggle />
+                        <Map />
+                        <BottomPanel />
+                        <LayerEdit />
+                        <ContextMenu />
+                        <AlertSnackbar />
+                        <Message />
+                        <DataDownloadDialog />
+                    </MapProvider>
+                </MuiThemeProvider>
+            </FatalErrorBoundary>
         );
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,14 +75,6 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/polyfill@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.0.0.tgz#c8ff65c9ec3be6a1ba10113ebd40e8750fb90bff"
-  integrity sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==
-  dependencies:
-    core-js "^2.5.7"
-    regenerator-runtime "^0.11.1"
-
 "@babel/runtime@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
@@ -332,6 +324,15 @@
     polylabel "^1.0.2"
     rbush "^2.0.2"
     whatwg-fetch "^3.0.0"
+
+"@dhis2/ui@^1.0.0-beta.12":
+  version "1.0.0-beta.12"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-1.0.0-beta.12.tgz#bd78835a1e165d1879e12be93790948016819c90"
+  integrity sha512-bpeDxVXqj4R6YqguH5Jt9i3pLtg5VpAWiwNmb/Cf7YqFDJHJ4RNTW01qYB+oV5SHwbAYNKmPpvYfpPOtiOFuuQ==
+  dependencies:
+    classnames "^2.2.6"
+    material-design-icons-iconfont "^4.0.2"
+    typeface-roboto "^0.0.54"
 
 "@emotion/babel-utils@^0.6.4":
   version "0.6.10"
@@ -3242,7 +3243,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
+core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
   integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
@@ -8603,10 +8604,10 @@ material-colors@^1.2.1:
   resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.6.tgz#6d1958871126992ceecc72f4bcc4d8f010865f46"
   integrity sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==
 
-material-design-icons@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/material-design-icons/-/material-design-icons-3.0.1.tgz#9a71c48747218ebca51e51a66da682038cdcb7bf"
-  integrity sha1-mnHEh0chjrylHlGmbaaCA4zct78=
+material-design-icons-iconfont@^4.0.2:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/material-design-icons-iconfont/-/material-design-icons-iconfont-4.0.5.tgz#4107ba3b8a9d688a3d9325fc7363af51b17d3aee"
+  integrity sha512-ByJJ1yz8+RfCx2uNiC5WjVCR7K3UWRb8ytWV3RMaoFRzQLNr/J5x7+Wg1+3OlIZahNXrId9Hu+BfXfQIo01v7g==
 
 material-ui@^0.20.0:
   version "0.20.2"
@@ -11008,7 +11009,7 @@ regenerator-runtime@^0.10.5:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
   integrity sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=
 
-regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
+regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
@@ -12724,16 +12725,6 @@ uglifyjs-webpack-plugin@^0.4.6:
     source-map "^0.5.6"
     uglify-js "^2.8.29"
     webpack-sources "^1.0.1"
-
-"ui@github:d2-ci/ui":
-  version "1.0.0-beta.5"
-  resolved "https://codeload.github.com/d2-ci/ui/tar.gz/a14c74a62a5baefe84786282b145ba20e19bc907"
-  dependencies:
-    "@babel/polyfill" "^7.0.0"
-    classnames "^2.2.6"
-    material-design-icons "^3.0.1"
-    prop-types "^15.6.2"
-    typeface-roboto "^0.0.54"
 
 unbzip2-stream@^1.0.9:
   version "1.3.1"


### PR DESCRIPTION
This PR includes importing the new @dhis2/ui package with updated styling rules such that `<strong>` and `<em>` tags are rendered without being reset.

The `<UI>` wrapper is removed, replaced with the new `reset.css` style sheet.
The old `<HeaderBar />` is replaced with the new from @dhis2/ui.

Additionally, 1 rule to the body (`font-family`) have been added, (similar to how the usage-analytics app, dashboard and data-visualizer utilize the new packages).

After merging this change, i'll open a PR for updating the interpretation package with rich text support.
