### PR TITLE
Show alert if no boundaries was returned

### DIFF
--- a/src/components/map/EventLayer.js
+++ b/src/components/map/EventLayer.js
@@ -157,7 +157,8 @@ class EventLayer extends Layer {
                 ' ' +
                 data.eventDate.substring(11, 16);
             const dataValues = data.dataValues;
-            let content = '<div style="overflow-x:auto"><table><tbody>';
+            let content =
+                '<div style="max-height:300px;overflow:auto;"><table><tbody>';
 
             // Output value if styled by data item, and item is not included in display elements
             if (styleDataItem && !this.displayElements[styleDataItem.id]) {

--- a/src/components/orgunits/OrgUnitDialog.js
+++ b/src/components/orgunits/OrgUnitDialog.js
@@ -84,6 +84,7 @@ export class OrgUnitDialog extends Component {
         } else if (
             id &&
             dataItems &&
+            dataItems.length &&
             period &&
             (id !== prevProps.id || period !== prevState.period)
         ) {

--- a/src/loaders/boundaryLoader.js
+++ b/src/loaders/boundaryLoader.js
@@ -4,6 +4,7 @@ import { getInstance as getD2 } from 'd2';
 import { toGeoJson } from '../util/map';
 import { getOrgUnitsFromRows } from '../util/analytics';
 import { getDisplayProperty, getDisplayPropertyUrl } from '../util/helpers';
+import { createAlert } from '../util/alerts';
 
 const colors = ['#111111', '#377eb8', '#a65628', '#984ea3', '#4daf4a'];
 const weights = [2, 1, 0.75, 0.5];
@@ -24,10 +25,6 @@ const boundaryLoader = async config => {
         .displayProperty(displayProperty)
         .getAll()
         .then(toGeoJson);
-
-    if (!features.length) {
-        return;
-    }
 
     const levels = uniqBy(f => f.properties.level, features)
         .map(f => f.properties.level)
@@ -67,6 +64,9 @@ const boundaryLoader = async config => {
         ...config,
         data: features,
         name: layerName,
+        alerts: !features.length
+            ? [createAlert(i18n.t('Alert'), i18n.t('No boundaries found'))]
+            : null,
         isLoaded: true,
         isExpanded: true,
         isVisible: true,


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-7773

The problem was that we didn't return any layer config if the array was empty. The code works fine empty arrays, so the fix was to remove an early return, and then include an alert if no boundary features was retuned (= empty array). 

![Skjermbilde 2019-10-24 kl  20 22 31](https://user-images.githubusercontent.com/548708/67514582-433ed380-f69d-11e9-9efc-6fe9fa3b8536.png)
