### PR TITLE
fix: set default legend set from data item

### DIFF
--- a/src/components/classification/NumericLegendStyle.js
+++ b/src/components/classification/NumericLegendStyle.js
@@ -14,6 +14,7 @@ import {
 export class NumericLegendStyle extends Component {
     static propTypes = {
         method: PropTypes.number,
+        legendSet: PropTypes.object,
         dataItem: PropTypes.object,
         setClassification: PropTypes.func.isRequired,
         setLegendSet: PropTypes.func.isRequired,
@@ -21,7 +22,9 @@ export class NumericLegendStyle extends Component {
     };
 
     componentDidMount() {
-        if (!this.props.method) {
+        const { method, legendSet } = this.props;
+
+        if (!method || (method === CLASSIFICATION_PREDEFINED && !legendSet)) {
             this.setDefaultLegendStyle();
         }
     }
@@ -78,6 +81,7 @@ export class NumericLegendStyle extends Component {
 export default connect(
     ({ layerEdit }) => ({
         method: layerEdit.method,
+        legendSet: layerEdit.legendSet,
     }),
     { setClassification, setLegendSet }
 )(NumericLegendStyle);

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -75,8 +75,13 @@ const thematicLoader = async config => {
 
     let legendSet = config.legendSet;
 
-    // Use legend set defined for data item if no classification method is selected
-    if (config.method === undefined && dataItem.legendSet) {
+    // Use legend set defined for data item as default
+    if (
+        !legendSet &&
+        dataItem.legendSet &&
+        (config.method === undefined ||
+            config.method === CLASSIFICATION_PREDEFINED)
+    ) {
         legendSet = dataItem.legendSet;
     }
 
@@ -179,7 +184,7 @@ const thematicLoader = async config => {
         name,
         legend,
         method,
-        ...(alert ? { alerts: [alert] } : {}),
+        alerts: alert ? [alert] : undefined,
         isLoaded: true,
         isExpanded: true,
         isVisible: true,


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8471

This PR fixes a bug when editing thematic layers multiple times. If style tab is not visited on the first edit, the default legend from the data item is not stored. This fix makes sure the default legend is applied. 

It also clear the alerts between edits. 