### PR TITLE
fix: sort to draw polygons before points

### DIFF
--- a/src/util/geojson.js
+++ b/src/util/geojson.js
@@ -107,6 +107,9 @@ export const createEventFeatures = (response, config = {}) => {
         )
     );
 
+    // Sort to draw polygons before points
+    data.sort(feature => (feature.geometry.type === 'Polygon' ? -1 : 0));
+
     return { data, names };
 };
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-6776

To draw polygons before points, they need to be first in the data array. 