### PR TITLE
fix: new temperature layer from google earth engine

### DIFF
--- a/src/components/edit/EarthEngineDialog.js
+++ b/src/components/edit/EarthEngineDialog.js
@@ -44,7 +44,7 @@ const datasets = {
         minLabel: 'Min mm',
         maxLabel: 'Max mm',
     },
-    'MODIS/MOD11A2': {
+    'MODIS/006/MOD11A2': {
         // Temperature
         description:
             'Land surface temperatures collected from satellite in 8 days periods. Blank spots will appear in areas with a persistent cloud cover.',

--- a/src/epics/earthEngine.js
+++ b/src/epics/earthEngine.js
@@ -76,10 +76,10 @@ const collections = {
             )
         );
     },
-    'MODIS/MOD11A2': resolve => {
+    'MODIS/006/MOD11A2': resolve => {
         // Temperature
         const imageCollection = ee
-            .ImageCollection('MODIS/MOD11A2')
+            .ImageCollection('MODIS/006/MOD11A2')
             .sort('system:time_start', false);
 
         const featureCollection = ee

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -187,6 +187,14 @@ const earthEngineLoader = async config => {
         // From database as favorite
         layerConfig = JSON.parse(config.config);
 
+        // Backward compability for temperature layer (could also be fixed in a db update script)
+        if (layerConfig.id === 'MODIS/MOD11A2' && layerConfig.filter) {
+            const period = layerConfig.image.slice(-10);
+            layerConfig.id = 'MODIS/006/MOD11A2';
+            layerConfig.image = period;
+            layerConfig.filter[0].arguments[1] = period;
+        }
+
         dataset = datasets[layerConfig.id];
 
         if (dataset) {

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -62,7 +62,7 @@ const datasets = {
                 'https://explorer.earthengine.google.com/#detail/UCSB-CHG%2FCHIRPS%2FPENTAD',
         },
     },
-    'MODIS/MOD11A2': {
+    'MODIS/006/MOD11A2': {
         name: 'Temperature',
         band: 'LST_Day_1km',
         mask: true,

--- a/src/reducers/layers.js
+++ b/src/reducers/layers.js
@@ -58,7 +58,7 @@ const defaultLayers = [
     },
     {
         layer: 'earthEngine',
-        datasetId: 'MODIS/MOD11A2',
+        datasetId: 'MODIS/006/MOD11A2',
         type: 'Temperature',
         img: 'images/temperature.png',
         params: {


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-6993

This PR changes to an up-to-date temperature layer from Google Earth Engine. I've also included a transformation to allow saved temperature layers to load. 

This fix should be backported to 2.30, 2.31 and 2.32