### PR TITLE
fix: clear dimension items array when filter is changed

### DIFF
--- a/src/components/dimensions/DimensionFilterRow.js
+++ b/src/components/dimensions/DimensionFilterRow.js
@@ -46,7 +46,9 @@ class DimensionFilterRow extends Component {
             <div className={classes.container}>
                 <DimensionSelect
                     dimension={dimension}
-                    onChange={dimension => this.onChange(dimension.id)}
+                    onChange={selectedDimension =>
+                        this.onChange(selectedDimension.id)
+                    }
                 />
                 <DimensionItemsSelect
                     dimension={dimension}

--- a/src/components/dimensions/DimensionFilterRow.js
+++ b/src/components/dimensions/DimensionFilterRow.js
@@ -46,7 +46,7 @@ class DimensionFilterRow extends Component {
             <div className={classes.container}>
                 <DimensionSelect
                     dimension={dimension}
-                    onChange={dimension => this.onChange(dimension.id, items)}
+                    onChange={dimension => this.onChange(dimension.id)}
                 />
                 <DimensionItemsSelect
                     dimension={dimension}


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-7866

When the user changed filter dimension, we did not clear the selected dimension items, which resulted in a crash. 
