### PR TITLE
fix: use JssProvider for maps plugin

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -168,7 +168,9 @@ const PluginContainer = () => {
                 const ref = createRef();
 
                 // JSS initialization
-                const generateClassName = createGenerateClassName();
+                const generateClassName = createGenerateClassName({
+                    productionPrefix: 'maps-plugin-',
+                });
                 jss.options.insertionPoint = 'jss-insertion-point';
 
                 render(

--- a/src/map.js
+++ b/src/map.js
@@ -171,7 +171,6 @@ const PluginContainer = () => {
                 const generateClassName = createGenerateClassName({
                     productionPrefix: 'maps-plugin-',
                 });
-                jss.options.insertionPoint = 'jss-insertion-point';
 
                 render(
                     <JssProvider

--- a/src/map.js
+++ b/src/map.js
@@ -1,5 +1,6 @@
 import React, { createRef } from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
+import { JssProvider, jss, createGenerateClassName } from 'react-jss';
 import { union } from 'lodash/fp';
 import { init, config, getUserSettings } from 'd2';
 import { isValidUid } from 'd2/uid';
@@ -166,7 +167,19 @@ const PluginContainer = () => {
             if (domEl) {
                 const ref = createRef();
 
-                render(<Plugin innerRef={ref} {...config} />, domEl);
+                // JSS initialization
+                const generateClassName = createGenerateClassName();
+                jss.options.insertionPoint = 'jss-insertion-point';
+
+                render(
+                    <JssProvider
+                        jss={jss}
+                        generateClassName={generateClassName}
+                    >
+                        <Plugin innerRef={ref} {...config} />
+                    </JssProvider>,
+                    domEl
+                );
 
                 _components[config.el] = ref;
             }


### PR DESCRIPTION
We have issues with class names collisions on the Dashboard, probably due to different Material UI versions and JSS. This PR wraps the maps plugin in a JssProvider using a maps-plugin- prefix. 