### PR TITLE
fix: timeline fix for Firefox and bi-monthly periods

### DIFF
--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -5,6 +5,7 @@ import Timeline from '../periods/Timeline';
 import PeriodName from './PeriodName';
 import { filterData } from '../../util/filter';
 import { cssColor } from '../../util/colors';
+import { getPeriodFromFilters } from '../../util/analytics';
 import { removeLineBreaks } from '../../util/helpers';
 import {
     LABEL_FONT_SIZE,
@@ -101,8 +102,9 @@ class ThematicLayer extends Layer {
     }
 
     render() {
-        const { periods, renderingStrategy } = this.props;
+        const { periods, renderingStrategy, filters } = this.props;
         const { period } = this.state;
+        const { id } = getPeriodFromFilters(filters);
 
         if (renderingStrategy !== 'TIMELINE' || !period) {
             return null;
@@ -112,6 +114,7 @@ class ThematicLayer extends Layer {
             <Fragment>
                 <PeriodName period={period.name} isTimeline={true} />
                 <Timeline
+                    periodId={id}
                     period={period}
                     periods={periods}
                     onChange={this.onPeriodChange}

--- a/src/components/periods/Timeline.js
+++ b/src/components/periods/Timeline.js
@@ -49,6 +49,7 @@ const labelWidth = 80;
 const delay = 1500;
 const playBtn = <path d="M8 5v14l11-7z" />;
 const pauseBtn = <path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" />;
+const doubleTicksPeriods = ['LAST_6_BIMONTHS', 'BIMONTHS_THIS_YEAR'];
 
 export class Timeline extends Component {
     static contextTypes = {
@@ -56,6 +57,7 @@ export class Timeline extends Component {
     };
 
     static propTypes = {
+        periodId: PropTypes.string.isRequired,
         period: PropTypes.object.isRequired,
         periods: PropTypes.array.isRequired,
         onChange: PropTypes.func.isRequired,
@@ -154,7 +156,9 @@ export class Timeline extends Component {
 
     // Set timeline axis
     setTimeAxis = () => {
-        const numPeriods = this.props.periods.length;
+        const { periodId, periods } = this.props;
+        const numPeriods =
+            periods.length * (doubleTicksPeriods.includes(periodId) ? 2 : 1);
         const { width } = this.state;
         const ticks = Math.round(width / labelWidth);
         const timeAxis = axisBottom(this.timeScale);
@@ -167,8 +171,10 @@ export class Timeline extends Component {
     // Set timeline width from DOM el
     setWidth = () => {
         if (this.node) {
-            const width =
-                this.node.parentNode.clientWidth - paddingLeft - paddingRight;
+            // clientWith returns 0 for SVG elements in Firefox
+            const box = this.node.parentNode.getBoundingClientRect();
+            const width = box.right - box.left - paddingLeft - paddingRight;
+
             this.setState({ width });
         }
     };


### PR DESCRIPTION
Fixes: 
https://jira.dhis2.org/browse/DHIS2-7490
https://jira.dhis2.org/browse/DHIS2-7478

The ticks still don't align with the periods on narrow screens, but I think it's acceptable. Changing it further requires us to edit the d3.js source implementation, which is not worth the effort. 

![Skjermbilde 2019-09-03 kl  14 04 38](https://user-images.githubusercontent.com/548708/64172232-c6d60400-ce54-11e9-9976-d5d07090a50c.png)
![Skjermbilde 2019-09-03 kl  14 04 29](https://user-images.githubusercontent.com/548708/64172233-c6d60400-ce54-11e9-8370-c4519303ee1f.png)
