### PR TITLE
fix: download multiple values for each feature

### DIFF
--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -52,11 +52,12 @@ const thematicLoader = async config => {
         renderingStrategy,
     } = config;
 
+    const isSingle = renderingStrategy === 'SINGLE';
     const period = getPeriodFromFilters(config.filters);
     const periods = getPeriodsFromMetaData(data.metaData);
     const dimensions = getValidDimensionsFromFilters(config.filters);
     const names = getApiResponseNames(data);
-    const valuesByPeriod = getValuesByPeriod(data);
+    const valuesByPeriod = !isSingle ? getValuesByPeriod(data) : null;
     const valueById = getValueById(data);
     const valueFeatures = features.filter(
         ({ id }) => valueById[id] !== undefined
@@ -66,7 +67,6 @@ const thematicLoader = async config => {
     const maxValue = orderedValues[orderedValues.length - 1];
     const dataItem = getDataItemFromColumns(columns);
     const name = names[dataItem.id];
-    const isSingle = renderingStrategy === 'SINGLE';
     let legendSet = config.legendSet;
     let method = legendSet ? 1 : config.method; // Favorites often have wrong method
     let alert;


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-7556

Value for each period is included in the data download from split view or timeline maps. 

![Skjermbilde 2019-09-19 kl  11 30 11](https://user-images.githubusercontent.com/548708/65234426-d603b580-dad4-11e9-84f6-5eea7be859b6.png)
