### PR TITLE
fix: make data for each period map unique

### DIFF
--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -31,16 +31,20 @@ class ThematicLayer extends Layer {
             renderingStrategy,
         } = this.props;
         const { period } = this.state;
+        let periodData = data;
 
         if (renderingStrategy !== 'SINGLE') {
-            const values = valuesByPeriod[period.id];
+            const values = valuesByPeriod[period.id] || {};
 
-            data.forEach(feature => {
-                feature.properties = {
+            periodData = data.map(feature => ({
+                ...feature,
+                properties: {
                     ...feature.properties,
-                    ...values[feature.id],
-                };
-            });
+                    ...(values[feature.id]
+                        ? values[feature.id]
+                        : { value: i18n.t('No data'), color: null }),
+                },
+            }));
         }
 
         const map = this.context.map;
@@ -51,7 +55,7 @@ class ThematicLayer extends Layer {
             index,
             opacity,
             isVisible,
-            data: filterData(data, dataFilters),
+            data: filterData(periodData, dataFilters),
             hoverLabel: '{name} ({value})',
             onClick: this.onFeatureClick.bind(this),
             onRightClick: this.onFeatureRightClick.bind(this),


### PR DESCRIPTION
Fixes: 
https://jira.dhis2.org/browse/DHIS2-7474
https://jira.dhis2.org/browse/DHIS2-7479

This PR fixes an issues where there are no data for certain period. When there is no data for an org unit for a time period, we set the value to "No data" and the color to null (it will then get the default no data color. 

We also make sure that the data (feature array) is unique for each period map by using the spread operator.

![Skjermbilde 2019-09-02 kl  17 07 06](https://user-images.githubusercontent.com/548708/64123458-b9614100-cda4-11e9-8a66-f7f151dace07.png)