### PR TITLE
fix: delete serverCluster option if previously set

### DIFF
--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -83,6 +83,9 @@ const loadEventLayer = async config => {
         items: [],
     };
 
+    // Delete serverCluster option if previously set
+    delete config.serverCluster;
+
     if (spatialSupport && eventClustering) {
         const response = await getCount(analyticsRequest);
         config.bounds = getBounds(response.extent);


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8529

When editing an existing event layer, the serverCluster option is not cleared. This option is not set by the user, but based on the number of events. 
