### PR TITLE
Empty and disable org unit levels and groups selections when user org unit is selected

### DIFF
--- a/src/components/edit/BoundaryDialog.js
+++ b/src/components/edit/BoundaryDialog.js
@@ -117,6 +117,7 @@ class BoundaryDialog extends Component {
 
         const orgUnits = getOrgUnitsFromRows(rows);
         const selectedUserOrgUnits = getUserOrgUnitsFromRows(rows);
+        const hasUserOrgUnits = !!selectedUserOrgUnits.length;
 
         return (
             <div data-test="boundarydialog">
@@ -142,11 +143,7 @@ class BoundaryDialog extends Component {
                                 <OrgUnitTree
                                     selected={getOrgUnitNodesFromRows(rows)}
                                     onClick={toggleOrgUnit}
-                                    disabled={
-                                        selectedUserOrgUnits.length
-                                            ? true
-                                            : false
-                                    }
+                                    disabled={hasUserOrgUnits}
                                 />
                             </div>
                             <div style={styles.flexColumn}>
@@ -155,12 +152,14 @@ class BoundaryDialog extends Component {
                                         rows
                                     )}
                                     onChange={setOrgUnitLevels}
+                                    disabled={hasUserOrgUnits}
                                 />
                                 <OrgUnitGroupSelect
                                     orgUnitGroup={getOrgUnitGroupsFromRows(
                                         rows
                                     )}
                                     onChange={setOrgUnitGroups}
+                                    disabled={hasUserOrgUnits}
                                 />
                                 <UserOrgUnitsSelect
                                     selected={selectedUserOrgUnits}

--- a/src/components/edit/FacilityDialog.js
+++ b/src/components/edit/FacilityDialog.js
@@ -157,6 +157,7 @@ class FacilityDialog extends Component {
 
         const orgUnits = getOrgUnitsFromRows(rows);
         const selectedUserOrgUnits = getUserOrgUnitsFromRows(rows);
+        const hasUserOrgUnits = !!selectedUserOrgUnits.length;
 
         return (
             <div data-test="facilitydialog">
@@ -197,11 +198,7 @@ class FacilityDialog extends Component {
                                 <OrgUnitTree
                                     selected={getOrgUnitNodesFromRows(rows)}
                                     onClick={toggleOrgUnit}
-                                    disabled={
-                                        selectedUserOrgUnits.length
-                                            ? true
-                                            : false
-                                    }
+                                    disabled={hasUserOrgUnits}
                                 />
                             </div>
                             <div style={styles.flexColumn}>
@@ -210,12 +207,14 @@ class FacilityDialog extends Component {
                                         rows
                                     )}
                                     onChange={setOrgUnitLevels}
+                                    disabled={hasUserOrgUnits}
                                 />
                                 <OrgUnitGroupSelect
                                     orgUnitGroup={getOrgUnitGroupsFromRows(
                                         rows
                                     )}
                                     onChange={setOrgUnitGroups}
+                                    disabled={hasUserOrgUnits}
                                 />
                                 <UserOrgUnitsSelect
                                     selected={selectedUserOrgUnits}

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -276,6 +276,7 @@ export class ThematicDialog extends Component {
         const selectedUserOrgUnits = getUserOrgUnitsFromRows(rows);
         const period = getPeriodFromFilters(filters);
         const dataItem = getDataItemFromColumns(columns);
+        const hasUserOrgUnits = !!selectedUserOrgUnits.length;
 
         return (
             <div data-test="thematicdialog">
@@ -491,11 +492,7 @@ export class ThematicDialog extends Component {
                                 <OrgUnitTree
                                     selected={getOrgUnitNodesFromRows(rows)}
                                     onClick={toggleOrgUnit}
-                                    disabled={
-                                        selectedUserOrgUnits.length
-                                            ? true
-                                            : false
-                                    }
+                                    disabled={hasUserOrgUnits}
                                 />
                             </div>
                             <div style={styles.flexColumn}>
@@ -504,12 +501,14 @@ export class ThematicDialog extends Component {
                                         rows
                                     )}
                                     onChange={setOrgUnitLevels}
+                                    disabled={hasUserOrgUnits}
                                 />
                                 <OrgUnitGroupSelect
                                     orgUnitGroup={getOrgUnitGroupsFromRows(
                                         rows
                                     )}
                                     onChange={setOrgUnitGroups}
+                                    disabled={hasUserOrgUnits}
                                 />
                                 <UserOrgUnitsSelect
                                     selected={selectedUserOrgUnits}

--- a/src/components/orgunits/OrgUnitGroupSelect.js
+++ b/src/components/orgunits/OrgUnitGroupSelect.js
@@ -14,9 +14,14 @@ export class OrgUnitGroupSelect extends Component {
     static propTypes = {
         orgUnitGroup: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
         orgUnitGroups: PropTypes.array,
+        disabled: PropTypes.bool,
         onChange: PropTypes.func.isRequired,
         loadOrgUnitGroups: PropTypes.func.isRequired,
         style: PropTypes.object,
+    };
+
+    static defaultProps = {
+        disabled: false,
     };
 
     componentDidMount() {
@@ -28,7 +33,7 @@ export class OrgUnitGroupSelect extends Component {
     }
 
     render() {
-        const { orgUnitGroup, orgUnitGroups, onChange } = this.props;
+        const { orgUnitGroup, orgUnitGroups, disabled, onChange } = this.props;
 
         return (
             <SelectField
@@ -40,6 +45,7 @@ export class OrgUnitGroupSelect extends Component {
                 onChange={onChange}
                 style={style}
                 data-test="orgunitgroupselect"
+                disabled={disabled}
             />
         );
     }

--- a/src/components/orgunits/OrgUnitLevelSelect.js
+++ b/src/components/orgunits/OrgUnitLevelSelect.js
@@ -41,9 +41,19 @@ export class OrgUnitLevelSelect extends Component {
     }
 
     componentDidUpdate() {
-        const { defaultLevel, orgUnitLevel, orgUnitLevels } = this.props;
+        const {
+            defaultLevel,
+            orgUnitLevel,
+            orgUnitLevels,
+            disabled,
+        } = this.props;
 
-        if (!orgUnitLevel.length && defaultLevel && orgUnitLevels) {
+        if (
+            !disabled &&
+            !orgUnitLevel.length &&
+            defaultLevel &&
+            orgUnitLevels
+        ) {
             const levelItem = orgUnitLevels.find(
                 item => item.level === defaultLevel
             );

--- a/src/components/orgunits/OrgUnitLevelSelect.js
+++ b/src/components/orgunits/OrgUnitLevelSelect.js
@@ -17,8 +17,13 @@ export class OrgUnitLevelSelect extends Component {
         orgUnitLevel: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
         orgUnitLevels: PropTypes.array,
         loadOrgUnitLevels: PropTypes.func.isRequired,
+        disabled: PropTypes.bool,
         onChange: PropTypes.func.isRequired,
         style: PropTypes.object,
+    };
+
+    static defaultProps = {
+        disabled: false,
     };
 
     constructor(props, context) {
@@ -50,7 +55,7 @@ export class OrgUnitLevelSelect extends Component {
     }
 
     render() {
-        const { orgUnitLevel, orgUnitLevels, onChange } = this.props;
+        const { orgUnitLevel, orgUnitLevels, disabled, onChange } = this.props;
         let sortedOrgUnitLevels;
 
         if (orgUnitLevels) {
@@ -69,6 +74,7 @@ export class OrgUnitLevelSelect extends Component {
                 onChange={onChange}
                 style={style}
                 data-test="orgunitlevelselect"
+                disabled={disabled}
             />
         );
     }

--- a/src/reducers/layerEdit.js
+++ b/src/reducers/layerEdit.js
@@ -5,7 +5,7 @@ import {
     setDataItemInColumns,
     addOrgUnitLevelsToRows,
     addOrgUnitGroupsToRows,
-    addUserOrgUnitsToRows,
+    createUserOrgUnitsDimension,
     toggleOrgUnitNodeInRows,
     setOrgUnitPathInRows,
 } from '../util/analytics';
@@ -304,7 +304,7 @@ const layerEdit = (state = null, action) => {
         case types.LAYER_EDIT_USER_ORGANISATION_UNITS_SET:
             return {
                 ...state,
-                rows: addUserOrgUnitsToRows(state.rows, action.userOrgUnits),
+                rows: createUserOrgUnitsDimension(action.userOrgUnits),
             };
 
         case types.LAYER_EDIT_ORGANISATIOM_UNIT_TOGGLE:

--- a/src/util/analytics.js
+++ b/src/util/analytics.js
@@ -134,11 +134,9 @@ export const getUserOrgUnitsFromRows = (rows = []) =>
         .filter(isUserOrgUnit)
         .map(getIdFromUserOrgUnit);
 
-export const addUserOrgUnitsToRows = (rows = [], userOrgUnits = []) => [
-    createDimension('ou', [
-        ...getOrgUnitsFromRows(rows).filter(negate(isUserOrgUnit)),
-        ...userOrgUnits.map(createUserOrgUnit),
-    ]),
+// Adding user org units will clear other org unit selections
+export const createUserOrgUnitsDimension = (userOrgUnits = []) => [
+    createDimension('ou', [...userOrgUnits.map(createUserOrgUnit)]),
 ];
 
 /* PERIODS */


### PR DESCRIPTION
This PR fixes issue: https://jira.dhis2.org/browse/DHIS2-6190

When selecting an user org unit level, all other org unit selections are cleared and disabled. This is fixed for thematic, facility and boundary layers. 

This is the same behaviour as the Data Visualizer app.

At a later stage we should switch to the same org unit selection components as the Data visualizer app. 

This fix needs to be backported to Map app 2.29. 