### PR TITLE
fix: point radius for thematic layers with time dimension

### DIFF
--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -36,6 +36,8 @@ import {
     DEFAULT_START_DATE,
     DEFAULT_END_DATE,
     DEFAULT_ORG_UNIT_LEVEL,
+    DEFAULT_RADIUS_LOW,
+    DEFAULT_RADIUS_HIGH,
 } from '../../../constants/layers';
 
 import {
@@ -234,8 +236,8 @@ export class ThematicDialog extends Component {
             startDate,
             endDate,
             program,
-            radiusHigh,
-            radiusLow,
+            radiusLow = DEFAULT_RADIUS_LOW,
+            radiusHigh = DEFAULT_RADIUS_HIGH,
             rows,
             valueType,
         } = this.props;
@@ -569,11 +571,7 @@ export class ThematicDialog extends Component {
                                         id="lowsize"
                                         type="number"
                                         label={i18n.t('Low size')}
-                                        value={
-                                            radiusLow !== undefined
-                                                ? radiusLow
-                                                : 5
-                                        }
+                                        value={radiusLow}
                                         onChange={radius =>
                                             setRadiusLow(radius)
                                         }
@@ -586,11 +584,7 @@ export class ThematicDialog extends Component {
                                         id="highsize"
                                         type="number"
                                         label={i18n.t('High size')}
-                                        value={
-                                            radiusHigh !== undefined
-                                                ? radiusHigh
-                                                : 15
-                                        }
+                                        value={radiusHigh}
                                         onChange={radius =>
                                             setRadiusHigh(radius)
                                         }

--- a/src/constants/layers.js
+++ b/src/constants/layers.js
@@ -7,6 +7,10 @@ export const DEFAULT_END_DATE = formatDate(new Date());
 
 export const DEFAULT_ORG_UNIT_LEVEL = 2;
 
+/* THEMATIC LAYER */
+export const DEFAULT_RADIUS_LOW = 5;
+export const DEFAULT_RADIUS_HIGH = 15;
+
 /* EVENT LAYER */
 export const EVENT_COLOR = '#333333';
 export const EVENT_RADIUS = 6;


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-7690

Default radius low and high are defined as constants. 
The radius is calculated for each period if split view or timeline maps. 

![Skjermbilde 2019-10-10 kl  12 35 24](https://user-images.githubusercontent.com/548708/66562949-0206d980-eb5d-11e9-9e21-6a614d7959e3.png)
