### PR TITLE
fix: refactor popup handling

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-09-03T08:55:52.263Z\n"
-"PO-Revision-Date: 2019-09-03T08:55:52.263Z\n"
+"POT-Creation-Date: 2019-10-10T17:23:15.515Z\n"
+"PO-Revision-Date: 2019-10-10T17:23:15.515Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -476,6 +476,12 @@ msgid "Event time"
 msgstr ""
 
 msgid "Groups"
+msgstr ""
+
+msgid "Longitude"
+msgstr ""
+
+msgid "Latitude"
 msgstr ""
 
 msgid "Viewing interpretation from {{interpretationDate}}"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@dhis2/d2-ui-interpretations": "6.2.1",
         "@dhis2/d2-ui-org-unit-dialog": "5.2.10",
         "@dhis2/d2-ui-org-unit-tree": "5.2.10",
-        "@dhis2/gis-api": "^33.0.8",
+        "@dhis2/gis-api": "^34.0.1",
         "@dhis2/ui": "^1.0.0-beta.15",
         "@material-ui/core": "^3.9.3",
         "@material-ui/icons": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "33.0.13",
+    "version": "34.0.0",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/components/datatable/ResizeHandle.css
+++ b/src/components/datatable/ResizeHandle.css
@@ -23,7 +23,7 @@
     cursor: grabbing;
     cursor: -moz-grabbing;
     cursor: -webkit-grabbing;
- }
+}
 
 .ResizeHandle svg {
     margin-left: 8px;

--- a/src/components/map/BoundaryLayer.js
+++ b/src/components/map/BoundaryLayer.js
@@ -1,9 +1,15 @@
+import React from 'react';
 import i18n from '@dhis2/d2-i18n';
 import Layer from './Layer';
+import Popup from './Popup';
 import { filterData } from '../../util/filter';
 import { LABEL_FONT_SIZE, LABEL_FONT_STYLE } from '../../constants/layers';
 
 export default class BoundaryLayer extends Layer {
+    state = {
+        popup: null,
+    };
+
     createLayer() {
         const {
             id,
@@ -61,23 +67,37 @@ export default class BoundaryLayer extends Layer {
         this.fitBoundsOnce();
     }
 
-    onFeatureClick(evt) {
-        const { feature, coordinates } = evt;
+    getPopup() {
+        const { coordinates, feature } = this.state.popup;
         const { name, level, parentName } = feature.properties;
 
-        let content = `<div class="dhis2-map-popup-orgunit"><em>${name}</em>`;
+        return (
+            <Popup
+                coordinates={coordinates}
+                onClose={this.onPopupClose}
+                className="dhis2-map-popup-orgunit"
+            >
+                <em>{name}</em>
+                {level && (
+                    <div>
+                        {i18n.t('Level')}: {level}
+                    </div>
+                )}
+                {parentName && (
+                    <div>
+                        {i18n.t('Parent unit')}: {parentName}
+                    </div>
+                )}
+            </Popup>
+        );
+    }
 
-        if (level) {
-            content += `<br/>${i18n.t('Level')}: ${level}`;
-        }
+    render() {
+        return this.state.popup ? this.getPopup() : null;
+    }
 
-        if (parentName) {
-            content += `<br/>${i18n.t('Parent unit')}: ${parentName}`;
-        }
-
-        content += '</div>';
-
-        this.context.map.openPopup(content, coordinates);
+    onFeatureClick(evt) {
+        this.setState({ popup: evt });
     }
 
     onFeatureRightClick(evt) {

--- a/src/components/map/EventLayer.js
+++ b/src/components/map/EventLayer.js
@@ -1,12 +1,13 @@
 import React from 'react';
-import i18n from '@dhis2/d2-i18n';
+// import i18n from '@dhis2/d2-i18n';
 import { getInstance as getD2 } from 'd2';
 import { apiFetch } from '../../util/api';
 import { getAnalyticsRequest } from '../../loaders/eventLoader';
 import { EVENT_COLOR, EVENT_RADIUS } from '../../constants/layers';
 import Layer from './Layer';
-import Popup from './Popup';
-import { getDisplayPropertyUrl, formatCoordinate } from '../../util/helpers';
+import EventPopup from './EventPopup';
+// import { getDisplayPropertyUrl, formatCoordinate } from '../../util/helpers';
+import { getDisplayPropertyUrl } from '../../util/helpers';
 
 class EventLayer extends Layer {
     state = {
@@ -106,14 +107,13 @@ class EventLayer extends Layer {
 
     getPopup() {
         // const { styleDataItem } = this.props;
-        const { coordinates, feature, data } = this.state.popup;
-        const { type, coordinates: coord } = feature.geometry;
+        // const { coordinates, feature, data } = this.state.popup;
+        // const { type, coordinates: coord } = feature.geometry;
         // const { value } = feature.properties;
-        const { eventDate, dataValues, orgUnitName } = data;
-        const date = eventDate.substring(0, 10);
-        const time = eventDate.substring(11, 16);
+        // const { eventDate, dataValues, orgUnitName } = data;
+        // const date = eventDate.substring(0, 10);
+        // const time = eventDate.substring(11, 16);
         // let styleDataRow;
-
         // Output value if styled by data item, and item is not included in display elements
         // if (styleDataItem && !this.displayElements[styleDataItem.id]) {
         /*
@@ -125,9 +125,8 @@ class EventLayer extends Layer {
             );
             */
         // }
-
         // {styleDataRow && styleDataRow}
-
+        /*
         const dataValuesRows =
             Array.isArray(dataValues) &&
             dataValues.map(({ dataElement, value }) => {
@@ -155,8 +154,9 @@ class EventLayer extends Layer {
                     </tr>
                 );
             });
-
+            */
         // TODO: style="overflow-x:auto"
+        /*
         return (
             <Popup
                 coordinates={coordinates}
@@ -196,10 +196,13 @@ class EventLayer extends Layer {
                 </table>
             </Popup>
         );
+        */
     }
 
     render() {
-        return this.state.popup ? this.getPopup() : null;
+        const { popup } = this.state;
+
+        return popup ? <EventPopup {...popup} /> : null;
     }
 
     // Load data elements that should be displayed in popups

--- a/src/components/map/EventLayer.js
+++ b/src/components/map/EventLayer.js
@@ -24,6 +24,8 @@ class EventLayer extends Layer {
             eventClustering,
             eventPointColor,
             eventPointRadius,
+            program,
+            programStage,
             serverCluster,
             areaRadius,
         } = this.props;
@@ -90,7 +92,9 @@ class EventLayer extends Layer {
             };
         }
 
-        this.loadDisplayElements();
+        if (program && programStage) {
+            this.loadDisplayElements();
+        }
 
         // Create and add event layer based on config object
         this.layer = map.createLayer(config);

--- a/src/components/map/EventPopup.js
+++ b/src/components/map/EventPopup.js
@@ -144,15 +144,33 @@ const EventPopup = props => {
 
     // Load data elements every time programStage is changed
     useEffect(() => {
-        loadDataElements(programStage, eventCoordinateField).then(
-            setDataElements
-        );
-    }, [programStage]);
+        let aborted = false;
+
+        loadDataElements(programStage, eventCoordinateField).then(data => {
+            if (!aborted) {
+                setDataElements(data);
+            }
+        });
+
+        return () => {
+            aborted = true;
+        };
+    }, [programStage, eventCoordinateField, setDataElements]);
 
     // Load event data every time a new feature is clicked
     useEffect(() => {
-        loadEventData(feature).then(setEventData);
-    }, [feature]);
+        let aborted = false;
+
+        loadEventData(feature).then(data => {
+            if (!aborted) {
+                setEventData(data);
+            }
+        });
+
+        return () => {
+            aborted = true;
+        };
+    }, [feature, setEventData]);
 
     if (!coordinates || !feature || !eventData) {
         return null;

--- a/src/components/map/EventPopup.js
+++ b/src/components/map/EventPopup.js
@@ -1,17 +1,184 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-// import i18n from '@dhis2/d2-i18n';
+import i18n from '@dhis2/d2-i18n';
+import { getInstance as getD2 } from 'd2';
 import Popup from './Popup';
+import { apiFetch } from '../../util/api';
+import { getDisplayPropertyUrl, formatCoordinate } from '../../util/helpers';
 
-const EventPopup = props => {
-    const { coordinates } = props;
-    // console.log('EventPopup', props);
+class EventPopup extends PureComponent {
+    static propTypes = {
+        coordinates: PropTypes.array,
+        feature: PropTypes.object,
+        programStage: PropTypes.object,
+        eventCoordinateField: PropTypes.string,
+        styleDataItem: PropTypes.object,
+        onClose: PropTypes.func.isRequired,
+    };
 
-    return <Popup coordinates={coordinates}>###</Popup>;
-};
+    state = {
+        data: null,
+        displayElements: null,
+        eventCoordinateFieldName: null,
+    };
 
-EventPopup.propTypes = {
-    coordinates: PropTypes.array.isRequired,
-};
+    componentDidMount() {
+        if (this.props.programStage) {
+            this.loadDataElements();
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        const { feature } = this.props;
+
+        if (feature && feature !== prevProps.feature) {
+            apiFetch(`/events/${feature.id}`).then(data =>
+                this.setState({ data })
+            );
+        }
+    }
+
+    render() {
+        const { coordinates, feature, styleDataItem } = this.props;
+        const { data, displayElements = {} } = this.state;
+
+        if (!coordinates || !feature || !data) {
+            return null;
+        }
+
+        const { type, coordinates: coord } = feature.geometry;
+        const { value } = feature.properties;
+        const { eventDate, dataValues = [], orgUnitName } = data;
+        const date = eventDate.substring(0, 10);
+        const time = eventDate.substring(11, 16);
+
+        // Output value if styled by data item, and item is not included in dataRows below
+        const styleDataRow = styleDataItem &&
+            !displayElements[styleDataItem.id] && (
+                <tr>
+                    <th>{styleDataItem.name}</th>
+                    <td>{value !== undefined ? value : i18n.t('Not set')}</td>
+                </tr>
+            );
+
+        const dataRows = dataValues.map(({ dataElement, value }) => {
+            const displayEl = displayElements[dataElement];
+
+            if (!displayEl) {
+                return null;
+            }
+
+            const { valueType, optionSet, name } = displayEl;
+            let formattedValue = value;
+
+            if (valueType === 'COORDINATE' && value) {
+                formattedValue = formatCoordinate(value);
+            } else if (optionSet) {
+                formattedValue = optionSet[value];
+            } else if (value === null || value === undefined) {
+                formattedValue = i18n.t('Not set');
+            }
+
+            return (
+                <tr key={dataElement}>
+                    <th>{name}</th>
+                    <td>{formattedValue}</td>
+                </tr>
+            );
+        });
+
+        return (
+            <Popup
+                coordinates={coordinates}
+                onClose={this.onPopupClose}
+                className="dhis2-map-popup-event"
+            >
+                <table>
+                    <tbody>
+                        {styleDataRow}
+                        {dataRows}
+                        {dataRows.length && <tr style={{ height: 5 }} />}
+                        {type === 'Point' && (
+                            <tr>
+                                <th>
+                                    {this.eventCoordinateFieldName ||
+                                        i18n.t('Event location')}
+                                </th>
+                                <td>
+                                    {coord[0]} {coord[1]}
+                                </td>
+                            </tr>
+                        )}
+                        <tr>
+                            <th>{i18n.t('Organisation unit')}</th>
+                            <td>{orgUnitName}</td>
+                        </tr>
+                        <tr>
+                            <th>{i18n.t('Event time')}</th>
+                            <td>
+                                {date} {time}
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </Popup>
+        );
+    }
+
+    // Load data elements that should be displayed in popups
+    // TODO: Possible to only load "displayInReports" data elements from api?
+    async loadDataElements() {
+        const { programStage, eventCoordinateField } = this.props;
+        const d2 = await getD2();
+        const data = await d2.models.programStage.get(programStage.id, {
+            fields: `programStageDataElements[displayInReports,dataElement[id,${getDisplayPropertyUrl(
+                d2
+            )},optionSet,valueType]]`,
+            paging: false,
+        });
+        const { programStageDataElements } = data;
+
+        if (programStageDataElements) {
+            const displayElements = {};
+            let eventCoordinateFieldName;
+
+            programStageDataElements.forEach(el => {
+                const dataElement = el.dataElement;
+
+                if (el.displayInReports) {
+                    displayElements[dataElement.id] = dataElement;
+
+                    if (dataElement.optionSet && dataElement.optionSet.id) {
+                        d2.models.optionSets
+                            .get(dataElement.optionSet.id, {
+                                fields:
+                                    'id,displayName~rename(name),options[code,displayName~rename(name)]',
+                                paging: false,
+                            })
+                            .then(optionSet => {
+                                optionSet.options.forEach(
+                                    option =>
+                                        (dataElement.optionSet[option.code] =
+                                            option.name)
+                                );
+                            });
+                    }
+                } else if (
+                    eventCoordinateField &&
+                    dataElement.id === eventCoordinateField
+                ) {
+                    eventCoordinateFieldName = dataElement.name;
+                }
+            });
+
+            this.setState({ displayElements, eventCoordinateFieldName });
+        }
+    }
+
+    onPopupClose = () => {
+        this.props.onClose();
+        this.setState({ data: null });
+    };
+}
 
 export default EventPopup;

--- a/src/components/map/EventPopup.js
+++ b/src/components/map/EventPopup.js
@@ -4,7 +4,11 @@ import i18n from '@dhis2/d2-i18n';
 import { getInstance as getD2 } from 'd2';
 import Popup from './Popup';
 import { apiFetch } from '../../util/api';
-import { getDisplayPropertyUrl, formatCoordinate } from '../../util/helpers';
+import {
+    getDisplayPropertyUrl,
+    formatTime,
+    formatCoordinate,
+} from '../../util/helpers';
 
 class EventPopup extends PureComponent {
     static propTypes = {
@@ -49,8 +53,6 @@ class EventPopup extends PureComponent {
         const { type, coordinates: coord } = feature.geometry;
         const { value } = feature.properties;
         const { eventDate, dataValues = [], orgUnitName } = data;
-        const date = eventDate.substring(0, 10);
-        const time = eventDate.substring(11, 16);
 
         // Output value if styled by data item, and item is not included in dataRows below
         const styleDataRow = styleDataItem &&
@@ -115,9 +117,7 @@ class EventPopup extends PureComponent {
                         </tr>
                         <tr>
                             <th>{i18n.t('Event time')}</th>
-                            <td>
-                                {date} {time}
-                            </td>
+                            <td>{formatTime(eventDate)}</td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/components/map/EventPopup.js
+++ b/src/components/map/EventPopup.js
@@ -1,82 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
-import { getInstance as getD2 } from 'd2';
 import Popup from './Popup';
 import { apiFetch } from '../../util/api';
-import {
-    getDisplayPropertyUrl,
-    formatTime,
-    formatCoordinate,
-} from '../../util/helpers';
+import { formatTime, formatCoordinate } from '../../util/helpers';
 
 // Returns true if value is not undefined or null;
 const hasValue = value => value !== undefined || value !== null;
-
-// Loads an option set for an data element to get option names
-const loadOptionSet = async dataElement => {
-    const { optionSet } = dataElement;
-
-    if (!optionSet || !optionSet.id) {
-        return dataElement;
-    }
-
-    const d2 = await getD2();
-
-    if (optionSet && optionSet.id) {
-        const fullOptionSet = await d2.models.optionSets.get(optionSet.id, {
-            fields:
-                'id,displayName~rename(name),options[code,displayName~rename(name)]',
-            paging: false,
-        });
-
-        if (fullOptionSet && fullOptionSet.options) {
-            dataElement.options = fullOptionSet.options.reduce(
-                (byId, option) => {
-                    byId[option.code] = option.name;
-                    return byId;
-                },
-                {}
-            );
-        }
-    }
-};
-
-// Loads the data elements for a program stage to display in popup
-const loadDataElements = async (programStage, eventCoordinateField) => {
-    const d2 = await getD2();
-    const data = await d2.models.programStage.get(programStage.id, {
-        fields: `programStageDataElements[displayInReports,dataElement[id,${getDisplayPropertyUrl(
-            d2
-        )},optionSet,valueType]]`,
-        paging: false,
-    });
-    const { programStageDataElements } = data;
-    let displayElements = [];
-    let eventCoordinateFieldName;
-
-    if (Array.isArray(programStageDataElements)) {
-        displayElements = programStageDataElements
-            .filter(d => d.displayInReports)
-            .map(d => d.dataElement);
-
-        for (let d of displayElements) {
-            await loadOptionSet(d);
-        }
-
-        if (eventCoordinateField) {
-            const coordElement = programStageDataElements.find(
-                d => d.dataElement.id === eventCoordinateField
-            );
-
-            if (coordElement) {
-                eventCoordinateFieldName = coordElement.dataElement.name;
-            }
-        }
-    }
-
-    return { displayElements, eventCoordinateFieldName };
-};
 
 // Loads event data for the selected feature
 const loadEventData = async feature =>
@@ -132,30 +62,13 @@ const EventPopup = props => {
     const {
         coordinates,
         feature,
-        programStage,
-        eventCoordinateField,
         styleDataItem,
+        displayElements,
+        eventCoordinateFieldName,
         onClose,
     } = props;
 
     const [eventData, setEventData] = useState();
-    const [dataElements, setDataElements] = useState({});
-    const { displayElements = [], eventCoordinateFieldName } = dataElements;
-
-    // Load data elements every time programStage is changed
-    useEffect(() => {
-        let aborted = false;
-
-        loadDataElements(programStage, eventCoordinateField).then(data => {
-            if (!aborted) {
-                setDataElements(data);
-            }
-        });
-
-        return () => {
-            aborted = true;
-        };
-    }, [programStage, eventCoordinateField, setDataElements]);
 
     // Load event data every time a new feature is clicked
     useEffect(() => {
@@ -168,11 +81,12 @@ const EventPopup = props => {
         });
 
         return () => {
+            setEventData(); // Clear event data
             aborted = true;
         };
     }, [feature, setEventData]);
 
-    if (!coordinates || !feature || !eventData) {
+    if (!eventData) {
         return null;
     }
 
@@ -183,10 +97,7 @@ const EventPopup = props => {
     return (
         <Popup
             coordinates={coordinates}
-            onClose={() => {
-                onClose();
-                setEventData();
-            }}
+            onClose={onClose}
             className="dhis2-map-popup-event"
         >
             <table>
@@ -208,14 +119,18 @@ const EventPopup = props => {
                             </td>
                         </tr>
                     )}
-                    <tr>
-                        <th>{i18n.t('Organisation unit')}</th>
-                        <td>{orgUnitName}</td>
-                    </tr>
-                    <tr>
-                        <th>{i18n.t('Event time')}</th>
-                        <td>{formatTime(eventDate)}</td>
-                    </tr>
+                    {orgUnitName && (
+                        <tr>
+                            <th>{i18n.t('Organisation unit')}</th>
+                            <td>{orgUnitName}</td>
+                        </tr>
+                    )}
+                    {eventDate && (
+                        <tr>
+                            <th>{i18n.t('Event time')}</th>
+                            <td>{formatTime(eventDate)}</td>
+                        </tr>
+                    )}
                 </tbody>
             </table>
         </Popup>
@@ -223,10 +138,10 @@ const EventPopup = props => {
 };
 
 EventPopup.propTypes = {
-    coordinates: PropTypes.array,
-    feature: PropTypes.object,
-    programStage: PropTypes.object,
-    eventCoordinateField: PropTypes.string,
+    coordinates: PropTypes.array.isRequired,
+    feature: PropTypes.object.isRequired,
+    displayElements: PropTypes.array.isRequired,
+    eventCoordinateFieldName: PropTypes.string,
     styleDataItem: PropTypes.object,
     onClose: PropTypes.func.isRequired,
 };

--- a/src/components/map/EventPopup.js
+++ b/src/components/map/EventPopup.js
@@ -99,6 +99,7 @@ const getDataRows = (displayElements, dataValues, styleDataItem, value) => {
         );
     }
 
+    // Include rows for each displayInReport data elements
     displayElements.forEach(({ id, name, valueType, options }) => {
         const { value } = dataValues.find(d => d.dataElement === id) || {};
         let formattedValue = value;
@@ -126,6 +127,7 @@ const getDataRows = (displayElements, dataValues, styleDataItem, value) => {
     return dataRows;
 };
 
+// Will display a popup for an event feature
 const EventPopup = props => {
     const {
         coordinates,
@@ -140,12 +142,14 @@ const EventPopup = props => {
     const [dataElements, setDataElements] = useState({});
     const { displayElements = [], eventCoordinateFieldName } = dataElements;
 
+    // Load data elements every time programStage is changed
     useEffect(() => {
         loadDataElements(programStage, eventCoordinateField).then(
             setDataElements
         );
     }, [programStage]);
 
+    // Load event data every time a new feature is clicked
     useEffect(() => {
         loadEventData(feature).then(setEventData);
     }, [feature]);

--- a/src/components/map/EventPopup.js
+++ b/src/components/map/EventPopup.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+// import i18n from '@dhis2/d2-i18n';
+import Popup from './Popup';
+
+const EventPopup = props => {
+    const { coordinates } = props;
+    // console.log('EventPopup', props);
+
+    return <Popup coordinates={coordinates}>###</Popup>;
+};
+
+EventPopup.propTypes = {
+    coordinates: PropTypes.array.isRequired,
+};
+
+export default EventPopup;

--- a/src/components/map/FacilityLayer.js
+++ b/src/components/map/FacilityLayer.js
@@ -113,29 +113,6 @@ class FacilityLayer extends Layer {
         this.setState({ popup: evt });
     }
 
-    // Show pupup on facility click
-    /*
-    onFeatureClick(evt) {
-        const { feature, coordinates } = evt;
-        const { name, dimensions, pn } = feature.properties;
-        let content = `<div class="dhis2-map-popup-orgunit"><em>${name}</em>`;
-
-        if (isPlainObject(dimensions)) {
-            content += `<br/>${i18n.t('Groups')}: ${Object.keys(dimensions)
-                .map(id => dimensions[id])
-                .join(', ')}`;
-        }
-
-        if (pn) {
-            content += `<br/>${i18n.t('Parent unit')}: ${pn}`;
-        }
-
-        content += '</div>';
-
-        this.context.map.openPopup(content, coordinates);
-    }
-    */
-
     onFeatureRightClick(evt) {
         const { id, layer } = this.props;
 

--- a/src/components/map/FacilityLayer.js
+++ b/src/components/map/FacilityLayer.js
@@ -1,6 +1,8 @@
+import React from 'react';
 import i18n from '@dhis2/d2-i18n';
 import { isPlainObject } from 'lodash/fp';
 import Layer from './Layer';
+import Popup from './Popup';
 import { filterData } from '../../util/filter';
 import { cssColor } from '../../util/colors';
 import {
@@ -11,6 +13,10 @@ import {
 } from '../../constants/layers';
 
 class FacilityLayer extends Layer {
+    state = {
+        popup: null,
+    };
+
     createLayer() {
         const {
             id,
@@ -71,7 +77,44 @@ class FacilityLayer extends Layer {
         this.fitBoundsOnce();
     }
 
+    getPopup() {
+        const { coordinates, feature } = this.state.popup;
+        const { name, dimensions, pn } = feature.properties;
+
+        return (
+            <Popup
+                coordinates={coordinates}
+                onClose={this.onPopupClose}
+                className="dhis2-map-popup-orgunit"
+            >
+                <em>{name}</em>
+                {isPlainObject(dimensions) && (
+                    <div>
+                        {i18n.t('Groups')}:
+                        {Object.keys(dimensions)
+                            .map(id => dimensions[id])
+                            .join(', ')}
+                    </div>
+                )}
+                {pn && (
+                    <div>
+                        {i18n.t('Parent unit')}: {pn}
+                    </div>
+                )}
+            </Popup>
+        );
+    }
+
+    render() {
+        return this.state.popup ? this.getPopup() : null;
+    }
+
+    onFeatureClick(evt) {
+        this.setState({ popup: evt });
+    }
+
     // Show pupup on facility click
+    /*
     onFeatureClick(evt) {
         const { feature, coordinates } = evt;
         const { name, dimensions, pn } = feature.properties;
@@ -91,6 +134,7 @@ class FacilityLayer extends Layer {
 
         this.context.map.openPopup(content, coordinates);
     }
+    */
 
     onFeatureRightClick(evt) {
         const { id, layer } = this.props;

--- a/src/components/map/Layer.js
+++ b/src/components/map/Layer.js
@@ -149,7 +149,13 @@ class Layer extends PureComponent {
         return null;
     }
 
-    onPopupClose = () => this.setState({ popup: null });
+    // Called when a map popup is closed
+    onPopupClose = popup => {
+        // Added check to avoid closing a new popup
+        if (!popup || this.state.popup === popup) {
+            this.setState({ popup: null });
+        }
+    };
 }
 
 export default Layer;

--- a/src/components/map/Layer.js
+++ b/src/components/map/Layer.js
@@ -148,6 +148,8 @@ class Layer extends PureComponent {
     render() {
         return null;
     }
+
+    onPopupClose = () => this.setState({ popup: null });
 }
 
 export default Layer;

--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
+import i18n from '@dhis2/d2-i18n';
 import mapApi from './MapApi';
 import Layer from './Layer';
 import EventLayer from './EventLayer';
@@ -10,6 +11,7 @@ import ThematicLayer from './ThematicLayer';
 import BoundaryLayer from './BoundaryLayer';
 import EarthEngineLayer from './EarthEngineLayer';
 import ExternalLayer from './ExternalLayer';
+import Popup from './Popup';
 
 const layerType = {
     event: EventLayer,
@@ -102,16 +104,6 @@ class Map extends Component {
         }
     }
 
-    componentDidUpdate() {
-        const { coordinatePopup } = this.props;
-
-        if (coordinatePopup) {
-            this.showCoordinate(coordinatePopup);
-        }
-
-        this.map.resize();
-    }
-
     // Remove map
     componentWillUnmount() {
         if (this.map) {
@@ -121,7 +113,15 @@ class Map extends Component {
     }
 
     render() {
-        const { basemap, layers, openContextMenu, classes } = this.props;
+        const {
+            basemap,
+            layers,
+            coordinatePopup: coordinates,
+            closeCoordinatePopup,
+            openContextMenu,
+            classes,
+        } = this.props;
+
         const overlays = layers.filter(layer => layer.isLoaded);
 
         return (
@@ -139,18 +139,18 @@ class Map extends Component {
                     );
                 })}
                 {basemap.isVisible !== false && <Layer {...basemap} />}
+                {coordinates && (
+                    <Popup
+                        coordinates={coordinates}
+                        onClose={closeCoordinatePopup}
+                    >
+                        {i18n.t('Longitude')}: {coordinates[0].toFixed(6)}
+                        <br />
+                        {i18n.t('Latitude')}: {coordinates[1].toFixed(6)}
+                    </Popup>
+                )}
             </div>
         );
-    }
-
-    showCoordinate(coord) {
-        const content =
-            'Longitude: ' +
-            coord[0].toFixed(6) +
-            '<br />Latitude: ' +
-            coord[1].toFixed(6);
-
-        this.map.openPopup(content, coord, this.props.closeCoordinatePopup);
     }
 
     onRightClick = evt => {

--- a/src/components/map/Popup.css
+++ b/src/components/map/Popup.css
@@ -1,0 +1,3 @@
+.dhis2-map-popup-event {
+    overflow-x: auto;
+}

--- a/src/components/map/Popup.js
+++ b/src/components/map/Popup.js
@@ -1,4 +1,5 @@
-import React, { PureComponent } from 'react';
+import { PureComponent } from 'react';
+import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 
 class Popup extends PureComponent {
@@ -10,6 +11,11 @@ class Popup extends PureComponent {
         coordinates: PropTypes.array.isRequired,
         children: PropTypes.node,
     };
+
+    constructor() {
+        super();
+        this.container = document.createElement('div');
+    }
 
     componentDidMount() {
         this.setPopup();
@@ -24,20 +30,12 @@ class Popup extends PureComponent {
     }
 
     render() {
-        return (
-            <div ref={el => (this.container = el)} style={{ display: 'none' }}>
-                {this.props.children}
-            </div>
-        );
+        return createPortal(this.props.children, this.container);
     }
 
     setPopup = () => {
         const { coordinates } = this.props;
-        const container = this.container.cloneNode(true);
-
-        container.style.display = 'block';
-
-        this.context.map.openPopup(container, coordinates);
+        this.context.map.openPopup(this.container, coordinates);
     };
 }
 

--- a/src/components/map/Popup.js
+++ b/src/components/map/Popup.js
@@ -1,0 +1,44 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+class Popup extends PureComponent {
+    static contextTypes = {
+        map: PropTypes.object,
+    };
+
+    static propTypes = {
+        coordinates: PropTypes.array.isRequired,
+        children: PropTypes.node,
+    };
+
+    componentDidMount() {
+        this.setPopup();
+    }
+
+    componentDidUpdate() {
+        this.setPopup();
+    }
+
+    componentWillUnmount() {
+        this.context.map.closePopup();
+    }
+
+    render() {
+        return (
+            <div ref={el => (this.container = el)} style={{ display: 'none' }}>
+                {this.props.children}
+            </div>
+        );
+    }
+
+    setPopup = () => {
+        const { coordinates } = this.props;
+        const container = this.container.cloneNode(true);
+
+        container.style.display = 'block';
+
+        this.context.map.openPopup(container, coordinates);
+    };
+}
+
+export default Popup;

--- a/src/components/map/Popup.js
+++ b/src/components/map/Popup.js
@@ -1,48 +1,32 @@
-import { PureComponent } from 'react';
+import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import './Popup.css';
 
-class Popup extends PureComponent {
-    static contextTypes = {
-        map: PropTypes.object,
-    };
+const container = document.createElement('div');
 
-    static propTypes = {
-        coordinates: PropTypes.array.isRequired,
-        onClose: PropTypes.func.isRequired,
-        className: PropTypes.string,
-        children: PropTypes.node,
-    };
+const Popup = (props, context) => {
+    const { className = '', coordinates, onClose, children } = props;
+    const { map } = context;
 
-    constructor() {
-        super();
-        this.container = document.createElement('div');
-    }
+    useEffect(() => {
+        container.className = className;
+        map.openPopup(container, coordinates, onClose);
+        return () => map.closePopup();
+    });
 
-    componentDidMount() {
-        this.setPopup();
-    }
+    return createPortal(children, container);
+};
 
-    componentDidUpdate() {
-        this.setPopup();
-    }
+Popup.contextTypes = {
+    map: PropTypes.object,
+};
 
-    componentWillUnmount() {
-        this.context.map.closePopup();
-    }
-
-    render() {
-        return createPortal(this.props.children, this.container);
-    }
-
-    setPopup = () => {
-        const { className, coordinates, onClose } = this.props;
-
-        this.container.className = className || '';
-
-        this.context.map.openPopup(this.container, coordinates, onClose);
-    };
-}
+Popup.propTypes = {
+    coordinates: PropTypes.array.isRequired,
+    onClose: PropTypes.func.isRequired,
+    className: PropTypes.string,
+    children: PropTypes.node,
+};
 
 export default Popup;

--- a/src/components/map/Popup.js
+++ b/src/components/map/Popup.js
@@ -9,6 +9,7 @@ class Popup extends PureComponent {
 
     static propTypes = {
         coordinates: PropTypes.array.isRequired,
+        onClose: PropTypes.func.isRequired,
         children: PropTypes.node,
     };
 
@@ -34,8 +35,8 @@ class Popup extends PureComponent {
     }
 
     setPopup = () => {
-        const { coordinates } = this.props;
-        this.context.map.openPopup(this.container, coordinates);
+        const { coordinates, onClose } = this.props;
+        this.context.map.openPopup(this.container, coordinates, onClose);
     };
 }
 

--- a/src/components/map/Popup.js
+++ b/src/components/map/Popup.js
@@ -1,13 +1,12 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import './Popup.css';
 
-const container = document.createElement('div');
-
 const Popup = (props, context) => {
     const { className = '', coordinates, onClose, children } = props;
     const { map } = context;
+    const container = useMemo(() => document.createElement('div'), []);
 
     useEffect(() => {
         container.className = className;

--- a/src/components/map/Popup.js
+++ b/src/components/map/Popup.js
@@ -3,7 +3,6 @@ import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import './Popup.css';
 
-// Displ
 const Popup = (props, context) => {
     const { className = '', coordinates, onClose, children } = props;
     const { map } = context;

--- a/src/components/map/Popup.js
+++ b/src/components/map/Popup.js
@@ -3,16 +3,18 @@ import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import './Popup.css';
 
+// Displ
 const Popup = (props, context) => {
     const { className = '', coordinates, onClose, children } = props;
     const { map } = context;
     const container = useMemo(() => document.createElement('div'), []);
 
+    // Create and open popup on map
     useEffect(() => {
         container.className = className;
         map.openPopup(container, coordinates, onClose);
         return () => map.closePopup();
-    });
+    }, [map, container, className, coordinates, onClose]);
 
     return createPortal(children, container);
 };

--- a/src/components/map/Popup.js
+++ b/src/components/map/Popup.js
@@ -1,6 +1,7 @@
 import { PureComponent } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
+import './Popup.css';
 
 class Popup extends PureComponent {
     static contextTypes = {

--- a/src/components/map/Popup.js
+++ b/src/components/map/Popup.js
@@ -10,6 +10,7 @@ class Popup extends PureComponent {
     static propTypes = {
         coordinates: PropTypes.array.isRequired,
         onClose: PropTypes.func.isRequired,
+        className: PropTypes.string,
         children: PropTypes.node,
     };
 
@@ -35,7 +36,10 @@ class Popup extends PureComponent {
     }
 
     setPopup = () => {
-        const { coordinates, onClose } = this.props;
+        const { className, coordinates, onClose } = this.props;
+
+        this.container.className = className || '';
+
         this.context.map.openPopup(this.container, coordinates, onClose);
     };
 }

--- a/src/components/map/Popup.js
+++ b/src/components/map/Popup.js
@@ -12,7 +12,9 @@ const Popup = (props, context) => {
     useEffect(() => {
         container.className = className;
         map.openPopup(container, coordinates, onClose);
-        return () => map.closePopup();
+        return () => {
+            map.closePopup();
+        };
     }, [map, container, className, coordinates, onClose]);
 
     return createPortal(children, container);

--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -112,18 +112,16 @@ class ThematicLayer extends Layer {
         const periodName = period ? period.name : legend.period;
 
         return (
-            <Popup coordinates={coordinates}>
-                <div className="dhis2-map-popup-orgunit">
-                    <h3>{name}</h3>
-                    <div>{indicator}</div>
-                    <div>{periodName}</div>
-                    <div>
-                        {i18n.t('Value')}: {value}
-                    </div>
-                    {aggregationType && aggregationType !== 'DEFAULT' && (
-                        <div>{aggregationType}</div>
-                    )}
+            <Popup coordinates={coordinates} onClose={this.onPopupClose}>
+                <h3>{name}</h3>
+                <div>{indicator}</div>
+                <div>{periodName}</div>
+                <div>
+                    {i18n.t('Value')}: {value}
                 </div>
+                {aggregationType && aggregationType !== 'DEFAULT' && (
+                    <div>{aggregationType}</div>
+                )}
             </Popup>
         );
     }
@@ -166,6 +164,8 @@ class ThematicLayer extends Layer {
             layerType: layer,
         });
     }
+
+    onPopupClose = () => this.setState({ popup: null });
 }
 
 export default ThematicLayer;

--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -164,8 +164,6 @@ class ThematicLayer extends Layer {
             layerType: layer,
         });
     }
-
-    onPopupClose = () => this.setState({ popup: null });
 }
 
 export default ThematicLayer;

--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -112,8 +112,12 @@ class ThematicLayer extends Layer {
         const periodName = period ? period.name : legend.period;
 
         return (
-            <Popup coordinates={coordinates} onClose={this.onPopupClose}>
-                <h3>{name}</h3>
+            <Popup
+                coordinates={coordinates}
+                onClose={this.onPopupClose}
+                className="dhis2-map-popup-orgunit"
+            >
+                <em>{name}</em>
                 <div>{indicator}</div>
                 <div>{periodName}</div>
                 <div>

--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -114,7 +114,7 @@ class ThematicLayer extends Layer {
         return (
             <Popup
                 coordinates={coordinates}
-                onClose={this.onPopupClose}
+                onClose={() => this.onPopupClose(popup)}
                 className="dhis2-map-popup-orgunit"
             >
                 <em>{name}</em>

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -121,10 +121,6 @@ export const addOrgUnitPaths = mapViews =>
             : view
     );
 
-// Remove line breaks from text (not displayed corrently in map downloads)
-// https://stackoverflow.com/questions/10805125/how-to-remove-all-line-breaks-from-a-string/10805292#10805292
-export const removeLineBreaks = text => text.replace(/\r?\n|\r/g, ' ');
-
 const mandatoryDataItemAttributes = ['id', 'name', 'valueType'];
 
 // Checks if a data item is valid (program stage data elements and tracked entity attributes)

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -151,3 +151,7 @@ export const formatCoordinate = value => {
         return value;
     }
 };
+
+// Formats a DHIS2 time string
+export const formatTime = time =>
+    `${time.substring(0, 10)} ${time.substring(11, 16)}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,10 +424,10 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/gis-api@^33.0.8":
-  version "33.0.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/gis-api/-/gis-api-33.0.8.tgz#8e9741be37538164c67e5d273f00d4660ca0e68c"
-  integrity sha512-ZndI+tj2Gj+FYYMqvsWZzWcokukBtxO+fW5ymvT4JjAryqtMOtPRNOSxkgwPetAtBF1xLg1jcdyozJ1XO8si+g==
+"@dhis2/gis-api@^34.0.1":
+  version "34.0.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/gis-api/-/gis-api-34.0.2.tgz#c6d3b944a1f32a088700eaa83c0d8af431ea6df1"
+  integrity sha512-l9ekDET62+ElI89z6yYGF7YXlG7cKq2kQHG5qNWpi+tObgHmHJSlDOENk4dkarbCGSZfdeq6dr/ger7d/MFLrg==
   dependencies:
     "@google/earthengine" "^0.1.172"
     "@mapbox/geojson-area" "^0.2.2"


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-7675

This PR refactors the popup handling in the Maps app, which is part of the larger Maps GL transition. Instead of generating HTML strings of popup content, we use react and createPortal from react-dom. 

A separate Popup component was created where the content is passed in as child elements. 

The event layer popup handling is complex, and an EventPopup component was created to separate it from the layer handling.