### PR TITLE
fix: style and default legend

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@dhis2/d2-ui-interpretations": "6.2.1",
         "@dhis2/d2-ui-org-unit-dialog": "5.2.10",
         "@dhis2/d2-ui-org-unit-tree": "5.2.10",
-        "@dhis2/maps-gl": "1.0.12",
+        "@dhis2/maps-gl": "1.0.13",
         "@dhis2/ui-core": "^4.1.1",
         "@dhis2/ui-widgets": "^2.0.5",
         "@material-ui/core": "^4.9.3",

--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -25,6 +25,9 @@ const styles = theme => ({
         width: 32,
         height: 32,
     },
+    menuItem: {
+        padding: '4px 16px',
+    },
     divider: {
         margin: `${theme.spacing(1)}px 0`,
     },
@@ -121,7 +124,10 @@ export class LayerToolbarMoreMenu extends Component {
                     disableRestoreFocus={true} // Don't re-focus on the Tooltip after the dialog is closed
                 >
                     {toggleDataTable && (
-                        <MenuItem onClick={this.handleDataTableBtnClick}>
+                        <MenuItem
+                            onClick={this.handleDataTableBtnClick}
+                            className={classes.menuItem}
+                        >
                             <ListItemIcon>
                                 <TableIcon />
                             </ListItemIcon>
@@ -129,7 +135,10 @@ export class LayerToolbarMoreMenu extends Component {
                         </MenuItem>
                     )}
                     {openAs && (
-                        <MenuItem onClick={this.handleOpenAsChartBtnClick}>
+                        <MenuItem
+                            onClick={this.handleOpenAsChartBtnClick}
+                            className={classes.menuItem}
+                        >
                             <ListItemIcon>
                                 <ChartIcon />
                             </ListItemIcon>
@@ -137,7 +146,10 @@ export class LayerToolbarMoreMenu extends Component {
                         </MenuItem>
                     )}
                     {downloadData && (
-                        <MenuItem onClick={this.handleDownloadBtnClick}>
+                        <MenuItem
+                            onClick={this.handleDownloadBtnClick}
+                            className={classes.menuItem}
+                        >
                             <ListItemIcon>
                                 <SaveIcon />
                             </ListItemIcon>
@@ -148,7 +160,10 @@ export class LayerToolbarMoreMenu extends Component {
                         <Divider className={classes.divider} light />
                     )}
                     {onEdit && (
-                        <MenuItem onClick={this.handleEditBtnClick}>
+                        <MenuItem
+                            onClick={this.handleEditBtnClick}
+                            className={classes.menuItem}
+                        >
                             <ListItemIcon>
                                 <EditIcon />
                             </ListItemIcon>
@@ -156,7 +171,10 @@ export class LayerToolbarMoreMenu extends Component {
                         </MenuItem>
                     )}
                     {onRemove && (
-                        <MenuItem onClick={this.handleRemoveBtnClick}>
+                        <MenuItem
+                            onClick={this.handleRemoveBtnClick}
+                            className={classes.menuItem}
+                        >
                             <ListItemIcon>
                                 <DeleteIcon />
                             </ListItemIcon>

--- a/src/components/map/MapItem.js
+++ b/src/components/map/MapItem.js
@@ -4,13 +4,13 @@ import { withStyles } from '@material-ui/core/styles';
 import mapApi from './MapApi';
 
 const styles = () => ({
-    item: {
+    item: ({ count }) => ({
         position: 'relative',
         boxSizing: 'border-box',
-        width: '33.3333%',
+        width: count === 4 ? '50%' : '33.3333%',
         borderRight: '1px solid #aaa',
         borderBottom: '1px solid #aaa',
-    },
+    }),
 });
 
 class MapItem extends PureComponent {

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -72,7 +72,14 @@ const thematicLoader = async config => {
     const maxValue = orderedValues[orderedValues.length - 1];
     const dataItem = getDataItemFromColumns(columns);
     const name = names[dataItem.id];
+
     let legendSet = config.legendSet;
+
+    // Use legend set defined for data item if no classification method is selected
+    if (config.method === undefined && dataItem.legendSet) {
+        legendSet = dataItem.legendSet;
+    }
+
     let method = legendSet ? CLASSIFICATION_PREDEFINED : config.method; // Favorites often have wrong method
     let alert;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,10 +417,10 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@1.0.12":
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.0.12.tgz#73b92e2bd1e17160ec341b6395b6af6660765a30"
-  integrity sha512-UfLx1YqrvM90WZ/Q7yyDxIR1goJIKS/CNay9IHfbli4bTL5dTm6E9qh3W8ceeIekbeRb5A8Wr4FjQ4yvPcpMxg==
+"@dhis2/maps-gl@1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.0.13.tgz#a253b0c2c5e559315c8f3879d865ca855f8588b6"
+  integrity sha512-wRknu4muBxqfmMyHQBK0a/m3aBNtts4PFlxxX/61JJvqZgUAO+6Ywu+kfVpNK7eo0B957uh9yJ3w0ZPI6TGUYQ==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.0.1"
@@ -431,7 +431,7 @@
     "@turf/length" "^6.0.2"
     fetch-jsonp "^1.1.3"
     lodash.throttle "^4.1.1"
-    mapbox-gl "^1.8.0"
+    mapbox-gl "^1.8.1"
     mapboxgl-spiderifier "^1.0.9"
     polylabel "^1.0.2"
     suggestions "^1.7.0"
@@ -9272,10 +9272,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapbox-gl@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.8.0.tgz#77f8350c1600c588299420e1435ac642bd2cedef"
-  integrity sha512-Uqg+2JdMKecmOmnfye06xrYx+Gg5iwhJcfkOv6p7MdlRspR0h02CwoDvM/ftOjTYp+Axi6+EWZHq8Um97JXcGQ==
+mapbox-gl@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.8.1.tgz#83fd2e99274a226adbf1c01012c37d17fccdd4bc"
+  integrity sha512-Q6c8XAFxHxMPnZIfiRsExk5dNN+dCgvbRNHPfX7hHV5LDcX5Ptc1MEVpOJEDyojuriZssAeWMTJob0hir9mpUw==
   dependencies:
     "@mapbox/geojson-rewind" "^0.4.0"
     "@mapbox/geojson-types" "^1.0.2"


### PR DESCRIPTION
This PR fixes: 
- Less padding for toolbar more menu (needed after Material UI upgrade)
- Show 2x2 for split view with 4 maps (not 3x1)
- Use predefined legend for data item if exist (as default) 