### PR TITLE
fix: set the default classification/legend for selected data item (DHIS2-8485)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-01-27T17:04:18.402Z\n"
-"PO-Revision-Date: 2020-01-27T17:04:18.402Z\n"
+"POT-Creation-Date: 2020-03-18T10:45:53.204Z\n"
+"PO-Revision-Date: 2020-03-18T10:45:53.204Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -682,6 +682,9 @@ msgid "No data found"
 msgstr ""
 
 msgid "Facilities"
+msgstr ""
+
+msgid "Thematic layer"
 msgstr ""
 
 msgid "Selected org units"

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -117,7 +117,6 @@ export class ThematicDialog extends Component {
         labelFontStyle: PropTypes.string,
         labelFontWeight: PropTypes.string,
         legendSet: PropTypes.object,
-        method: PropTypes.number,
         indicatorGroup: PropTypes.object,
         dataElementGroup: PropTypes.object,
         program: PropTypes.object,

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -38,9 +38,12 @@ import {
     DEFAULT_ORG_UNIT_LEVEL,
     DEFAULT_RADIUS_LOW,
     DEFAULT_RADIUS_HIGH,
+    CLASSIFICATION_PREDEFINED,
+    CLASSIFICATION_EQUAL_INTERVALS,
 } from '../../../constants/layers';
 
 import {
+    setClassification,
     setDataItem,
     setDataElementGroup,
     setIndicatorGroup,
@@ -49,6 +52,7 @@ import {
     setLabelFontSize,
     setLabelFontWeight,
     setLabelFontStyle,
+    setLegendSet,
     setOperand,
     setOrgUnitLevels,
     setOrgUnitGroups,
@@ -112,6 +116,8 @@ export class ThematicDialog extends Component {
         labelFontSize: PropTypes.string,
         labelFontStyle: PropTypes.string,
         labelFontWeight: PropTypes.string,
+        legendSet: PropTypes.object,
+        method: PropTypes.number,
         indicatorGroup: PropTypes.object,
         dataElementGroup: PropTypes.object,
         program: PropTypes.object,
@@ -124,6 +130,7 @@ export class ThematicDialog extends Component {
         radiusLow: PropTypes.number,
         valueType: PropTypes.string,
         loadOrgUnitPath: PropTypes.func.isRequired,
+        setClassification: PropTypes.func.isRequired,
         setDataItem: PropTypes.func.isRequired,
         setDataElementGroup: PropTypes.func.isRequired,
         setIndicatorGroup: PropTypes.func.isRequired,
@@ -132,6 +139,7 @@ export class ThematicDialog extends Component {
         setLabelFontSize: PropTypes.func.isRequired,
         setLabelFontStyle: PropTypes.func.isRequired,
         setLabelFontWeight: PropTypes.func.isRequired,
+        setLegendSet: PropTypes.func.isRequired,
         setOperand: PropTypes.func.isRequired,
         setPeriod: PropTypes.func.isRequired,
         setStartDate: PropTypes.func.isRequired,
@@ -199,6 +207,9 @@ export class ThematicDialog extends Component {
     componentDidUpdate(prev) {
         const {
             rows,
+            columns,
+            setClassification,
+            setLegendSet,
             loadOrgUnitPath,
             validateLayer,
             onLayerValidation,
@@ -211,6 +222,21 @@ export class ThematicDialog extends Component {
             orgUnits
                 .filter(ou => !ou.path)
                 .forEach(ou => loadOrgUnitPath(ou.id));
+        }
+
+        // Set the default classification/legend for selected data item without visiting the style tab
+        if (columns !== prev.columns) {
+            const dataItem = getDataItemFromColumns(columns);
+
+            if (dataItem) {
+                if (dataItem.legendSet) {
+                    setClassification(CLASSIFICATION_PREDEFINED);
+                    setLegendSet(dataItem.legendSet);
+                } else {
+                    setClassification(CLASSIFICATION_EQUAL_INTERVALS);
+                    setLegendSet();
+                }
+            }
         }
 
         if (validateLayer && validateLayer !== prev.validateLayer) {
@@ -759,6 +785,7 @@ export class ThematicDialog extends Component {
 export default connect(
     null,
     {
+        setClassification,
         setDataItem,
         setDataElementGroup,
         setIndicatorGroup,
@@ -767,6 +794,7 @@ export default connect(
         setLabelFontSize,
         setLabelFontWeight,
         setLabelFontStyle,
+        setLegendSet,
         setOperand,
         setOrgUnitLevels,
         setOrgUnitGroups,


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8485

This PR fixes an issue with thematic layer not getting default classification/legend stored if the styled tab is not visited by the user before "Add layer" button is clicked. 

The solution is to set the default classification/legend whenever a data item is first selected or changed.

Before this fix making this selection would produce a map with a predefined legend: 

<img width="596" alt="Screenshot 2020-03-18 at 12 51 08" src="https://user-images.githubusercontent.com/548708/76958162-7f5a2580-6917-11ea-965c-08b8e6f46f1f.png">
 
But the predefined legend was not saved with the map, as the selection was never made in the UI without first visiting the Style tab. This PR makes sure this is happening. 
