### PR TITLE
fix: authentication header for map plugin

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -57,7 +57,9 @@ const PluginContainer = () => {
         }
 
         if (username && password) {
-            config.context = { auth: `${username}:${password}` };
+            config.headers = {
+                Authorization: 'Basic ' + btoa(`${username}:${password}`),
+            };
         }
 
         config.schemas = union(config.schemas, [


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8215

Allows the user to authenticate with username and password with the map plugin. 