### PR TITLE
fix: clean ou dimension before app switching

### DIFF
--- a/src/util/analyticalObject.js
+++ b/src/util/analyticalObject.js
@@ -1,6 +1,7 @@
 import { config, getInstance as getD2 } from 'd2';
 import { getPeriodNameFromId, getDimensionsFromFilters } from './analytics';
 import { loadDataItemLegendSet } from './legend';
+import { cleanDimension } from './favorites';
 
 export const NAMESPACE = 'analytics';
 export const CURRENT_AO_KEY = 'currentAnalyticalObject';
@@ -91,7 +92,7 @@ export const getAnalyticalObjectFromThematicLayer = (layer = {}) => {
 
     return {
         columns,
-        rows,
+        rows: rows.map(cleanDimension),
         filters,
         aggregationType,
     };

--- a/src/util/favorites.js
+++ b/src/util/favorites.js
@@ -167,7 +167,7 @@ const models2objects = config => {
     return config;
 };
 
-const cleanDimension = dim => ({
+export const cleanDimension = dim => ({
     ...dim,
     items: dim.items.map(item => pick(validModelProperties, item)),
 });


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8585

This PR fixes an issue where we try to serialise OU dimensions represented as models resulting in a circular structure error.  This fix is to use the same approach as we do on save, to clean the OU dimensions by only allowing the needed properties to pass through. 

Solves this error: 
![image-2020-04-02-13-19-05-669](https://user-images.githubusercontent.com/548708/79228227-633b9c80-7e61-11ea-875d-5a41e4c03931.png)