### PR TITLE
fix: remove doble scrollbars for dimension select

### DIFF
--- a/src/components/dimensions/DimensionSelect.js
+++ b/src/components/dimensions/DimensionSelect.js
@@ -33,6 +33,7 @@ const styles = {
         width: 400,
         marginTop: -13,
         marginLeft: -8,
+        overflowY: 'hidden',
     },
 };
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8487

Avoids double scrollbars for dimension select popover: 

<img width="432" alt="Screenshot 2020-03-18 at 14 37 43" src="https://user-images.githubusercontent.com/548708/76966586-7faded00-6926-11ea-92b7-12a85c1d5671.png">

Setting overflow-y to "hidden" is not affecting the inner scroll to reach the bottom of the list.