### PR TITLE
fix: keep dynamic filters when switching from DV (DHIS2-8575) 

### DIFF
--- a/src/util/analyticalObject.js
+++ b/src/util/analyticalObject.js
@@ -1,5 +1,5 @@
 import { config, getInstance as getD2 } from 'd2';
-import { getPeriodNameFromId } from './analytics';
+import { getPeriodNameFromId, getDimensionsFromFilters } from './analytics';
 import { loadDataItemLegendSet } from './legend';
 
 export const NAMESPACE = 'analytics';
@@ -41,6 +41,7 @@ export const getThematicLayerFromAnalyticalObject = async (
     const dataDims = getDataDimensionsFromAnalyticalObject(ao);
     const dims = getDimensionsFromAnalyticalObject(ao);
     const orgUnits = dims.find(i => i.dimension === 'ou');
+    const filters = getDimensionsFromFilters(dims); // Dynamic dimension filters
     let period = dims.find(i => i.dimension === 'pe');
     let dataDim = dataDims[0];
 
@@ -72,7 +73,7 @@ export const getThematicLayerFromAnalyticalObject = async (
         layer: 'thematic',
         columns: [{ dimension: 'dx', items: [dataDim] }],
         rows: [orgUnits],
-        filters: [period],
+        filters: [period, ...filters],
         aggregationType,
         legendSet,
         isVisible,


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8575

This PR fixes an issue to keep dynamic filters are not kept when switching from DV to Maps. 

This screenshots shows a map opened from DV where the dynamic filters are kept: 
<img width="1150" alt="Screenshot 2020-04-01 at 15 30 47" src="https://user-images.githubusercontent.com/548708/78143661-db9c6980-742e-11ea-989e-ffd3dbf17502.png">
