### PR TITLE
fix: change fullscreen control container and period state handling (DHIS2-8524)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@dhis2/d2-ui-interpretations": "6.2.1",
         "@dhis2/d2-ui-org-unit-dialog": "5.2.10",
         "@dhis2/d2-ui-org-unit-tree": "5.2.10",
-        "@dhis2/maps-gl": "1.0.16",
+        "@dhis2/maps-gl": "1.0.17",
         "@dhis2/ui-core": "^4.1.1",
         "@dhis2/ui-widgets": "^2.0.5",
         "@material-ui/core": "^4.9.3",

--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -97,10 +97,12 @@ class ThematicLayer extends Layer {
                 renderingStrategy === 'SINGLE' ? null : period || periods[0],
         };
 
-        if (this.state) {
-            this.setState(initialPeriod, callback);
-        } else {
+        // Can't call setState if component is unmounted
+        // setPeriod without callback is called from the constructor
+        if (!this.state || !callback) {
             this.state = initialPeriod;
+        } else {
+            this.setState(initialPeriod, callback);
         }
     }
 

--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -97,9 +97,8 @@ class ThematicLayer extends Layer {
                 renderingStrategy === 'SINGLE' ? null : period || periods[0],
         };
 
-        // Can't call setState if component is unmounted
-        // setPeriod without callback is called from the constructor
-        if (!this.state || !callback) {
+        // setPeriod without callback is called from the constructor (unmounted)
+        if (!callback) {
             this.state = initialPeriod;
         } else {
             this.setState(initialPeriod, callback);

--- a/src/constants/mapControls.js
+++ b/src/constants/mapControls.js
@@ -34,6 +34,5 @@ export const pluginControls = [
     },
     {
         type: 'fullscreen',
-        isPlugin: true,
     },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,10 +417,10 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@1.0.16":
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.0.16.tgz#7fbc884825a1fb9751cb84ad807b0bc5288b7e63"
-  integrity sha512-dM44cjCf6x0CFFU5dHg3kTVGURLYB9uw/B97A/7kixC2aAskQ1GB5C9FMQxUNMvySYKMCUElFs/SMab7k/qSgg==
+"@dhis2/maps-gl@1.0.17":
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.0.17.tgz#6a3f511c1da5f356d9b67b48ed008490ee0c2d81"
+  integrity sha512-zog66Pp0PKiGWLWVYsFB06rZw5Jv0RzQawdGibDzxZ56SoVR+SDCRpg4KzDUda+riZ7KOKGH0lkjHDkZKfprtw==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.0.1"


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8524

Related PR in `maps-gl` which is now merged and the dependency is updated in this PR: https://github.com/dhis2/maps-gl/pull/77

The `isPlugin` option is removed from the fullscreen control as it's no longer in use. 

A bug was discovered while working on this issue, and a fix is included in this PR. The bug was introduced in a previous PR which is not present in the 2.34 release candidate. 

 The `if (this.state)` check failed as we now set `state = {};` in the Layer component, so the check is always true. We then got an error as we can't called setState on an unmounted component. The fix is to use the callback parameter to decide if the component is mounted or not. 

<img width="1493" alt="Screenshot 2020-03-25 at 12 42 07" src="https://user-images.githubusercontent.com/548708/77534862-bab99e80-6e99-11ea-833f-36b35bf80ef9.png">
