### PR TITLE
fix: remove unsupported filter operators for event layers (DHIS2-7089)

### DIFF
--- a/src/components/filter/FilterSelect.js
+++ b/src/components/filter/FilterSelect.js
@@ -129,7 +129,6 @@ export class FilterSelect extends Component {
         ];
     }
 
-    // Supported operators: https://docs.dhis2.org/master/en/dhis2_developer_manual/web-api.html#filtering_1
     getOperators(valueType, optionSet) {
         let operators;
 

--- a/src/components/filter/FilterSelect.js
+++ b/src/components/filter/FilterSelect.js
@@ -66,7 +66,7 @@ export class FilterSelect extends Component {
         }
 
         return [
-            operators && (
+            operators ? (
                 <SelectField
                     key="operator"
                     label={i18n.t('Operator')}
@@ -77,7 +77,7 @@ export class FilterSelect extends Component {
                     }
                     style={styles.operator}
                 />
-            ),
+            ) : null,
             optionSet && optionSets[optionSet.id] ? (
                 <OptionSetSelect
                     key="optionset"

--- a/src/components/filter/FilterSelect.js
+++ b/src/components/filter/FilterSelect.js
@@ -66,7 +66,7 @@ export class FilterSelect extends Component {
         }
 
         return [
-            operators ? (
+            operators && (
                 <SelectField
                     key="operator"
                     label={i18n.t('Operator')}
@@ -77,7 +77,7 @@ export class FilterSelect extends Component {
                     }
                     style={styles.operator}
                 />
-            ) : null,
+            ),
             optionSet && optionSets[optionSet.id] ? (
                 <OptionSetSelect
                     key="optionset"
@@ -129,6 +129,7 @@ export class FilterSelect extends Component {
         ];
     }
 
+    // Supported operators: https://docs.dhis2.org/master/en/dhis2_developer_manual/web-api.html#filtering_1
     getOperators(valueType, optionSet) {
         let operators;
 
@@ -146,16 +147,12 @@ export class FilterSelect extends Component {
                 { id: 'NE', name: '!=' },
             ];
         } else if (optionSet) {
-            operators = [
-                { id: 'IN', name: i18n.t('one of') },
-                { id: '!IN', name: i18n.t('not one of') },
-            ];
+            operators = [{ id: 'IN', name: i18n.t('one of') }];
         } else if (textValueTypes.indexOf(valueType) >= 0) {
             operators = [
                 { id: 'LIKE', name: i18n.t('contains') },
-                { id: '!LIKE', name: i18n.t("doesn't contains") },
                 { id: 'EQ', name: i18n.t('is') },
-                { id: '!EQ', name: i18n.t('is not') },
+                { id: 'NE', name: i18n.t('is not') },
             ];
         }
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-7089

For event filtering we show some operators not supported by the Web API, and this PR removes them. 

Supported operators: 
https://docs.dhis2.org/master/en/dhis2_developer_manual/web-api.html#filtering_1

For option sets the `!IN` (not in) operator has been removed. 
For text the `!LIKE `(not contains) operator has been removed, and the `!EQ` operator has been renamed to `NE`. 

As there is only one operator (`IN`) available for option sets, the selection could be removed. I decided to keep it to have minimal changes for this bugfix which should be backported. 

There is a plan to use similar components as in use for DV map. 
