### PR TITLE
feat: hideTitle option for plugin maps (DHIS2-8618)

### DIFF
--- a/src/components/plugin/Plugin.js
+++ b/src/components/plugin/Plugin.js
@@ -23,6 +23,7 @@ const defaultBounds = [
 
 class Plugin extends Component {
     static propTypes = {
+        hideTitle: PropTypes.bool,
         name: PropTypes.string,
         basemap: PropTypes.object,
         mapViews: PropTypes.array,
@@ -30,6 +31,7 @@ class Plugin extends Component {
     };
 
     static defaultProps = {
+        hideTitle: false,
         basemap: { id: 'osmLight' },
     };
 
@@ -43,7 +45,7 @@ class Plugin extends Component {
     }
 
     render() {
-        const { name, basemap, classes } = this.props;
+        const { name, basemap, hideTitle, classes } = this.props;
         const {
             position,
             offset,
@@ -56,7 +58,7 @@ class Plugin extends Component {
 
         return (
             <div className={`dhis2-map-plugin ${classes.root}`}>
-                <MapName name={name} />
+                {!hideTitle && <MapName name={name} />}
                 <MapView
                     isPlugin={true}
                     basemap={basemap}


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8618

This PR adds a new boolean "hideTitle" option for plugin maps. Default value is "false" (show title). When "true" the map title will not be shown on the map. 

NB! "hideTitle: true" needs to be added for the maps plugin in the Dashboard app after this PR is merged. 

When "hideTitle" is "false" or option not present. 
<img width="463" alt="Screenshot 2020-04-08 at 12 17 39" src="https://user-images.githubusercontent.com/548708/78773653-db065480-7993-11ea-9311-472d67774fa7.png">

When "hideTitle" is "true": 
<img width="464" alt="Screenshot 2020-04-08 at 12 17 09" src="https://user-images.githubusercontent.com/548708/78773655-dc378180-7993-11ea-955a-0bf2a89e509a.png">
