### PR TITLE
fix: extract map id from web api response

### DIFF
--- a/src/epics/favorites.js
+++ b/src/epics/favorites.js
@@ -44,13 +44,16 @@ export const saveNewFavorite = (action$, store) =>
                 config.mapViews.forEach(view => delete view.id);
             }
 
-            return apiFetch('/maps/', 'POST', config).then(async res => {
-                const location = res.headers.get('Location');
-                const id = location ? location.substring(6) : null;
-                const response = await res.json();
-
-                return response.status === 'OK' ? { ...config, id } : response;
-            });
+            return apiFetch('/maps/', 'POST', config)
+                .then(response => response.json())
+                .then(response =>
+                    response.status === 'OK'
+                        ? {
+                              ...config,
+                              id: response.response.uid,
+                          }
+                        : response
+                );
         })
         .mergeMap(({ id, name, description, message }) =>
             name


### PR DESCRIPTION
Fixes issue: https://jira.dhis2.org/browse/DHIS2-6750

When we save a map, the Web API returns the id in the Location header. The format of this string is changed in the backend, so we need to change how we extract the id. 

We now get the uid from the response itself which should be less fragile.

![Skjermbilde 2019-04-24 kl  15 36 45](https://user-images.githubusercontent.com/548708/56664905-50a4e200-66a9-11e9-8b55-bcb0f2fc1cec.png)
![Skjermbilde 2019-04-24 kl  15 35 18](https://user-images.githubusercontent.com/548708/56664906-50a4e200-66a9-11e9-807f-213021a537f5.png)