### PR TITLE
fix: Bing Maps download and more compact select lists

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -66,12 +66,14 @@ getManifest('manifest.webapp')
     })
     .then(configI18n)
     .then(init)
+    .then(d2 =>
+        d2.system.settings.get('keyBingMapsApiKey').then(key => {
+            store.dispatch(setBingMapsApiKey(key));
+            return d2;
+        })
+    )
     .then(
-        async d2 => {
-            await d2.system.settings
-                .get('keyBingMapsApiKey')
-                .then(key => store.dispatch(setBingMapsApiKey(key)));
-
+        d2 => {
             const mapId = getUrlParameter('id');
             if (mapId) {
                 store.dispatch(loadFavorite(mapId));

--- a/src/app.js
+++ b/src/app.js
@@ -67,8 +67,8 @@ getManifest('manifest.webapp')
     .then(configI18n)
     .then(init)
     .then(
-        d2 => {
-            d2.system.settings
+        async d2 => {
+            await d2.system.settings
                 .get('keyBingMapsApiKey')
                 .then(key => store.dispatch(setBingMapsApiKey(key)));
 

--- a/src/components/core/SelectField.js
+++ b/src/components/core/SelectField.js
@@ -86,7 +86,7 @@ export const SelectField = props => {
                 <MenuItem
                     key={id}
                     value={id}
-                    dense={true}
+                    dense
                     className={multiple && classes.menuItem}
                     data-test="selectfield-menuitem"
                 >

--- a/src/components/core/SelectField.js
+++ b/src/components/core/SelectField.js
@@ -20,7 +20,10 @@ const styles = {
         zIndex: 2500,
     },
     menuItem: {
-        paddingLeft: 0,
+        padding: '4px 0',
+    },
+    checkbox: {
+        padding: '0 9px',
     },
 };
 
@@ -65,6 +68,7 @@ export const SelectField = props => {
             className={classes.textField}
             SelectProps={{
                 MenuProps: {
+                    variant: 'menu',
                     className: classes.menu,
                 },
                 multiple,
@@ -82,12 +86,13 @@ export const SelectField = props => {
                 <MenuItem
                     key={id}
                     value={id}
-                    dense
+                    dense={true}
                     className={multiple && classes.menuItem}
                     data-test="selectfield-menuitem"
                 >
                     {multiple && (
                         <Checkbox
+                            className={classes.checkbox}
                             checked={
                                 Array.isArray(value) && value.indexOf(id) >= 0
                             }

--- a/src/components/download/DownloadDialog.js
+++ b/src/components/download/DownloadDialog.js
@@ -163,17 +163,22 @@ export class DownloadDialog extends Component {
         // Adding 1 to the computed width of the title element avoids text
         // wrapping outside the box in the generated image
         const titleEl = mapEl.getElementsByClassName('dhis2-maps-title')[0];
-        const width = window
-            .getComputedStyle(titleEl, null)
-            .getPropertyValue('width');
 
-        titleEl.style.width = parseInt(width, 10) + 1 + 'px';
+        if (titleEl) {
+            const width = window
+                .getComputedStyle(titleEl, null)
+                .getPropertyValue('width');
+
+            titleEl.style.width = parseInt(width, 10) + 1 + 'px';
+        }
 
         convertToPng(mapEl, options)
             .then(dataUri => {
                 downloadFile(dataURItoBlob(dataUri), filename);
 
-                titleEl.style.width = 'auto';
+                if (titleEl) {
+                    titleEl.style.width = 'auto';
+                }
 
                 this.onClose();
             })

--- a/src/components/download/DownloadDialog.js
+++ b/src/components/download/DownloadDialog.js
@@ -144,16 +144,20 @@ export class DownloadDialog extends Component {
         // Skip map controls in download except attribution and scale
         // Mapbox map controls contains inline SVG for CSS background-image, which
         // is not accepted by dom-to-image
-        const skipControls = el =>
+        // Bing Maps logo is blocked by CORS policy
+        const skipElements = el =>
             !el.classList ||
             el.classList.contains('mapboxgl-ctrl-scale') ||
             el.classList.contains('mapboxgl-ctrl-attrib') ||
-            !el.classList.contains('mapboxgl-ctrl');
+            !(
+                el.classList.contains('mapboxgl-ctrl') ||
+                el.classList.contains('dhis2-map-bing-logo')
+            );
 
         const options = {
             width: mapEl.offsetWidth,
             height: mapEl.offsetHeight,
-            filter: skipControls,
+            filter: skipElements,
         };
 
         // Adding 1 to the computed width of the title element avoids text

--- a/src/components/layers/legend/LegendItem.js
+++ b/src/components/layers/legend/LegendItem.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import LineSymbol from './LineSymbol';
 import LegendItemRange from './LegendItemRange';
 
+const maxRadius = 15;
+
 const LegendItem = ({
     image,
     color,
@@ -23,9 +25,11 @@ const LegendItem = ({
     };
 
     if (radius) {
-        symbol.width = radius * 2 + 'px';
-        symbol.height = radius * 2 + 'px';
-        symbol.borderRadius = radius ? '50%' : '0';
+        const r = (radius < maxRadius ? radius : maxRadius) * 2;
+
+        symbol.width = `${r}px`;
+        symbol.height = `${r}px`;
+        symbol.borderRadius = '50%';
     }
 
     return (

--- a/src/components/layers/legend/LegendItem.js
+++ b/src/components/layers/legend/LegendItem.js
@@ -25,7 +25,7 @@ const LegendItem = ({
     };
 
     if (radius) {
-        const r = (radius < maxRadius ? radius : maxRadius) * 2;
+        const r = Math.min(radius, maxRadius) * 2;
 
         symbol.width = `${r}px`;
         symbol.height = `${r}px`;


### PR DESCRIPTION
This PR fixes:
- Bing Maps key is loaded before a saved map to make sure if have the Bing Maps key available.
- Select lists are more compact. 
- Bing Maps logo is not included in map download (it's blocked by CORS policy).
- Allow maps to be downloaded if no title in present. 
- Set max radius for legend items
