### PR TITLE
Period selection fix for EE layers

### DIFF
--- a/src/components/earthengine/Collection.js
+++ b/src/components/earthengine/Collection.js
@@ -51,31 +51,39 @@ export class CollectionSelect extends Component {
 
         if (id && !collections[id]) {
             loadEarthEngineCollection(id);
+        } else {
+            this.setYears();
         }
     }
 
     componentDidUpdate(prevProps) {
-        const { id, filter, collections } = this.props;
+        const { id, collections } = this.props;
 
         if (id && collections[id] !== prevProps.collections[id]) {
-            const yearItems = collections[id]
-                .filter(item => item.year)
-                .map(item => item.year);
+            this.setYears();
+        }
+    }
 
-            if (yearItems.length) {
-                // Get unique years
-                const years = [...new Set(yearItems)].map(year => ({
-                    id: year,
-                    name: year.toString(),
-                }));
+    setYears() {
+        const { id, filter, collections } = this.props;
 
-                // Get year from saved filter or select the most recent
-                const year = filter
-                    ? Number(filter[0].arguments[1].substring(0, 4))
-                    : years[0].id;
+        const yearItems = collections[id]
+            .filter(item => item.year)
+            .map(item => item.year);
 
-                this.setState({ years, year });
-            }
+        if (yearItems.length) {
+            // Get unique years
+            const years = [...new Set(yearItems)].map(year => ({
+                id: year,
+                name: year.toString(),
+            }));
+
+            // Get year from saved filter or select the most recent
+            const year = filter
+                ? Number(filter[0].arguments[1].substring(0, 4))
+                : years[0].id;
+
+            this.setState({ years, year });
         }
     }
 

--- a/src/components/earthengine/Collection.js
+++ b/src/components/earthengine/Collection.js
@@ -34,7 +34,7 @@ export class CollectionSelect extends Component {
         id: PropTypes.string.isRequired,
         label: PropTypes.string,
         errorText: PropTypes.string,
-        collections: PropTypes.object,
+        collections: PropTypes.object.isRequired,
         filter: PropTypes.array,
         loadEarthEngineCollection: PropTypes.func.isRequired,
         onChange: PropTypes.func.isRequired,
@@ -49,10 +49,12 @@ export class CollectionSelect extends Component {
     componentDidMount() {
         const { id, collections, loadEarthEngineCollection } = this.props;
 
-        if (id && !collections[id]) {
-            loadEarthEngineCollection(id);
-        } else {
-            this.setYears();
+        if (id) {
+            if (collections[id]) {
+                this.setYears();
+            } else {
+                loadEarthEngineCollection(id);
+            }
         }
     }
 


### PR DESCRIPTION
A small refactoring to show the year dropdown when the user is editing an EE layer which is already created (and collections are loaded). 

Related issue: https://jira.dhis2.org/browse/DHIS2-6321