### PR TITLE
Change order of layer dialog tabs

### DIFF
--- a/src/components/edit/EventDialog.js
+++ b/src/components/edit/EventDialog.js
@@ -210,8 +210,8 @@ export class EventDialog extends Component {
                 <Tabs value={tab} onChange={tab => this.setState({ tab })}>
                     <Tab value="data" label={i18n.t('data')} />
                     <Tab value="period" label={i18n.t('period')} />
-                    <Tab value="filter" label={i18n.t('Filter')} />
                     <Tab value="orgunits" label={i18n.t('Org units')} />
+                    <Tab value="filter" label={i18n.t('Filter')} />
                     <Tab value="style" label={i18n.t('Style')} />
                 </Tabs>
                 <div style={styles.tabContent} data-test="eventdialog-content">
@@ -277,20 +277,6 @@ export class EventDialog extends Component {
                             ) : null}
                         </div>
                     )}
-                    {tab === 'filter' && (
-                        <div
-                            style={styles.flexRowFlow}
-                            data-test="eventdialog-filtertab"
-                        >
-                            <FilterGroup
-                                program={program}
-                                programStage={programStage}
-                                filters={columns.filter(
-                                    c => c.filter !== undefined
-                                )}
-                            />
-                        </div>
-                    )}
                     {tab === 'orgunits' && (
                         <div
                             style={styles.flexColumnFlow}
@@ -323,6 +309,20 @@ export class EventDialog extends Component {
                                     error={orgUnitsError}
                                 />
                             </div>
+                        </div>
+                    )}
+                    {tab === 'filter' && (
+                        <div
+                            style={styles.flexRowFlow}
+                            data-test="eventdialog-filtertab"
+                        >
+                            <FilterGroup
+                                program={program}
+                                programStage={programStage}
+                                filters={columns.filter(
+                                    c => c.filter !== undefined
+                                )}
+                            />
                         </div>
                     )}
                     {tab === 'style' && (

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -296,14 +296,14 @@ export class ThematicDialog extends Component {
                         data-test="thematicdialog-tabs-period"
                     />
                     <Tab
-                        value="filter"
-                        label={i18n.t('Filter')}
-                        data-test="thematicdialog-tabs-filter"
-                    />
-                    <Tab
                         value="orgunits"
                         label={i18n.t('Org units')}
                         data-test="thematicdialog-tabs-orgunits"
+                    />
+                    <Tab
+                        value="filter"
+                        label={i18n.t('Filter')}
+                        data-test="thematicdialog-tabs-filter"
                     />
                     <Tab
                         value="style"
@@ -487,14 +487,6 @@ export class ThematicDialog extends Component {
                             ]}
                         </div>
                     )}
-                    {tab === 'filter' && (
-                        <div
-                            style={styles.flexRowFlow}
-                            data-test="thematicdialog-filtertab"
-                        >
-                            <DimensionFilter dimensions={dimensions} />
-                        </div>
-                    )}
                     {tab === 'orgunits' && (
                         <div
                             style={styles.flexColumnFlow}
@@ -537,6 +529,14 @@ export class ThematicDialog extends Component {
                                     </div>
                                 )}
                             </div>
+                        </div>
+                    )}
+                    {tab === 'filter' && (
+                        <div
+                            style={styles.flexRowFlow}
+                            data-test="thematicdialog-filtertab"
+                        >
+                            <DimensionFilter dimensions={dimensions} />
                         </div>
                     )}
                     {tab === 'style' && (


### PR DESCRIPTION
This PR moves the filter tab after the org units tab. Reasons are:

1. its nice to have the _mandatory_ dimensions come first, so that user can quickly create a map (i know org unit is preselected). Filters are optional while org unit is mandatory).
2. this makes it consistent with pivots/charts where we have data, period, org unit in that order.