### PR TITLE
fix: backport fixes to 2.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@dhis2/d2-ui-interpretations": "6.2.1",
         "@dhis2/d2-ui-org-unit-dialog": "5.2.10",
         "@dhis2/d2-ui-org-unit-tree": "5.2.10",
-        "@dhis2/maps-gl": "1.0.17",
+        "@dhis2/maps-gl": "1.0.14",
         "@dhis2/ui-core": "^4.1.1",
         "@dhis2/ui-widgets": "^2.0.5",
         "@material-ui/core": "^4.9.3",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@dhis2/d2-ui-interpretations": "6.2.1",
         "@dhis2/d2-ui-org-unit-dialog": "5.2.10",
         "@dhis2/d2-ui-org-unit-tree": "5.2.10",
-        "@dhis2/maps-gl": "1.0.14",
+        "@dhis2/maps-gl": "1.0.15",
         "@dhis2/ui-core": "^4.1.1",
         "@dhis2/ui-widgets": "^2.0.5",
         "@material-ui/core": "^4.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "34.0.25",
+    "version": "34.0.26",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {
@@ -53,7 +53,7 @@
         "@dhis2/d2-ui-interpretations": "6.2.1",
         "@dhis2/d2-ui-org-unit-dialog": "5.2.10",
         "@dhis2/d2-ui-org-unit-tree": "5.2.10",
-        "@dhis2/maps-gl": "1.0.13",
+        "@dhis2/maps-gl": "1.0.17",
         "@dhis2/ui-core": "^4.1.1",
         "@dhis2/ui-widgets": "^2.0.5",
         "@material-ui/core": "^4.9.3",

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -83,6 +83,9 @@ const loadEventLayer = async config => {
         items: [],
     };
 
+    // Delete serverCluster option if previously set
+    delete config.serverCluster;
+
     if (spatialSupport && eventClustering) {
         const response = await getCount(analyticsRequest);
         config.bounds = getBounds(response.extent);

--- a/src/util/analyticalObject.js
+++ b/src/util/analyticalObject.js
@@ -1,5 +1,5 @@
 import { config, getInstance as getD2 } from 'd2';
-import { getPeriodNameFromId } from './analytics';
+import { getPeriodNameFromId, getDimensionsFromFilters } from './analytics';
 import { loadDataItemLegendSet } from './legend';
 
 export const NAMESPACE = 'analytics';
@@ -41,6 +41,7 @@ export const getThematicLayerFromAnalyticalObject = async (
     const dataDims = getDataDimensionsFromAnalyticalObject(ao);
     const dims = getDimensionsFromAnalyticalObject(ao);
     const orgUnits = dims.find(i => i.dimension === 'ou');
+    const filters = getDimensionsFromFilters(dims); // Dynamic dimension filters
     let period = dims.find(i => i.dimension === 'pe');
     let dataDim = dataDims[0];
 
@@ -72,7 +73,7 @@ export const getThematicLayerFromAnalyticalObject = async (
         layer: 'thematic',
         columns: [{ dimension: 'dx', items: [dataDim] }],
         rows: [orgUnits],
-        filters: [period],
+        filters: [period, ...filters],
         aggregationType,
         legendSet,
         isVisible,

--- a/src/util/analyticalObject.js
+++ b/src/util/analyticalObject.js
@@ -1,5 +1,5 @@
 import { config, getInstance as getD2 } from 'd2';
-import { getPeriodNameFromId, getDimensionsFromFilters } from './analytics';
+import { getPeriodNameFromId } from './analytics';
 import { loadDataItemLegendSet } from './legend';
 
 export const NAMESPACE = 'analytics';
@@ -41,7 +41,6 @@ export const getThematicLayerFromAnalyticalObject = async (
     const dataDims = getDataDimensionsFromAnalyticalObject(ao);
     const dims = getDimensionsFromAnalyticalObject(ao);
     const orgUnits = dims.find(i => i.dimension === 'ou');
-    const filters = getDimensionsFromFilters(dims); // Dynamic dimension filters
     let period = dims.find(i => i.dimension === 'pe');
     let dataDim = dataDims[0];
 
@@ -73,7 +72,7 @@ export const getThematicLayerFromAnalyticalObject = async (
         layer: 'thematic',
         columns: [{ dimension: 'dx', items: [dataDim] }],
         rows: [orgUnits],
-        filters: [period, ...filters],
+        filters: [period],
         aggregationType,
         legendSet,
         isVisible,

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,10 +417,10 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@1.0.17":
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.0.17.tgz#6a3f511c1da5f356d9b67b48ed008490ee0c2d81"
-  integrity sha512-zog66Pp0PKiGWLWVYsFB06rZw5Jv0RzQawdGibDzxZ56SoVR+SDCRpg4KzDUda+riZ7KOKGH0lkjHDkZKfprtw==
+"@dhis2/maps-gl@1.0.14":
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.0.14.tgz#7fec156968e61b32af7569959ad666462f5d17bb"
+  integrity sha512-pZgGABvm4lloj8XaIRQhvAdCKsTU9uke+q/k30Zct+sTBpr4HY85//HbU2smYq05WhYQhYfZoC5l1z+xtq+6VA==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,10 +417,10 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@1.0.13":
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.0.13.tgz#a253b0c2c5e559315c8f3879d865ca855f8588b6"
-  integrity sha512-wRknu4muBxqfmMyHQBK0a/m3aBNtts4PFlxxX/61JJvqZgUAO+6Ywu+kfVpNK7eo0B957uh9yJ3w0ZPI6TGUYQ==
+"@dhis2/maps-gl@1.0.17":
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.0.17.tgz#6a3f511c1da5f356d9b67b48ed008490ee0c2d81"
+  integrity sha512-zog66Pp0PKiGWLWVYsFB06rZw5Jv0RzQawdGibDzxZ56SoVR+SDCRpg4KzDUda+riZ7KOKGH0lkjHDkZKfprtw==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,10 +417,10 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@1.0.14":
-  version "1.0.14"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.0.14.tgz#7fec156968e61b32af7569959ad666462f5d17bb"
-  integrity sha512-pZgGABvm4lloj8XaIRQhvAdCKsTU9uke+q/k30Zct+sTBpr4HY85//HbU2smYq05WhYQhYfZoC5l1z+xtq+6VA==
+"@dhis2/maps-gl@1.0.15":
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.0.15.tgz#623900ec2c51573b261fb86ce9ae93dbc3177084"
+  integrity sha512-lIPz6UGALfTo2nPE3/z1OQzUcwAGXDpp1OLG6bjUP3dnZs0tlwwINT77dchadGgMZczrPJpzpq3L+zmTRSrVbg==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.0.1"


### PR DESCRIPTION
This PR is a backport of the following issues:
- [DHIS2-8496](https://jira.dhis2.org/browse/DHIS2-8496) - Support layer ordering for tracked entities layers (https://github.com/dhis2/maps-gl/pull/69)
- [DHIS2-8498](https://jira.dhis2.org/browse/DHIS2-8498) - Update server clusters when map is zoomed to layer bounds (https://github.com/dhis2/maps-gl/pull/70)
- [DHIS2-8529](https://jira.dhis2.org/browse/DHIS2-8529) - Editing Event layer from "Group events" to "Show all events" result… (#528) 