### PR TITLE
feat: improved period selection for google earth engine layers

### DIFF
--- a/src/components/earthengine/Collection.js
+++ b/src/components/earthengine/Collection.js
@@ -18,6 +18,17 @@ const collectionFilters = {
     ],
 };
 
+const styles = {
+    year: {
+        width: '35%',
+        paddingRight: 16,
+        boxSizing: 'border-box',
+    },
+    period: {
+        width: '65%',
+    },
+};
+
 export class CollectionSelect extends Component {
     static propTypes = {
         id: PropTypes.string.isRequired,
@@ -30,6 +41,11 @@ export class CollectionSelect extends Component {
         style: PropTypes.object,
     };
 
+    state = {
+        years: null,
+        year: null,
+    };
+
     componentDidMount() {
         const { id, collections, loadEarthEngineCollection } = this.props;
 
@@ -38,20 +54,70 @@ export class CollectionSelect extends Component {
         }
     }
 
-    render() {
-        const {
-            id,
-            filter,
-            label,
-            collections,
-            onChange,
-            style,
-            errorText,
-        } = this.props;
+    componentDidUpdate(prevProps) {
+        const { id, collections } = this.props;
 
-        const items = collections[id];
+        if (id && collections[id] !== prevProps.collections[id]) {
+            const years = collections[id]
+                .filter(item => item.year)
+                .map(item => item.year);
+
+            if (years.length) {
+                const yearItems = [...new Set(years)].map(year => ({
+                    id: year,
+                    name: year.toString(),
+                }));
+
+                this.setState({
+                    years: yearItems,
+                    year: yearItems[0].id,
+                });
+            }
+        }
+    }
+
+    render() {
+        const { id, filter, label, collections, style, errorText } = this.props;
+
+        const { years, year } = this.state;
+
+        const items = year
+            ? collections[id].filter(item => item.year === year)
+            : collections[id];
+
         const value = filter && filter[0].arguments[1];
 
+        return (
+            <div style={style}>
+                {years && (
+                    <SelectField
+                        label={label || i18n.t('Year')}
+                        items={years}
+                        value={year}
+                        onChange={this.onYearChange}
+                        style={styles.year}
+                    />
+                )}
+                <SelectField
+                    label={label || i18n.t('Period')}
+                    loading={items ? false : true}
+                    items={items}
+                    value={value}
+                    onChange={this.onPeriodChange}
+                    style={styles.period}
+                    errorText={!value && errorText ? errorText : null}
+                />
+            </div>
+        );
+    }
+
+    onYearChange = year => {
+        this.setState({ year: year.id });
+        this.props.onChange(null, null);
+    };
+
+    onPeriodChange = period => {
+        const { id, onChange } = this.props;
         const collectionFilter =
             collectionFilters[id] ||
             (index => [
@@ -61,20 +127,8 @@ export class CollectionSelect extends Component {
                 },
             ]);
 
-        return (
-            <SelectField
-                label={label || i18n.t('Period')}
-                loading={items ? false : true}
-                items={items}
-                value={value}
-                onChange={period =>
-                    onChange(period.name, collectionFilter(period.id))
-                }
-                style={style}
-                errorText={!value && errorText ? errorText : null}
-            />
-        );
-    }
+        onChange(period.name, collectionFilter(period.id));
+    };
 }
 
 export default connect(

--- a/src/components/earthengine/Collection.js
+++ b/src/components/earthengine/Collection.js
@@ -63,11 +63,13 @@ export class CollectionSelect extends Component {
                 .map(item => item.year);
 
             if (yearItems.length) {
+                // Get unique years
                 const years = [...new Set(yearItems)].map(year => ({
                     id: year,
                     name: year.toString(),
                 }));
 
+                // Get year from saved filter or select the most recent
                 const year = filter
                     ? Number(filter[0].arguments[1].substring(0, 4))
                     : years[0].id;
@@ -105,7 +107,7 @@ export class CollectionSelect extends Component {
                     items={items}
                     value={value}
                     onChange={this.onPeriodChange}
-                    style={styles.period}
+                    style={years && styles.period}
                     errorText={!value && errorText ? errorText : null}
                 />
             </div>

--- a/src/components/earthengine/Collection.js
+++ b/src/components/earthengine/Collection.js
@@ -55,23 +55,24 @@ export class CollectionSelect extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        const { id, collections } = this.props;
+        const { id, filter, collections } = this.props;
 
         if (id && collections[id] !== prevProps.collections[id]) {
-            const years = collections[id]
+            const yearItems = collections[id]
                 .filter(item => item.year)
                 .map(item => item.year);
 
-            if (years.length) {
-                const yearItems = [...new Set(years)].map(year => ({
+            if (yearItems.length) {
+                const years = [...new Set(yearItems)].map(year => ({
                     id: year,
                     name: year.toString(),
                 }));
 
-                this.setState({
-                    years: yearItems,
-                    year: yearItems[0].id,
-                });
+                const year = filter
+                    ? Number(filter[0].arguments[1].substring(0, 4))
+                    : years[0].id;
+
+                this.setState({ years, year });
             }
         }
     }

--- a/src/epics/earthEngine.js
+++ b/src/epics/earthEngine.js
@@ -68,6 +68,9 @@ const collections = {
             resolve(
                 data.features.map(f => ({
                     id: f.id,
+                    year: new Date(
+                        f.properties['system:time_start']
+                    ).getFullYear(),
                     name: formatStartEndDate(
                         f.properties['system:time_start'],
                         f.properties['system:time_end'] - 7200001

--- a/src/epics/earthEngine.js
+++ b/src/epics/earthEngine.js
@@ -73,8 +73,10 @@ const collections = {
                     ).getFullYear(),
                     name: formatStartEndDate(
                         f.properties['system:time_start'],
-                        f.properties['system:time_end'] - 7200001
-                    ), // Minus 2 hrs to end the day before
+                        f.properties['system:time_end'] - 7200001, // Minus 2 hrs to end the day before
+                        null,
+                        false
+                    ),
                 }))
             )
         );
@@ -98,8 +100,10 @@ const collections = {
                     ).getFullYear(),
                     name: formatStartEndDate(
                         f.properties['system:time_start'],
-                        f.properties['system:time_end'] - 7200001
-                    ), // Minus 2 hrs to end the day before
+                        f.properties['system:time_end'] - 7200001, // Minus 2 hrs to end the day before
+                        null,
+                        false
+                    ),
                 }))
             )
         );

--- a/src/epics/earthEngine.js
+++ b/src/epics/earthEngine.js
@@ -93,6 +93,9 @@ const collections = {
             resolve(
                 data.features.map(f => ({
                     id: f.id,
+                    year: new Date(
+                        f.properties['system:time_start']
+                    ).getFullYear(),
                     name: formatStartEndDate(
                         f.properties['system:time_start'],
                         f.properties['system:time_end'] - 7200001

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -64,7 +64,7 @@ export const formatLocaleDate = (dateString, locale, showYear = true) =>
         : fallbackDateFormat(dateString);
 
 /**
- * Formats a date range without showing year
+ * Formats a date range
  * @param {String|Number} startDate
  * @param {String|Number} endDate
  * @param {String} locale

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -51,29 +51,32 @@ export const hasIntlSupport =
  * Formats a date string or timestamp to the default display format: 13 Aug 2018 (en locale)
  * @param {String} dateString
  * @param {String} locale
+ * @param {Boolean} showYear
  * @returns {String}
  */
-export const formatLocaleDate = (dateString, locale) =>
+export const formatLocaleDate = (dateString, locale, showYear = true) =>
     hasIntlSupport
         ? new Intl.DateTimeFormat(locale || i18n.language || DEFAULT_LOCALE, {
-              year: 'numeric',
+              year: showYear ? 'numeric' : undefined,
               month: 'short',
               day: 'numeric',
           }).format(toDate(dateString))
         : fallbackDateFormat(dateString);
 
 /**
- * Formats a date range
+ * Formats a date range without showing year
  * @param {String|Number} startDate
  * @param {String|Number} endDate
  * @param {String} locale
+ * @param {Boolean} showYear
  * @returns {String}
  */
-export const formatStartEndDate = (startDate, endDate, locale) => {
+export const formatStartEndDate = (startDate, endDate, locale, showYear) => {
     const loc = locale || i18n.language || DEFAULT_LOCALE;
-    return `${formatLocaleDate(startDate, loc)} - ${formatLocaleDate(
+    return `${formatLocaleDate(startDate, loc, showYear)} - ${formatLocaleDate(
         endDate,
-        locale
+        locale,
+        showYear
     )}`;
 };
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-6321

This PR solves an issue with precipitation and temperature layers from Google Earth Engine. The data is provided in 5 and 8-days intervals, and with multiple years the period dropdown gets too big. The solution was to include a separate year select for these layers. 

![Skjermbilde 2019-05-21 kl  15 22 51](https://user-images.githubusercontent.com/548708/58099905-e4040100-7bdc-11e9-9518-a2c86605a4da.png)

The most recent year is autoselected. If a saved map is loaded, the year is extracted from the used period. 