### PR TITLE
Empty filters error with Earth Engine layers

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
         "@dhis2/d2-ui-interpretations": "5.2.10",
         "@dhis2/d2-ui-org-unit-dialog": "5.2.10",
         "@dhis2/d2-ui-org-unit-tree": "5.2.10",
-        "@dhis2/gis-api": "32.0.9",
+        "@dhis2/gis-api": "32.0.14",
         "@dhis2/ui": "^1.0.0-beta.15",
         "@material-ui/core": "^3.4.0",
         "@material-ui/icons": "^3.0.1",

--- a/src/epics/earthEngine.js
+++ b/src/epics/earthEngine.js
@@ -147,22 +147,20 @@ export const loadCollection = action$ =>
                 );
             }
 
-            return setAuthToken(token)
-                .then(() =>
-                    new Promise(collections[action.id]).then(data =>
-                        setEarthEngineCollection(action.id, data)
-                    )
-                )
-                .catch(() =>
-                    setAlert(
-                        createAlert(
-                            i18n.t('Error'),
-                            i18n.t(
-                                'A connection to Google Earth Engine could not be established.'
-                            )
+            await setAuthToken(token).catch(() =>
+                setAlert(
+                    createAlert(
+                        i18n.t('Error'),
+                        i18n.t(
+                            'A connection to Google Earth Engine could not be established.'
                         )
                     )
-                );
+                )
+            );
+
+            return new Promise(collections[action.id]).then(data =>
+                setEarthEngineCollection(action.id, data)
+            );
         });
 
 export default combineEpics(loadCollection);

--- a/src/epics/earthEngine.js
+++ b/src/epics/earthEngine.js
@@ -147,17 +147,18 @@ export const loadCollection = action$ =>
                 );
             }
 
-            await setAuthToken(token).catch(() =>
-                setAlert(
+            try {
+                await setAuthToken(token);
+            } catch (e) {
+                return setAlert(
                     createAlert(
                         i18n.t('Error'),
                         i18n.t(
                             'A connection to Google Earth Engine could not be established.'
                         )
                     )
-                )
-            );
-
+                );
+            }
             return new Promise(collections[action.id]).then(data =>
                 setEarthEngineCollection(action.id, data)
             );

--- a/yarn.lock
+++ b/yarn.lock
@@ -302,12 +302,12 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/gis-api@32.0.9":
-  version "32.0.9"
-  resolved "https://registry.yarnpkg.com/@dhis2/gis-api/-/gis-api-32.0.9.tgz#4c18e06a7fe4b6f956fd6b1c1813a36f9226d1c3"
-  integrity sha512-6+9fG7xyYLNFZC/8kVbAQNDSnxcIAFRhkiEB7fxrcStX3rZMMmzHXtb3gZhLVfS3NEm4yErSf1SzInLiLBnkAQ==
+"@dhis2/gis-api@32.0.14":
+  version "32.0.14"
+  resolved "https://registry.yarnpkg.com/@dhis2/gis-api/-/gis-api-32.0.14.tgz#2652567a37ec772a7a1261cf63746d5c567ce534"
+  integrity sha512-68aRCb2mZFwB1LFZYGalHCr4aClSp5+BaB2ddTBW817WVi4xkRi/ssQIAb92knSSLlB8e72MX+SBNVUXKfRvcA==
   dependencies:
-    "@google/earthengine" "^0.1.167"
+    "@google/earthengine" "^0.1.172"
     "@mapbox/geojson-area" "^0.2.2"
     "@mapbox/polylabel" "^1.0.2"
     "@turf/buffer" "^5.1.5"
@@ -375,10 +375,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
   integrity sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==
 
-"@google/earthengine@^0.1.167":
-  version "0.1.171"
-  resolved "https://registry.yarnpkg.com/@google/earthengine/-/earthengine-0.1.171.tgz#929012aa21bec3befa663a11493867d9b63a6b22"
-  integrity sha512-vxyI1t5oCVRNjuSeEwI2cjHtBaup87uKXqgJFfeYXOxhg8Plbk+oZAkukYdyZnPFD6DDsG51GOc41qBPTbfEMw==
+"@google/earthengine@^0.1.172":
+  version "0.1.172"
+  resolved "https://registry.yarnpkg.com/@google/earthengine/-/earthengine-0.1.172.tgz#407e4273efc395d4b24bb4e33efaf4249a280314"
+  integrity sha512-QnQR2jUMlboWXHQfdTW0BdHxJ51GHv4E7ijUdtKCotCAlGU6kWnPk49XKxeT9N07m8gnvxxMedKhNm0U4tUh4g==
   dependencies:
     googleapis "^16.1.0"
     xmlhttprequest "^1.8.0"


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-6377

This PR uses a newer version of the GIS API with fixes for the Earth Engine dependency. 

It's also setting the error message to the correct promise. 