### PR TITLE
fix: format coordinate values in event popups

### DIFF
--- a/src/components/app/App.css
+++ b/src/components/app/App.css
@@ -4,6 +4,7 @@ body {
 /* Scrollbar width */
 ::-webkit-scrollbar {
     width: 6px;
+    height: 6px;
 }
 
 /* Scrollbar handle */

--- a/src/components/map/EventLayer.js
+++ b/src/components/map/EventLayer.js
@@ -157,7 +157,7 @@ class EventLayer extends Layer {
                 ' ' +
                 data.eventDate.substring(11, 16);
             const dataValues = data.dataValues;
-            let content = '<table><tbody>';
+            let content = '<div style="overflow-x:auto"><table><tbody>';
 
             // Output value if styled by data item, and item is not included in display elements
             if (styleDataItem && !this.displayElements[styleDataItem.id]) {
@@ -209,7 +209,7 @@ class EventLayer extends Layer {
                 <td>${time}</td>
               </tr>`;
 
-            content += '</tbody></table>';
+            content += '</tbody></table></div>';
 
             // Remove all line breaks as it's not working for map download
             this.context.map.openPopup(removeLineBreaks(content), coordinates);

--- a/src/components/map/EventLayer.js
+++ b/src/components/map/EventLayer.js
@@ -4,7 +4,11 @@ import { apiFetch } from '../../util/api';
 import { getAnalyticsRequest } from '../../loaders/eventLoader';
 import { EVENT_COLOR, EVENT_RADIUS } from '../../constants/layers';
 import Layer from './Layer';
-import { getDisplayPropertyUrl, removeLineBreaks } from '../../util/helpers';
+import {
+    getDisplayPropertyUrl,
+    removeLineBreaks,
+    formatCoordinate,
+} from '../../util/helpers';
 
 class EventLayer extends Layer {
     createLayer() {
@@ -173,9 +177,7 @@ class EventLayer extends Layer {
                         let { value } = dataValue;
 
                         if (valueType === 'COORDINATE' && value) {
-                            value = JSON.parse(value)
-                                .map(v => v.toFixed(6))
-                                .join(', ');
+                            value = formatCoordinate(value);
                         } else if (optionSet) {
                             value = optionSet[value];
                         }

--- a/src/components/map/EventLayer.js
+++ b/src/components/map/EventLayer.js
@@ -105,7 +105,7 @@ class EventLayer extends Layer {
         const data = await d2.models.programStage.get(props.programStage.id, {
             fields: `programStageDataElements[displayInReports,dataElement[id,${getDisplayPropertyUrl(
                 d2
-            )},optionSet]]`,
+            )},optionSet,valueType]]`,
             paging: false,
         });
 
@@ -169,13 +169,18 @@ class EventLayer extends Layer {
                     ];
 
                     if (displayEl) {
-                        let value = dataValue.value;
+                        const { valueType, optionSet, name } = displayEl;
+                        let { value } = dataValue;
 
-                        if (displayEl.optionSet) {
-                            value = displayEl.optionSet[value];
+                        if (valueType === 'COORDINATE' && value) {
+                            value = JSON.parse(value)
+                                .map(v => v.toFixed(6))
+                                .join(', ');
+                        } else if (optionSet) {
+                            value = optionSet[value];
                         }
 
-                        content += `<tr><th>${displayEl.name}</th><td>${value ||
+                        content += `<tr><th>${name}</th><td>${value ||
                             i18n.t('Not set')}</td></tr>`;
                     }
                 });

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -141,3 +141,13 @@ export const getSplitViewLayer = layers =>
 
 // Checks if split view map
 export const isSplitViewMap = layers => !!getSplitViewLayer(layers);
+
+export const formatCoordinate = value => {
+    try {
+        return JSON.parse(value)
+            .map(v => v.toFixed(6))
+            .join(', ');
+    } catch (e) {
+        return value;
+    }
+};


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-6394

The Web API returns corrdinates as a string array with high decimal precision. The fix formats this value to use 6 decimals (meter precision). 

Needs to be backported. 

![Skjermbilde 2019-09-18 kl  11 40 46](https://user-images.githubusercontent.com/548708/65137853-55788280-da0a-11e9-96e6-8d32536561ea.png)

![Skjermbilde 2019-09-18 kl  11 39 45](https://user-images.githubusercontent.com/548708/65137870-5b6e6380-da0a-11e9-8080-a8d42ab9dd7a.png)
