### PR TITLE
fix: expand the width of drop down menus

### DIFF
--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -12,4 +12,5 @@ body {
 /* Fix to allow menus to have a width that fits its content in Material-UI 0.20 */
 div[role='presentation'] {
     width: auto !important;
+    max-width: 400px;
 }

--- a/scss/layout.scss
+++ b/scss/layout.scss
@@ -8,3 +8,8 @@ body {
         opacity: 0.5;
     }
 }
+
+/* Fix to allow menus to have a width that fits its content in Material-UI 0.20 */
+div[role='presentation'] {
+    width: auto !important;
+}


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-4726 for Maps 2.30

The fix allows drop down menus to have a width of its content, rather than the width of the select field that triggers it. 

I applied a quickfix for this backport as the original select field component is in another repo that is no longer maintained. I've clicked through all layer dialogs and did't notice any unwanted side effects. 

![Skjermbilde 2019-05-16 kl  16 38 28](https://user-images.githubusercontent.com/548708/57863515-86e20700-77fa-11e9-9762-67ade525a718.png)
![Skjermbilde 2019-05-16 kl  16 37 53](https://user-images.githubusercontent.com/548708/57863516-86e20700-77fa-11e9-862e-8357f28a96ea.png)
