### PR TITLE
fix: period select fixes

### DIFF
--- a/src/components/periods/PeriodSelect.js
+++ b/src/components/periods/PeriodSelect.js
@@ -44,14 +44,9 @@ class PeriodSelect extends Component {
     };
 
     state = {
-        year: getYear(),
+        year: null,
         periods: null,
     };
-
-    constructor(props) {
-        super(props);
-        this.periodIndex = null;
-    }
 
     componentDidMount() {
         this.setPeriods();
@@ -64,11 +59,11 @@ class PeriodSelect extends Component {
         if (periodType !== prevProps.periodType) {
             this.setPeriods();
         } else if (periods && !period) {
-            onChange(filterFuturePeriods(periods)[0]); // Autoselect most recent period
+            onChange(filterFuturePeriods(periods)[0] || periods[0]); // Autoselect most recent period
         }
 
         // Change period if year is changed (but keep period index)
-        if (period && year !== prevState.year) {
+        if (period && prevState.periods && year !== prevState.year) {
             const periodIndex = prevState.periods.findIndex(
                 item => item.id === period.id
             );
@@ -130,15 +125,16 @@ class PeriodSelect extends Component {
 
     setPeriods() {
         const { periodType, period, locale } = this.props;
+        const year = this.state.year || getYear(period && period.startDate);
         let periods;
 
         if (periodType) {
-            periods = createPeriods(locale, periodType, this.state.year);
+            periods = createPeriods(locale, periodType, year);
         } else if (period) {
             periods = [period]; // If period is loaded in favorite
         }
 
-        this.setState({ periods });
+        this.setState({ periods, year });
     }
 
     nextYear = () => {


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-7839

This PR fixes 2 issues with the period selector:

1. Avoids crash if year is changed into the future, and then period type is changed. The crash happened because filterFuturePeriods would return an empty periods array as all of them would be in the future. If this is the case, we return the first period in the array.

2. If you select a period type, change the year, and then then change the tab, the period will no longer be selected. This PR fixes the issue by making sure the year is still the same, and not reset to the most recent year. 

The long term plan is to switch to a shared period selector component, so I've tried to make as few changes as possible here, as the fix also needs to be backported. 

