### PR TITLE
fix: correctly look up lowercase option code

### DIFF
--- a/src/util/styleByDataItem.js
+++ b/src/util/styleByDataItem.js
@@ -170,7 +170,8 @@ export const styleByOptionSet = async config => {
 
     // Add style data value and color to each feature
     config.data = config.data.map(feature => {
-        const option = optionsByCode[feature.properties[id]];
+        const featureOptionCode = String(feature.properties[id]).toLowerCase();
+        const option = optionsByCode[featureOptionCode];
 
         if (!option) {
             return feature;


### PR DESCRIPTION
This fixes [DHIS2-6913](https://jira.dhis2.org/browse/DHIS2-6913) which was introduced by a change to use lowercase strings in the OptionSet map (a15cd4f6904ac163c953fa7517c51869f27e61d3)