### PR TITLE
fix. class name prefix for map plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "34.0.18",
+    "version": "34.0.19",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/map.js
+++ b/src/map.js
@@ -1,6 +1,9 @@
 import React, { createRef } from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
-import { JssProvider, jss, createGenerateClassName } from 'react-jss';
+import {
+    StylesProvider,
+    createGenerateClassName,
+} from '@material-ui/core/styles';
 import { union } from 'lodash/fp';
 import { init, config, getUserSettings } from 'd2';
 import { isValidUid } from 'd2/uid';
@@ -167,18 +170,14 @@ const PluginContainer = () => {
             if (domEl) {
                 const ref = createRef();
 
-                // JSS initialization
                 const generateClassName = createGenerateClassName({
-                    productionPrefix: 'maps-plugin-',
+                    productionPrefix: 'map-plugin-',
                 });
 
                 render(
-                    <JssProvider
-                        jss={jss}
-                        generateClassName={generateClassName}
-                    >
+                    <StylesProvider generateClassName={generateClassName}>
                         <Plugin innerRef={ref} {...config} />
-                    </JssProvider>,
+                    </StylesProvider>,
                     domEl
                 );
 


### PR DESCRIPTION
The previous try using JssProvider to add a prefix to class names did't have an effect, so I'm switching to StylesProvider as documented on https://material-ui.com/styles/api/#creategenerateclassname-options-class-name-generator