### PR TITLE
fix: clear data and legend when loading fails (DHIS2-8564)

### DIFF
--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -53,6 +53,8 @@ const thematicLoader = async config => {
                   }
                 : {}),
             name: dataItem ? dataItem.name : i18n.t('Thematic layer'),
+            data: null,
+            legend: null,
             isLoaded: true,
             isVisible: true,
         };


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8564

The issue is that the data and legend is not cleared for a thematic layer if a new org unit selection is invalid. This fix will clear the data and legend from the config object. 

Before this fix, the map and legend is not cleared: 
<img width="1151" alt="Screenshot 2020-04-01 at 11 42 47" src="https://user-images.githubusercontent.com/548708/78127129-eb5a8480-7413-11ea-80ca-23caa46ac215.png">

After this fix: 
<img width="1153" alt="Screenshot 2020-04-01 at 11 41 31" src="https://user-images.githubusercontent.com/548708/78127140-ee557500-7413-11ea-9112-4594f0502c04.png">
