### PR TITLE
fix: allow basemap to be 'none'

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -109,6 +109,12 @@ const Plugin = () => {
     async function loadLayers(config) {
         if (!isUnmounted(config.el)) {
             let basemap = config.basemap || 'osmLight';
+
+            // Default basemap is required, visibility is set to false below
+            if (basemap === 'none') {
+                basemap = 'osmLight';
+            }
+
             const basemapId = basemap.id || basemap;
 
             if (isValidUid(basemapId)) {
@@ -134,6 +140,10 @@ const Plugin = () => {
                         ...mapView,
                         userOrgUnit: config.userOrgUnit,
                     }));
+                }
+
+                if (config.basemap === 'none') {
+                    basemap.isVisible = false;
                 }
 
                 Promise.all(config.mapViews.map(fetchLayer)).then(mapViews =>


### PR DESCRIPTION
For backward compatibility, we need to allow basemap to be "none", e.g. don't show any basemap. We now control this with the visibility paramenter. 

Later (when we retire the old GIS app) we should fix this in a db upgrade script. 

Fixes: https://jira.dhis2.org/browse/DHIS2-7075

Needs to be backported. 