### PR TITLE
fix: use lower case when comparing options

### DIFF
--- a/src/util/styleByDataItem.js
+++ b/src/util/styleByDataItem.js
@@ -170,7 +170,8 @@ export const styleByOptionSet = async config => {
 
     // Add style data value and color to each feature
     config.data = config.data.map(feature => {
-        const option = optionsByCode[feature.properties[id]];
+        const code = (feature.properties[id] || '').toLowerCase();
+        const option = optionsByCode[code];
 
         if (!option) {
             return feature;

--- a/src/util/styleByDataItem.js
+++ b/src/util/styleByDataItem.js
@@ -170,21 +170,23 @@ export const styleByOptionSet = async config => {
 
     // Add style data value and color to each feature
     config.data = config.data.map(feature => {
-        const code = (feature.properties[id] || '').toLowerCase();
-        const option = optionsByCode[code];
+        const code = feature.properties[id];
 
-        if (!option) {
-            return feature;
+        if (code) {
+            const option = optionsByCode[code.toLowerCase()];
+            if (option) {
+                return {
+                    ...feature,
+                    properties: {
+                        ...feature.properties,
+                        value: option.name,
+                        color: option.style.color,
+                    },
+                };
+            }
         }
 
-        return {
-            ...feature,
-            properties: {
-                ...feature.properties,
-                value: option.name,
-                color: option.style.color,
-            },
-        };
+        return feature;
     });
 
     // Add legend data


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-7041

Fixes an issue where events are not styled by an option set, due to different case. 

We should switch to use uid to match options - it was previously not supported by the Web API, but we should check again. 