### PR TITLE
Correct context menu position for plugin maps  (DHIS2-8520)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "33.0.19",
+    "version": "33.0.20",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -150,11 +150,14 @@ class ThematicLayer extends Layer {
 
     onFeatureRightClick(evt) {
         const { id, layer } = this.props;
+        const container = this.context.map.getContainer();
+        const { x, y } = container.getBoundingClientRect();
 
         this.props.openContextMenu({
             ...evt,
             layerId: id,
             layerType: layer,
+            mapPosition: [x, window.scrollY + y],
         });
     }
 }

--- a/src/components/plugin/Plugin.js
+++ b/src/components/plugin/Plugin.js
@@ -16,7 +16,10 @@ const styles = {
     },
 };
 
-const defaultBounds = [[-18.7, -34.9], [50.2, 35.9]];
+const defaultBounds = [
+    [-18.7, -34.9],
+    [50.2, 35.9],
+];
 
 class Plugin extends Component {
     static propTypes = {
@@ -41,7 +44,18 @@ class Plugin extends Component {
 
     render() {
         const { name, basemap, classes } = this.props;
-        const { position, feature, mapViews, resizeCount } = this.state;
+        const {
+            position,
+            mapPosition,
+            feature,
+            mapViews,
+            resizeCount,
+        } = this.state;
+
+        const pos =
+            position && mapPosition
+                ? [position[0] - mapPosition[0], position[1] - mapPosition[1]]
+                : null;
 
         return (
             <div className={classes.root}>
@@ -57,7 +71,7 @@ class Plugin extends Component {
                 />
                 <Legend layers={mapViews} />
                 <ContextMenu
-                    position={position}
+                    position={pos}
                     feature={feature}
                     onDrill={this.onDrill}
                 />


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8520

The right-click context menu is not shown in the correct position for plugin maps (including Dashboards): 

<img width="762" alt="Screenshot 2020-03-24 at 18 27 38" src="https://user-images.githubusercontent.com/548708/77462350-51d41700-6e04-11ea-8698-510bdde4845c.png">

The fix calculates the position relative to the window/document:

<img width="462" alt="Screenshot 2020-03-24 at 19 11 03" src="https://user-images.githubusercontent.com/548708/77462467-703a1280-6e04-11ea-9ccb-c31ca90ab836.png">

This is fixed in a more elegant way in Maps app master/2.34.

 