### PR TITLE
Fix: use variant fullwidth instead of deprecated property

### DIFF
--- a/src/components/core/Tabs.js
+++ b/src/components/core/Tabs.js
@@ -14,7 +14,7 @@ const Tabs = props => (
     <MuiTabs
         indicatorColor="primary"
         textColor="primary"
-        fullWidth
+        variant="fullWidth"
         {...props}
         onChange={(event, tab) => props.onChange(tab)}
     />


### PR DESCRIPTION
This is a tiny fix for a console error resulting from an upgraded dependency - we were previously using the `fullWidth` property for the tabs in layer dialog, but that property is deprecated.  The console error was:

```
checkPropTypes.js:20 Warning: Failed prop type: The prop `fullWidth` of `Tabs` is deprecated. Instead, use the `variant="fullWidth"` property.
```

Fixed by switching to use variant instead.