### PR TITLE
fix: expand/collapse layer tooltip

### DIFF
--- a/src/components/layers/basemaps/BasemapCard.js
+++ b/src/components/layers/basemaps/BasemapCard.js
@@ -85,15 +85,14 @@ const BasemapCard = props => {
                 title={name}
                 subheader={subtitle}
                 action={
-                    <Tooltip key="expand" title={i18n.t('Collapse')}>
+                    <Tooltip
+                        title={
+                            isExpanded ? i18n.t('Collapse') : i18n.t('Expand')
+                        }
+                    >
                         <IconButton
                             className={classes.expand}
                             onClick={toggleBasemapExpand}
-                            tooltip={
-                                isExpanded
-                                    ? i18n.t('Collapse')
-                                    : i18n.t('Expand')
-                            }
                             style={{ backgroundColor: 'transparent' }}
                         >
                             {isExpanded ? (

--- a/src/components/layers/layers/LayerCard.js
+++ b/src/components/layers/layers/LayerCard.js
@@ -123,15 +123,15 @@ const LayerCard = ({
                 }
                 action={[
                     <SortableHandle key="handle" />,
-                    <Tooltip key="expand" title={i18n.t('Collapse')}>
+                    <Tooltip
+                        key="expand"
+                        title={
+                            isExpanded ? i18n.t('Collapse') : i18n.t('Expand')
+                        }
+                    >
                         <IconButton
                             className={classes.expand}
                             onClick={() => toggleLayerExpand(id)}
-                            tooltip={
-                                isExpanded
-                                    ? i18n.t('Collapse')
-                                    : i18n.t('Expand')
-                            }
                             style={{ backgroundColor: 'transparent' }}
                         >
                             {isExpanded ? (


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-6681

 If layer is open tooltip should read 'Collapse', if layer is closed tooltip should read 'Expand'.