### PR TITLE
fix: only set default org unit level if no other org units are selected (DHIS2-7924)

### DIFF
--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -198,7 +198,7 @@ export class ThematicDialog extends Component {
         }
 
         // Set default org unit level
-        if (!getOrgUnitLevelsFromRows(rows).length) {
+        if (!getOrgUnitsFromRows(rows).length) {
             setOrgUnitLevels([DEFAULT_ORG_UNIT_LEVEL]);
         }
     }


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-7924

For thematic layers we use the second level as the default org unit selection. This fix makes sure that this level is only selected when no other org units are selected, including user org units. 

Before this fix, the second org unit level is selected even though a user org unit level is selected. It is not possible deselect the org unit level, leading to an error when the layer is updated. 
<img width="595" alt="Screenshot 2020-04-15 at 13 24 55" src="https://user-images.githubusercontent.com/548708/79332119-87a87f00-7f1c-11ea-8cb6-e178402a6a51.png">

With this PR the default org unit level is not selected: 
<img width="598" alt="Screenshot 2020-04-15 at 13 23 43" src="https://user-images.githubusercontent.com/548708/79332128-8aa36f80-7f1c-11ea-8614-7c98fe2ed3e9.png">
