### PR TITLE
fix: use first period as default

### DIFF
--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -88,7 +88,7 @@ class ThematicLayer extends Layer {
     setPeriod(callback) {
         const { period, periods, renderingStrategy } = this.props;
 
-        if (!period || !periods) {
+        if (!period && !periods) {
             return;
         }
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8640

This bug was introduced by this PR: https://github.com/dhis2/maps-app/pull/496/
So this bug has never faced the user. 

It is not present in 2.34.0-rc tested on: https://verify.dhis2.org/2.34.0-rc/

`(!period || !periods)` returned true if period was undefined while periods was not. If no period is defined the first period should be used. Fixed by using `&&` - the function should only return if both period and periods are undefined. 
