### PR TITLE
Validity check of program stage data elements and tracked entity attributes

### DIFF
--- a/src/components/dataItem/CoordinateField.js
+++ b/src/components/dataItem/CoordinateField.js
@@ -48,7 +48,7 @@ export class CoordinateField extends Component {
                 [
                     ...(programAttributes[program.id] || []),
                     ...(dataElements[programStage.id] || []),
-                ].filter(field => field && field.valueType === 'COORDINATE')
+                ].filter(field => field.valueType === 'COORDINATE')
             );
         }
 

--- a/src/epics/programs.js
+++ b/src/epics/programs.js
@@ -13,7 +13,7 @@ import {
     setProgramStageDataElements,
 } from '../actions/programs';
 import { errorActionCreator } from '../actions/helpers';
-import { getDisplayPropertyUrl } from '../util/helpers';
+import { getDisplayPropertyUrl, getValidDataItems } from '../util/helpers';
 
 export const loadPrograms = action$ =>
     action$.ofType(types.PROGRAMS_LOAD).concatMap(() =>
@@ -80,12 +80,13 @@ export const loadProgramTrackedEntityAttributes = action$ =>
                 })
             )
             .then(program =>
-                setProgramAttributes(
-                    action.programId,
-                    program.programTrackedEntityAttributes.map(
-                        d => d.trackedEntityAttribute
-                    )
+                program.programTrackedEntityAttributes.map(
+                    d => d.trackedEntityAttribute
                 )
+            )
+            .then(getValidDataItems)
+            .then(attributes =>
+                setProgramAttributes(action.programId, attributes)
             )
             .catch(errorActionCreator(types.PROGRAM_ATTRIBUTES_LOAD_ERROR))
     );
@@ -126,6 +127,7 @@ export const loadProgramStageDataElements = action$ =>
             .then(programStage =>
                 programStage.programStageDataElements.map(d => d.dataElement)
             )
+            .then(getValidDataItems)
             .then(dataElements =>
                 setProgramStageDataElements(action.programStageId, dataElements)
             )

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -125,10 +125,12 @@ export const addOrgUnitPaths = mapViews =>
 // https://stackoverflow.com/questions/10805125/how-to-remove-all-line-breaks-from-a-string/10805292#10805292
 export const removeLineBreaks = text => text.replace(/\r?\n|\r/g, ' ');
 
-const mandatoryProps = ['id', 'name', 'valueType'];
+const mandatoryDataItemAttributes = ['id', 'name', 'valueType'];
 
 // Checks if a data item is valid (program stage data elements and tracked entity attributes)
 export const getValidDataItems = items =>
     items.filter(
-        item => isObject(item) && mandatoryProps.every(prop => prop in item)
+        item =>
+            isObject(item) &&
+            mandatoryDataItemAttributes.every(prop => prop in item)
     );

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -1,4 +1,5 @@
 import { getInstance as getD2 } from 'd2';
+import { isObject } from 'lodash/fp';
 
 const propertyMap = {
     name: 'name',
@@ -123,3 +124,11 @@ export const addOrgUnitPaths = mapViews =>
 // Remove line breaks from text (not displayed corrently in map downloads)
 // https://stackoverflow.com/questions/10805125/how-to-remove-all-line-breaks-from-a-string/10805292#10805292
 export const removeLineBreaks = text => text.replace(/\r?\n|\r/g, ' ');
+
+const mandatoryProps = ['id', 'name', 'valueType'];
+
+// Checks if a data item is valid (program stage data elements and tracked entity attributes)
+export const getValidDataItems = items =>
+    items.filter(
+        item => isObject(item) && mandatoryProps.every(prop => prop in item)
+    );


### PR DESCRIPTION
Fixes app crash: https://jira.dhis2.org/browse/DHIS2-6733

The root cause to this issue is that the Web API allows an empty data item (no properties) to pass through: https://jira.dhis2.org/browse/DHIS2-6760

With this PR we validate that all program stage data elements and tracked entity attributes contains id, name and valueType properties which are required by the app. 

This replaces the fix in https://github.com/dhis2/maps-app/pull/128 which is reverted im this PR.