### PR TITLE
fix: only show org units with data values for timeline and split view maps (DHIS2-8176)

### DIFF
--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -38,15 +38,15 @@ class ThematicLayer extends Layer {
         if (renderingStrategy !== 'SINGLE') {
             const values = valuesByPeriod[period.id] || {};
 
-            periodData = data.map(feature => ({
-                ...feature,
-                properties: {
-                    ...feature.properties,
-                    ...(values[feature.id]
-                        ? values[feature.id]
-                        : { value: i18n.t('No data'), color: '#CCC' }),
-                },
-            }));
+            periodData = data
+                .filter(feature => values[feature.id] !== undefined)
+                .map(feature => ({
+                    ...feature,
+                    properties: {
+                        ...feature.properties,
+                        ...values[feature.id],
+                    },
+                }));
         }
 
         const map = this.context.map;


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8176

We're treating nodata for timeline and split view maps differently than for the default single (aggregate) maps. For single maps, we don't show org units with no data values, and with this PR we do the same for timeline and split view maps. 

There is a separate issue to make this user selectable in a future release: https://jira.dhis2.org/browse/DHIS2-8642

Before:
<img width="1574" alt="Screenshot 2020-04-15 at 10 47 17" src="https://user-images.githubusercontent.com/548708/79317868-8a987500-7f06-11ea-9b39-569bbd0bf45f.png">

After: 
<img width="1574" alt="Screenshot 2020-04-15 at 10 43 23" src="https://user-images.githubusercontent.com/548708/79317651-4016f880-7f06-11ea-8c29-6ed261c832f6.png">

Before: 
<img width="1575" alt="Screenshot 2020-04-15 at 10 42 40" src="https://user-images.githubusercontent.com/548708/79317669-473e0680-7f06-11ea-8b73-0ac9349d8672.png">

After: 
<img width="1573" alt="Screenshot 2020-04-15 at 10 42 52" src="https://user-images.githubusercontent.com/548708/79317702-4f964180-7f06-11ea-9f0a-03d119fff29a.png">

