### PR TITLE
fix: set alerts to undefined

### DIFF
--- a/src/loaders/boundaryLoader.js
+++ b/src/loaders/boundaryLoader.js
@@ -66,7 +66,7 @@ const boundaryLoader = async config => {
         name: layerName,
         alerts: !features.length
             ? [createAlert(i18n.t('Alert'), i18n.t('No boundaries found'))]
-            : null,
+            : undefined,
         isLoaded: true,
         isExpanded: true,
         isVisible: true,

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -145,7 +145,7 @@ const layer = (state, action) => {
         case types.ALERTS_CLEAR:
             return {
                 ...state,
-                alerts: null,
+                alerts: undefined,
             };
 
         case types.MAP_EARTH_ENGINE_VALUE_SHOW:
@@ -324,7 +324,7 @@ const map = (state = defaultState, action) => {
         case types.ALERTS_CLEAR:
             return {
                 ...state,
-                alerts: null,
+                alerts: undefined,
                 mapViews: state.mapViews.map(l => layer(l, action)),
             };
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -129,7 +129,9 @@ if (!isDevBuild) {
         // Replace any occurance of process.env.NODE_ENV with the string 'production'
         new webpack.DefinePlugin({
             'process.env': { NODE_ENV: JSON.stringify('production') },
-            DHIS_CONFIG: JSON.stringify({}),
+            DHIS_CONFIG: JSON.stringify({
+                baseUrl: '../',
+            }),
         })
     );
     webpackConfig.plugins.push(new webpack.optimize.OccurrenceOrderPlugin());


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8222

If alerts is NULL, it will not be set to an empty array here: https://github.com/dhis2/maps-app/blob/master/src/components/plugin/Legend.js#L88

This PR sets alerts to undefined. 

Should also be backported to 2.33. 

<img width="466" alt="Screenshot 2020-02-05 at 21 18 46" src="https://user-images.githubusercontent.com/548708/73879644-29e12200-485d-11ea-8104-b7fd3e2f781c.png">

This PR also sets baseUrl to '../' for production builds. 