### PR TITLE
fix: loading indicator for new layers

### DIFF
--- a/src/components/map/MapContainer.js
+++ b/src/components/map/MapContainer.js
@@ -36,6 +36,7 @@ const MapContainer = ({
     mapViews,
     bounds,
     showName,
+    newLayerIsLoading,
     coordinatePopup,
     layersPanelOpen,
     interpretationsPanelOpen,
@@ -57,7 +58,7 @@ const MapContainer = ({
     let className = classes.container;
 
     const layers = mapViews.filter(layer => layer.isLoaded);
-    const isLoading = layers.length !== mapViews.length;
+    const isLoading = newLayerIsLoading || layers.length !== mapViews.length;
 
     if (isDownload) {
         className += ` ${classes.download} dhis2-map-download`;
@@ -94,6 +95,7 @@ MapContainer.propTypes = {
     mapViews: PropTypes.array,
     bounds: PropTypes.array,
     showName: PropTypes.bool,
+    newLayerIsLoading: PropTypes.bool,
     coordinatePopup: PropTypes.array,
     dataTableOpen: PropTypes.bool,
     dataTableHeight: PropTypes.number,
@@ -112,6 +114,7 @@ export default connect(
             ...basemaps.filter(b => b.id === map.basemap.id)[0],
             ...map.basemap,
         },
+        newLayerIsLoading: map.newLayerIsLoading,
         coordinatePopup: map.coordinatePopup,
         mapViews: map.mapViews,
         bounds: map.bounds,

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -312,6 +312,8 @@ const map = (state = defaultState, action) => {
                 mapViews: state.mapViews.map(l => layer(l, action)),
             };
 
+        // TODO: newLayerIsLoading will not cover an edge case where another layer is created while the first is still loading.
+        // The only concequence would be that the spinner is removed before both layers are loaded, which will rarly happen.
         case types.LAYER_LOADING_SET:
             return {
                 ...state,

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -265,6 +265,7 @@ const map = (state = defaultState, action) => {
                         ...action.payload,
                     },
                 ],
+                newLayerIsLoading: false,
             };
 
         case types.LAYER_ADD_DATA:
@@ -296,7 +297,6 @@ const map = (state = defaultState, action) => {
         case types.LAYER_LOAD:
         case types.LAYER_UPDATE:
         case types.LAYER_EDIT:
-        case types.LAYER_LOADING_SET:
         case types.LAYER_CHANGE_OPACITY:
         case types.LAYER_TOGGLE_VISIBILITY:
         case types.LAYER_TOGGLE_EXPAND:
@@ -310,6 +310,13 @@ const map = (state = defaultState, action) => {
             return {
                 ...state,
                 mapViews: state.mapViews.map(l => layer(l, action)),
+            };
+
+        case types.LAYER_LOADING_SET:
+            return {
+                ...state,
+                mapViews: state.mapViews.map(l => layer(l, action)),
+                newLayerIsLoading: action.id ? false : true,
             };
 
         case types.ALERTS_CLEAR:

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -313,7 +313,7 @@ const map = (state = defaultState, action) => {
             };
 
         // TODO: newLayerIsLoading will not cover an edge case where another layer is created while the first is still loading.
-        // The only concequence would be that the spinner is removed before both layers are loaded, which will rarly happen.
+        // The only concequence would be that the spinner is removed before both layers are loaded, which will rarely happen.
         case types.LAYER_LOADING_SET:
             return {
                 ...state,


### PR DESCRIPTION
Fixes an issue with https://github.com/dhis2/maps-app/pull/177 where the loading spinner was not showing for newly created layers. The layer don't exist in the redux store before it's loaded the first time, so it's not possible to set the loading state. As a fix, I've added a "newLayerIsLoading" property on the map object which is used in this case. 