### PR TITLE
fix: Handle error if org unit selection is invalid for thematic layers (DHIS2-8479)

### DIFF
--- a/src/components/map/Layer.js
+++ b/src/components/map/Layer.js
@@ -45,7 +45,7 @@ class Layer extends PureComponent {
             editCounter,
             dataFilters,
         } = this.props;
-        const { period } = this.state || {};
+        const { period } = this.state;
         const { period: prevPeriod } = prevState || {};
         const isEdited = editCounter !== prevProps.editCounter;
 

--- a/src/components/map/Layer.js
+++ b/src/components/map/Layer.js
@@ -27,6 +27,8 @@ class Layer extends PureComponent {
         isVisible: true,
     };
 
+    state = {};
+
     constructor(...args) {
         super(...args);
         this.setPeriod();

--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -31,6 +31,7 @@ class ThematicLayer extends Layer {
             valuesByPeriod,
             renderingStrategy = 'SINGLE',
         } = this.props;
+
         const { period } = this.state;
         let periodData = data;
 
@@ -86,6 +87,11 @@ class ThematicLayer extends Layer {
     // Set initial period
     setPeriod(callback) {
         const { period, periods, renderingStrategy } = this.props;
+
+        if (!period || !periods) {
+            return;
+        }
+
         const initialPeriod = {
             period:
                 renderingStrategy === 'SINGLE' ? null : period || periods[0],

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -26,6 +26,18 @@ import {
 } from '../constants/layers';
 
 const thematicLoader = async config => {
+    const {
+        columns,
+        rows,
+        radiusLow = DEFAULT_RADIUS_LOW,
+        radiusHigh = DEFAULT_RADIUS_HIGH,
+        classes,
+        colorScale,
+        renderingStrategy = 'SINGLE',
+    } = config;
+
+    const dataItem = getDataItemFromColumns(columns);
+
     let error;
 
     const response = await loadData(config).catch(err => {
@@ -40,22 +52,13 @@ const thematicLoader = async config => {
                       alerts: [createAlert(i18n.t('Error'), error.message)],
                   }
                 : {}),
+            name: dataItem ? dataItem.name : i18n.t('Thematic layer'),
             isLoaded: true,
             isVisible: true,
         };
     }
 
     const [features, data] = response;
-
-    const {
-        columns,
-        rows,
-        radiusLow = DEFAULT_RADIUS_LOW,
-        radiusHigh = DEFAULT_RADIUS_HIGH,
-        classes,
-        colorScale,
-        renderingStrategy = 'SINGLE',
-    } = config;
 
     const isSingle = renderingStrategy === 'SINGLE';
     const period = getPeriodFromFilters(config.filters);
@@ -70,7 +73,6 @@ const thematicLoader = async config => {
     const orderedValues = getOrderedValues(data);
     const minValue = orderedValues[0];
     const maxValue = orderedValues[orderedValues.length - 1];
-    const dataItem = getDataItemFromColumns(columns);
     const name = names[dataItem.id];
 
     let legendSet = config.legendSet;


### PR DESCRIPTION
Partly fixes:  https://jira.dhis2.org/browse/DHIS2-8479

Related to the same issue with invalid org unit selections for facility layers: https://github.com/dhis2/maps-app/pull/495

The error originates in an invalid org unit selection that was not handled properly. 

<img width="592" alt="Screenshot 2020-03-17 at 14 41 27" src="https://user-images.githubusercontent.com/548708/76862064-d0a5de80-685d-11ea-8ac5-c2ce91f6476c.png">

This PR includes a fix that check if period(s) are available (which is not the case if org unit selection is invalid). We allow the limited layer config to pass through so the user can edit the layer and fix the org unit selection. 

The error message received could be more descriptive, but I think it will work until we get new org uni selection in place: https://jira.dhis2.org/browse/DHIS2-8481

<img width="795" alt="Screenshot 2020-03-17 at 14 42 24" src="https://user-images.githubusercontent.com/548708/76862093-da2f4680-685d-11ea-8334-6c867dc1849e.png">