### PR TITLE
chore: add tool to input JSON config object to plugin.html

### DIFF
--- a/public/plugin.html
+++ b/public/plugin.html
@@ -26,6 +26,10 @@
             <input type="text" id="inputMapID" value="smxK71C26QU" />
         </div>
         <div>
+            <label>Config JSON</label>
+            <textarea id="inputMapConfig"></textarea>
+        </div>
+        <div>
             <label>User Org Unit</label>
             <input type="text" id="inputUserOrgUnit" value="" />
             <small><strong>Bo</strong> district = <strong>O6uvpzGd5pu</strong></small>
@@ -48,11 +52,24 @@
         mapPlugin.url = '//localhost:8080';
         mapPlugin.username = 'admin';
         mapPlugin.password = 'district';
+
         function onReloadBtnPress(e) {
+            let config = {}
+            try {
+                config = JSON.parse(document.getElementById('inputMapConfig').value);
+            } catch (e) {}
+
+            const id = document.getElementById('inputMapID').value;
+            if (id && id.length) {
+                config = {
+                    id
+                }
+            }
+
             mapPlugin.load({
-                id: document.getElementById('inputMapID').value,
                 el: 'map',
                 userOrgUnit: [document.getElementById('inputUserOrgUnit').value],
+                ...config
             })
 
             picker.style.display = 'none';

--- a/public/plugin.html
+++ b/public/plugin.html
@@ -57,20 +57,23 @@
             let config = {}
             try {
                 config = JSON.parse(document.getElementById('inputMapConfig').value);
-            } catch (e) {}
+            } catch (e) {
+                console.error(e)
+            }
 
             const id = document.getElementById('inputMapID').value;
             if (id && id.length) {
-                config = {
+                config.id = {
                     id
                 }
             }
 
-            mapPlugin.load({
+            config = Object.assign({
                 el: 'map',
-                userOrgUnit: [document.getElementById('inputUserOrgUnit').value],
-                ...config
-            })
+                userOrgUnit: [document.getElementById('inputUserOrgUnit').value]
+            }, config);
+
+            mapPlugin.load(config);
 
             picker.style.display = 'none';
             mapContainer.style.display = 'block';


### PR DESCRIPTION
This simply adds a `<textarea>` to `plugin.html` to support debugging of raw JSON config objects, rather than loading the plugin map by ID.  Note that to prevent the Plugin code from fetching a "favorite" from the server this requires the config to **omit** the `id` property and also for the `id` text field to be empty.

There's some divergence in how "fetched" and "configured" favorites are loaded which may cause some problems or make things harder to test with this method.  We should refactor the logic so that it is shared after the config is fetched.