### PR TITLE
fix: translation strings (DHIS2-8658)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-04-21T08:26:42.865Z\n"
-"PO-Revision-Date: 2020-04-21T08:26:42.865Z\n"
+"POT-Creation-Date: 2020-04-21T10:07:10.891Z\n"
+"PO-Revision-Date: 2020-04-21T10:07:10.892Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -146,6 +146,69 @@ msgstr ""
 msgid "No organisation units are selected"
 msgstr ""
 
+msgid ""
+"Population density estimates with national totals adjusted to match UN "
+"population division estimates. Try a different year if you don't see data "
+"for your country."
+msgstr ""
+
+msgid "Select year"
+msgstr ""
+
+msgid "Min people"
+msgstr ""
+
+msgid "Max people"
+msgstr ""
+
+msgid ""
+"Elevation above sea-level. You can adjust the min and max values so it "
+"better representes the terrain in your region."
+msgstr ""
+
+msgid "Min meters"
+msgstr ""
+
+msgid "Max meters"
+msgstr ""
+
+msgid ""
+"Precipitation collected from satellite and weather stations on the ground. "
+"The values are in millimeters within 5 days periods. Updated monthly, "
+"during the 3rd week of the following month."
+msgstr ""
+
+msgid "Min mm"
+msgstr ""
+
+msgid "Max mm"
+msgstr ""
+
+msgid ""
+"Land surface temperatures collected from satellite in 8 days periods. Blank "
+"spots will appear in areas with a persistent cloud cover."
+msgstr ""
+
+msgid "Min °C"
+msgstr ""
+
+msgid "Max °C"
+msgstr ""
+
+msgid "17 distinct landcover types collected from satellites."
+msgstr ""
+
+msgid ""
+"Light intensity from cities, towns, and other sites with persistent "
+"lighting, including gas flares."
+msgstr ""
+
+msgid "Min"
+msgstr ""
+
+msgid "Max"
+msgstr ""
+
 msgid "Steps"
 msgstr ""
 
@@ -213,6 +276,12 @@ msgid "Remember to select the organisation unit level containing the facilities.
 msgstr ""
 
 msgid "Group set is required"
+msgstr ""
+
+msgid "Edit {{name}} layer"
+msgstr ""
+
+msgid "Add {{name}} layer"
 msgstr ""
 
 msgid "Update layer"
@@ -412,7 +481,7 @@ msgstr ""
 msgid "Loading layer"
 msgstr ""
 
-msgid "deleted"
+msgid "{{name}} deleted."
 msgstr ""
 
 msgid "Split view can not be combined with other layer types."
@@ -615,6 +684,15 @@ msgstr ""
 msgid "Selected organisation units"
 msgstr ""
 
+msgid "Main"
+msgstr ""
+
+msgid "Below"
+msgstr ""
+
+msgid "2 x below"
+msgstr ""
+
 msgid "User organisation units"
 msgstr ""
 
@@ -628,6 +706,9 @@ msgid "Relative"
 msgstr ""
 
 msgid "Period type"
+msgstr ""
+
+msgid "Start/end dates"
 msgstr ""
 
 msgid "Display periods"
@@ -663,6 +744,30 @@ msgstr ""
 msgid "Tracked Entity Type"
 msgstr ""
 
+msgid "By data element"
+msgstr ""
+
+msgid "Count"
+msgstr ""
+
+msgid "Average"
+msgstr ""
+
+msgid "Sum"
+msgstr ""
+
+msgid "Standard deviation"
+msgstr ""
+
+msgid "Variance"
+msgstr ""
+
+msgid "Equal intervals"
+msgstr ""
+
+msgid "Equal counts"
+msgstr ""
+
 msgid "Daily"
 msgstr ""
 
@@ -670,6 +775,9 @@ msgid "Weekly"
 msgstr ""
 
 msgid "Monthly"
+msgstr ""
+
+msgid "Bi-monthly)"
 msgstr ""
 
 msgid "Quarterly"
@@ -691,9 +799,6 @@ msgid "Financial year (Start July)"
 msgstr ""
 
 msgid "Financial year (Start April)"
-msgstr ""
-
-msgid "Start/end dates"
 msgstr ""
 
 msgid "Today"
@@ -809,10 +914,7 @@ msgstr ""
 msgid "A connection to Google Earth Engine could not be established."
 msgstr ""
 
-msgid "Favorite"
-msgstr ""
-
-msgid "is saved"
+msgid "Map \"{{name}}\" is saved."
 msgstr ""
 
 msgid "Boundaries"
@@ -861,6 +963,27 @@ msgid "No tracked entities found"
 msgstr ""
 
 msgid "related"
+msgstr ""
+
+msgid "Thematic"
+msgstr ""
+
+msgid "Population density"
+msgstr ""
+
+msgid "Elevation"
+msgstr ""
+
+msgid "Temperature"
+msgstr ""
+
+msgid "Precipitation"
+msgstr ""
+
+msgid "Landcover"
+msgstr ""
+
+msgid "Nighttime lights"
 msgstr ""
 
 msgid "not one of"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-04-21T10:49:58.534Z\n"
-"PO-Revision-Date: 2020-04-21T10:49:58.534Z\n"
+"POT-Creation-Date: 2020-04-23T09:07:39.614Z\n"
+"PO-Revision-Date: 2020-04-23T09:07:39.614Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -672,13 +672,13 @@ msgstr ""
 msgid "two levels below user organisation unit"
 msgstr ""
 
-msgid "in"
+msgid "{{units}} in {{orgunits}}"
 msgstr ""
 
-msgid "in and right below"
+msgid "{{units}} in and right below {{orgunits}}"
 msgstr ""
 
-msgid "in and all below"
+msgid "{{units}} in and all below {{orgunits}}"
 msgstr ""
 
 msgid "Selected organisation units"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-04-21T10:07:10.891Z\n"
-"PO-Revision-Date: 2020-04-21T10:07:10.892Z\n"
+"POT-Creation-Date: 2020-04-21T10:49:58.534Z\n"
+"PO-Revision-Date: 2020-04-21T10:49:58.534Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -926,6 +926,112 @@ msgstr ""
 msgid "No boundaries found"
 msgstr ""
 
+msgid "Elevation"
+msgstr ""
+
+msgid "metres"
+msgstr ""
+
+msgid "Elevation above sea-level."
+msgstr ""
+
+msgid "Population density"
+msgstr ""
+
+msgid "people per km²"
+msgstr ""
+
+msgid ""
+"Population density estimates with national totals adjusted to match UN "
+"population division estimates."
+msgstr ""
+
+msgid "Nighttime lights"
+msgstr ""
+
+msgid "light intensity"
+msgstr ""
+
+msgid "Precipitation"
+msgstr ""
+
+msgid "millimeter"
+msgstr ""
+
+msgid "Precipitation collected from satellite and weather stations on the ground."
+msgstr ""
+
+msgid "Temperature"
+msgstr ""
+
+msgid "°C during daytime"
+msgstr ""
+
+msgid ""
+"Land surface temperatures collected from satellite. Blank spots will appear "
+"in areas with a persistent cloud cover."
+msgstr ""
+
+msgid "Landcover"
+msgstr ""
+
+msgid "Distinct landcover types collected from satellites."
+msgstr ""
+
+msgid "Water"
+msgstr ""
+
+msgid "Evergreen Needleleaf forest"
+msgstr ""
+
+msgid "Evergreen Broadleaf forest"
+msgstr ""
+
+msgid "Deciduous Needleleaf forest"
+msgstr ""
+
+msgid "Deciduous Broadleaf forest"
+msgstr ""
+
+msgid "Mixed forest"
+msgstr ""
+
+msgid "Closed shrublands"
+msgstr ""
+
+msgid "Open shrublands"
+msgstr ""
+
+msgid "Woody savannas"
+msgstr ""
+
+msgid "Savannas"
+msgstr ""
+
+msgid "Grasslands"
+msgstr ""
+
+msgid "Permanent wetlands"
+msgstr ""
+
+msgid "Croplands"
+msgstr ""
+
+msgid "Urban and built-up"
+msgstr ""
+
+msgid "Cropland/Natural vegetation mosaic"
+msgstr ""
+
+msgid "Snow and ice"
+msgstr ""
+
+msgid "Barren or sparsely vegetated"
+msgstr ""
+
+msgid "Unclassified"
+msgstr ""
+
 msgid "Access denied"
 msgstr ""
 
@@ -966,24 +1072,6 @@ msgid "related"
 msgstr ""
 
 msgid "Thematic"
-msgstr ""
-
-msgid "Population density"
-msgstr ""
-
-msgid "Elevation"
-msgstr ""
-
-msgid "Temperature"
-msgstr ""
-
-msgid "Precipitation"
-msgstr ""
-
-msgid "Landcover"
-msgstr ""
-
-msgid "Nighttime lights"
 msgstr ""
 
 msgid "not one of"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-03-18T10:45:53.204Z\n"
-"PO-Revision-Date: 2020-03-18T10:45:53.204Z\n"
+"POT-Creation-Date: 2020-04-21T08:26:42.865Z\n"
+"PO-Revision-Date: 2020-04-21T08:26:42.865Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -251,6 +251,15 @@ msgstr ""
 msgid "Selection mode"
 msgstr ""
 
+msgid "Selected only"
+msgstr ""
+
+msgid "Selected and below"
+msgstr ""
+
+msgid "Selected and all below"
+msgstr ""
+
 msgid "Tracked entities"
 msgstr ""
 
@@ -353,13 +362,7 @@ msgstr ""
 msgid "one of"
 msgstr ""
 
-msgid "not one of"
-msgstr ""
-
 msgid "contains"
-msgstr ""
-
-msgid "doesn't contains"
 msgstr ""
 
 msgid "is"
@@ -583,6 +586,11 @@ msgstr ""
 msgid "Select levels"
 msgstr ""
 
+msgid ""
+"It’s not possible to combine user organisation units and select individual "
+"units."
+msgstr ""
+
 msgid "Click the map where you want to relocate facility"
 msgstr ""
 
@@ -604,6 +612,12 @@ msgstr ""
 msgid "in and all below"
 msgstr ""
 
+msgid "Selected organisation units"
+msgstr ""
+
+msgid "User organisation units"
+msgstr ""
+
 msgid "Previous year"
 msgstr ""
 
@@ -614,6 +628,18 @@ msgid "Relative"
 msgstr ""
 
 msgid "Period type"
+msgstr ""
+
+msgid "Display periods"
+msgstr ""
+
+msgid "Single (aggregate)"
+msgstr ""
+
+msgid "Timeline"
+msgstr ""
+
+msgid "Split map views"
 msgstr ""
 
 msgid "Only one timeline is allowed."
@@ -635,6 +661,141 @@ msgid "Stage"
 msgstr ""
 
 msgid "Tracked Entity Type"
+msgstr ""
+
+msgid "Daily"
+msgstr ""
+
+msgid "Weekly"
+msgstr ""
+
+msgid "Monthly"
+msgstr ""
+
+msgid "Quarterly"
+msgstr ""
+
+msgid "Six-monthly"
+msgstr ""
+
+msgid "Six-monthly April"
+msgstr ""
+
+msgid "Yearly"
+msgstr ""
+
+msgid "Financial year (Start October)"
+msgstr ""
+
+msgid "Financial year (Start July)"
+msgstr ""
+
+msgid "Financial year (Start April)"
+msgstr ""
+
+msgid "Start/end dates"
+msgstr ""
+
+msgid "Today"
+msgstr ""
+
+msgid "Yesterday"
+msgstr ""
+
+msgid "Last 3 days"
+msgstr ""
+
+msgid "Last 7 days"
+msgstr ""
+
+msgid "Last 14 days"
+msgstr ""
+
+msgid "This week"
+msgstr ""
+
+msgid "Last week"
+msgstr ""
+
+msgid "Last 4 weeks"
+msgstr ""
+
+msgid "Last 12 weeks"
+msgstr ""
+
+msgid "Last 52 weeks"
+msgstr ""
+
+msgid "Weeks this year"
+msgstr ""
+
+msgid "This month"
+msgstr ""
+
+msgid "Last month"
+msgstr ""
+
+msgid "Last 3 months"
+msgstr ""
+
+msgid "Last 6 months"
+msgstr ""
+
+msgid "Last 12 months"
+msgstr ""
+
+msgid "Months this year"
+msgstr ""
+
+msgid "This bi-month"
+msgstr ""
+
+msgid "Last bi-month"
+msgstr ""
+
+msgid "Last 6 bi-months"
+msgstr ""
+
+msgid "Bi-months this year"
+msgstr ""
+
+msgid "This quarter"
+msgstr ""
+
+msgid "Last quarter"
+msgstr ""
+
+msgid "Last 4 quarters"
+msgstr ""
+
+msgid "Quarters this year"
+msgstr ""
+
+msgid "This six-month"
+msgstr ""
+
+msgid "Last six-month"
+msgstr ""
+
+msgid "Last 2 six-months"
+msgstr ""
+
+msgid "This year"
+msgstr ""
+
+msgid "Last year"
+msgstr ""
+
+msgid "Last 5 years"
+msgstr ""
+
+msgid "This financial year"
+msgstr ""
+
+msgid "Last financial year"
+msgstr ""
+
+msgid "Last 5 financial years"
 msgstr ""
 
 msgid ""
@@ -700,6 +861,12 @@ msgid "No tracked entities found"
 msgstr ""
 
 msgid "related"
+msgstr ""
+
+msgid "not one of"
+msgstr ""
+
+msgid "doesn't contains"
 msgstr ""
 
 msgid "true"

--- a/src/components/classification/Classification.js
+++ b/src/components/classification/Classification.js
@@ -6,7 +6,7 @@ import { range } from 'lodash/fp';
 import SelectField from '../core/SelectField';
 import ColorScaleSelect from '../core/ColorScaleSelect';
 import { setClassification, setColorScale } from '../../actions/layerEdit';
-import { classificationTypes } from '../../constants/layers';
+import { getClassificationTypes } from '../../constants/layers';
 import {
     defaultColorScaleName,
     defaultClasses,
@@ -49,10 +49,7 @@ const Classification = ({
             key="classification"
             label={i18n.t('Classification')}
             value={method || CLASSIFICATION_EQUAL_INTERVALS}
-            items={classificationTypes.map(({ id, name }) => ({
-                id,
-                name: i18n.t(name),
-            }))}
+            items={getClassificationTypes()}
             onChange={method => setClassification(method.id)}
             style={styles.select}
         />,

--- a/src/components/edit/EarthEngineDialog.js
+++ b/src/components/edit/EarthEngineDialog.js
@@ -15,58 +15,65 @@ import { createLegend } from '../../loaders/earthEngineLoader';
 import { layerDialogStyles } from './LayerDialogStyles';
 import legendStyle from '../layers/legend/legendStyle';
 
-const datasets = {
+const getDatasets = () => ({
     'WorldPop/POP': {
         // Population density
-        description:
-            "Population density estimates with national totals adjusted to match UN population division estimates. Try a different year if you don't see data for your country.",
-        collectionLabel: 'Select year',
+        description: i18n.t(
+            "Population density estimates with national totals adjusted to match UN population division estimates. Try a different year if you don't see data for your country."
+        ),
+        collectionLabel: i18n.t('Select year'),
         minValue: 0,
         maxValue: Number.MAX_VALUE,
-        minLabel: 'Min people',
-        maxLabel: 'Max people',
+        minLabel: i18n.t('Min people'),
+        maxLabel: i18n.t('Max people'),
     },
     'USGS/SRTMGL1_003': {
         // Elevation
-        description:
-            'Elevation above sea-level. You can adjust the min and max values so it better representes the terrain in your region.',
+        description: i18n.t(
+            'Elevation above sea-level. You can adjust the min and max values so it better representes the terrain in your region.'
+        ),
         minValue: 0,
         maxValue: 8848,
-        minLabel: 'Min meters',
-        maxLabel: 'Max meters',
+        minLabel: i18n.t('Min meters'),
+        maxLabel: i18n.t('Max meters'),
     },
     'UCSB-CHG/CHIRPS/PENTAD': {
         // Precipitation
-        description:
-            'Precipitation collected from satellite and weather stations on the ground. The values are in millimeters within 5 days periods. Updated monthly, during the 3rd week of the following month.',
+        description: i18n.t(
+            'Precipitation collected from satellite and weather stations on the ground. The values are in millimeters within 5 days periods. Updated monthly, during the 3rd week of the following month.'
+        ),
         minValue: 0,
         maxValue: 100,
-        minLabel: 'Min mm',
-        maxLabel: 'Max mm',
+        minLabel: i18n.t('Min mm'),
+        maxLabel: i18n.t('Max mm'),
     },
     'MODIS/006/MOD11A2': {
         // Temperature
-        description:
-            'Land surface temperatures collected from satellite in 8 days periods. Blank spots will appear in areas with a persistent cloud cover.',
+        description: i18n.t(
+            'Land surface temperatures collected from satellite in 8 days periods. Blank spots will appear in areas with a persistent cloud cover.'
+        ),
         minValue: -100,
         maxValue: 100,
-        minLabel: 'Min °C',
-        maxLabel: 'Max °C',
+        minLabel: i18n.t('Min °C'),
+        maxLabel: i18n.t('Max °C'),
     },
     'MODIS/051/MCD12Q1': {
         // Landcover
-        description: '17 distinct landcover types collected from satellites.',
-        valueLabel: 'Select year',
+        description: i18n.t(
+            '17 distinct landcover types collected from satellites.'
+        ),
+        valueLabel: i18n.t('Select year'),
     },
     'NOAA/DMSP-OLS/NIGHTTIME_LIGHTS': {
         // Nighttime lights
-        description:
-            'Light intensity from cities, towns, and other sites with persistent lighting, including gas flares.',
-        valueLabel: 'Select year',
+        description: i18n.t(
+            'Light intensity from cities, towns, and other sites with persistent lighting, including gas flares.'
+        ),
+        valueLabel: i18n.t('Select year'),
         minValue: 0,
         maxValue: 63,
     },
-};
+});
 
 const styles = {
     ...layerDialogStyles,
@@ -159,7 +166,7 @@ class EarthEngineDialog extends Component {
             setPeriodName,
             classes,
         } = this.props;
-        const dataset = datasets[datasetId];
+        const dataset = getDatasets()[datasetId];
         const { tab, steps, filterError, rangeError, stepsError } = this.state;
 
         return (
@@ -173,7 +180,7 @@ class EarthEngineDialog extends Component {
                             <div>{dataset.description}</div>
                             {datasetId !== 'USGS/SRTMGL1_003' && ( // If not elevation
                                 <Collection
-                                    label={i18n.t(dataset.collectionLabel)}
+                                    label={dataset.collectionLabel}
                                     id={datasetId}
                                     filter={filter}
                                     onChange={(periodName, filter) => {
@@ -191,9 +198,9 @@ class EarthEngineDialog extends Component {
                                 >
                                     <TextField
                                         type="number"
-                                        label={i18n.t(
-                                            dataset.minLabel || 'Min'
-                                        )}
+                                        label={
+                                            dataset.minLabel || i18n.t('Min')
+                                        }
                                         value={params.min}
                                         onChange={min =>
                                             setParams(
@@ -206,9 +213,9 @@ class EarthEngineDialog extends Component {
                                     />
                                     <TextField
                                         type="number"
-                                        label={i18n.t(
-                                            dataset.maxLabel || 'Max'
-                                        )}
+                                        label={
+                                            dataset.maxLabel || i18n.t('Max')
+                                        }
                                         value={params.max}
                                         onChange={max =>
                                             setParams(
@@ -298,7 +305,7 @@ class EarthEngineDialog extends Component {
 
     isValidRange() {
         const { datasetId, params } = this.props;
-        const dataset = datasets[datasetId];
+        const dataset = getDatasets()[datasetId];
         const { min, max } = params;
         const { minValue, maxValue } = dataset;
 
@@ -319,7 +326,7 @@ class EarthEngineDialog extends Component {
 
     validate() {
         const { datasetId, filter, params } = this.props;
-        const dataset = datasets[datasetId];
+        const dataset = getDatasets()[datasetId];
 
         if (datasetId !== 'USGS/SRTMGL1_003' && !filter) {
             return this.setErrorState(

--- a/src/components/edit/LayerEdit.js
+++ b/src/components/edit/LayerEdit.js
@@ -102,9 +102,9 @@ class LayerEdit extends Component {
             return null;
         }
 
-        const title = i18n.t(
-            layer.id ? `Edit ${name} layer` : `Add new ${name} layer`
-        );
+        const title = layer.id
+            ? i18n.t('Edit {{name}} layer', { name })
+            : i18n.t('Add {{name}} layer', { name });
 
         return (
             <Dialog open={true} maxWidth="md" data-test="layeredit">

--- a/src/components/edit/TrackedEntityDialog.js
+++ b/src/components/edit/TrackedEntityDialog.js
@@ -405,15 +405,17 @@ export class TrackedEntityDialog extends Component {
                                     items={[
                                         {
                                             id: 'SELECTED',
-                                            name: 'Selected only',
+                                            name: i18n.t('Selected only'),
                                         },
                                         {
                                             id: 'CHILDREN',
-                                            name: 'Selected and below',
+                                            name: i18n.t('Selected and below'),
                                         },
                                         {
                                             id: 'DESCENDANTS',
-                                            name: 'Selected and all below',
+                                            name: i18n.t(
+                                                'Selected and all below'
+                                            ),
                                         },
                                     ]}
                                     value={

--- a/src/components/edit/thematic/AggregationTypeSelect.js
+++ b/src/components/edit/thematic/AggregationTypeSelect.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import { connect } from 'react-redux';
 import SelectField from '../../core/SelectField';
-import { aggregationTypes } from '../../../constants/aggregationTypes';
+import { getAggregationTypes } from '../../../constants/aggregationTypes';
 import { setAggregationType } from '../../../actions/layerEdit';
 
 let types;
@@ -12,24 +12,15 @@ export const AggregationTypeSelect = ({
     aggregationType,
     setAggregationType,
     style,
-}) => {
-    if (!types) {
-        types = aggregationTypes.map(type => ({
-            id: type.id,
-            name: i18n.t(type.name),
-        }));
-    }
-
-    return (
-        <SelectField
-            label={i18n.t('Aggregation type')}
-            items={types}
-            value={aggregationType || types[0].id}
-            onChange={type => setAggregationType(type.id)}
-            style={style}
-        />
-    );
-};
+}) => (
+    <SelectField
+        label={i18n.t('Aggregation type')}
+        items={getAggregationTypes()}
+        value={aggregationType || types[0].id}
+        onChange={type => setAggregationType(type.id)}
+        style={style}
+    />
+);
 
 AggregationTypeSelect.propTypes = {
     aggregationType: PropTypes.string,

--- a/src/components/edit/thematic/AggregationTypeSelect.js
+++ b/src/components/edit/thematic/AggregationTypeSelect.js
@@ -6,21 +6,23 @@ import SelectField from '../../core/SelectField';
 import { getAggregationTypes } from '../../../constants/aggregationTypes';
 import { setAggregationType } from '../../../actions/layerEdit';
 
-let types;
-
 export const AggregationTypeSelect = ({
     aggregationType,
     setAggregationType,
     style,
-}) => (
-    <SelectField
-        label={i18n.t('Aggregation type')}
-        items={getAggregationTypes()}
-        value={aggregationType || types[0].id}
-        onChange={type => setAggregationType(type.id)}
-        style={style}
-    />
-);
+}) => {
+    const types = getAggregationTypes();
+
+    return (
+        <SelectField
+            label={i18n.t('Aggregation type')}
+            items={types}
+            value={aggregationType || types[0].id}
+            onChange={type => setAggregationType(type.id)}
+            style={style}
+        />
+    );
+};
 
 AggregationTypeSelect.propTypes = {
     aggregationType: PropTypes.string,

--- a/src/components/layers/layers/LayerCard.js
+++ b/src/components/layers/layers/LayerCard.js
@@ -170,7 +170,7 @@ const LayerCard = ({
                         }
                         onRemove={() => {
                             removeLayer(id);
-                            setMessage(`${name} ${i18n.t('deleted')}.`);
+                            setMessage(i18n.t('{{name}} deleted.', { name }));
                         }}
                         downloadData={
                             canDownload

--- a/src/components/orgunits/OrgUnitTree.js
+++ b/src/components/orgunits/OrgUnitTree.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
+import i18n from '@dhis2/d2-i18n';
 import { OrgUnitTreeMultipleRoots } from '@dhis2/d2-ui-org-unit-tree';
 import orgUnitStyles from '@dhis2/d2-ui-org-unit-dialog/styles/OrgUnitSelector.style';
 import { loadOrgUnitTree } from '../../actions/orgUnits';
@@ -74,8 +75,9 @@ export class OrgUnitTreeMaps extends Component {
                 />
                 {disabled ? (
                     <div className={classes.disabled}>
-                        It’s not possible to combine user organisation units and
-                        select individual units.
+                        {i18n.t(
+                            'It’s not possible to combine user organisation units and select individual units.'
+                        )}
                     </div>
                 ) : null}
             </div>

--- a/src/components/orgunits/SelectedOrgUnits.js
+++ b/src/components/orgunits/SelectedOrgUnits.js
@@ -24,10 +24,10 @@ const getLevels = () => ({
     ),
 });
 
-const getModes = () => ({
-    SELECTED: i18n.t('in'),
-    CHILDREN: i18n.t('in and right below'),
-    DESCENDANTS: i18n.t('in and all below'),
+const getModeString = props => ({
+    SELECTED: i18n.t('{{units}} in {{orgunits}}', props),
+    CHILDREN: i18n.t('{{units}} in and right below {{orgunits}}', props),
+    DESCENDANTS: i18n.t('{{units}} in and all below {{orgunits}}', props),
 });
 
 const SelectedOrgUnits = ({ units, rows, mode = 'SELECTED', error }) => {
@@ -41,13 +41,12 @@ const SelectedOrgUnits = ({ units, rows, mode = 'SELECTED', error }) => {
     let selected = i18n.t('No organisation units are selected');
 
     if (orgUnits.length || userOrgUnits.length) {
-        selected = `${units} ${getModes()[mode]} `;
-
-        if (userOrgUnits.length) {
-            selected += userOrgUnits.join(', ');
-        } else {
-            selected += orgUnits.join(', ');
-        }
+        selected = getModeString({
+            orgunits: userOrgUnits.length
+                ? userOrgUnits.join(', ')
+                : orgUnits.join(', '),
+            units,
+        })[mode];
     }
 
     return (

--- a/src/components/orgunits/SelectedOrgUnits.js
+++ b/src/components/orgunits/SelectedOrgUnits.js
@@ -56,7 +56,7 @@ const SelectedOrgUnits = ({ units, rows, mode = 'SELECTED', error }) => {
                 <div style={styles.error}>{error}</div>
             ) : (
                 <div>
-                    <strong>Selected organisation units</strong>
+                    <strong>{i18n.t('Selected organisation units')}</strong>
                     <br />
                     {selected}
                 </div>

--- a/src/components/orgunits/SelectedOrgUnits.js
+++ b/src/components/orgunits/SelectedOrgUnits.js
@@ -16,19 +16,19 @@ const styles = {
     },
 };
 
-const levels = {
+const getLevels = () => ({
     USER_ORGUNIT: i18n.t('user organisation unit'),
     USER_ORGUNIT_CHILDREN: i18n.t('right below user organisation unit'),
     USER_ORGUNIT_GRANDCHILDREN: i18n.t(
         'two levels below user organisation unit'
     ),
-};
+});
 
-const modes = {
+const getModes = () => ({
     SELECTED: i18n.t('in'),
     CHILDREN: i18n.t('in and right below'),
     DESCENDANTS: i18n.t('in and all below'),
-};
+});
 
 const SelectedOrgUnits = ({ units, rows, mode = 'SELECTED', error }) => {
     const orgUnits = getOrgUnitNodesFromRows(rows)
@@ -36,12 +36,12 @@ const SelectedOrgUnits = ({ units, rows, mode = 'SELECTED', error }) => {
         .sort();
     const userOrgUnits = getUserOrgUnitsFromRows(rows)
         .sort()
-        .map(id => i18n.t(levels[id]));
+        .map(id => getLevels()[id]);
 
     let selected = i18n.t('No organisation units are selected');
 
     if (orgUnits.length || userOrgUnits.length) {
-        selected = `${units} ${modes[mode]} `;
+        selected = `${units} ${getModes()[mode]} `;
 
         if (userOrgUnits.length) {
             selected += userOrgUnits.join(', ');

--- a/src/components/orgunits/UserOrgUnitsSelect.js
+++ b/src/components/orgunits/UserOrgUnitsSelect.js
@@ -30,20 +30,20 @@ const styles = theme => ({
     },
 });
 
-const levels = [
+const getLevels = () => [
     {
         id: 'USER_ORGUNIT',
-        label: 'Main',
+        label: i18n.t('Main'),
         Icon: FirstLevel,
     },
     {
         id: 'USER_ORGUNIT_CHILDREN',
-        label: 'Below',
+        label: i18n.t('Below'),
         Icon: SecondLevel,
     },
     {
         id: 'USER_ORGUNIT_GRANDCHILDREN',
-        label: '2 x below',
+        label: i18n.t('2 x below'),
         Icon: ThirdLevel,
     },
 ];
@@ -53,7 +53,7 @@ const UserOrgUnitSelect = ({ classes, selected, onChange, style }) => (
     <div className="UserOrgUnits" style={style}>
         <div className={classes.title}>{i18n.t('User organisation units')}</div>
         <div className={classes.container}>
-            {levels.map(level => {
+            {getLevels().map(level => {
                 const isSelected = selected.indexOf(level.id) !== -1;
 
                 return (

--- a/src/components/orgunits/UserOrgUnitsSelect.js
+++ b/src/components/orgunits/UserOrgUnitsSelect.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
+import i18n from '@dhis2/d2-i18n';
 import FirstLevel from './UserOrgUnitsFirstLevel';
 import SecondLevel from './UserOrgUnitsSecondLevel';
 import ThirdLevel from './UserOrgUnitsThirdLevel';
@@ -50,7 +51,7 @@ const levels = [
 // TODO: Use ImageSelect.js component for selectable image?
 const UserOrgUnitSelect = ({ classes, selected, onChange, style }) => (
     <div className="UserOrgUnits" style={style}>
-        <div className={classes.title}>User organisation units</div>
+        <div className={classes.title}>{i18n.t('User organisation units')}</div>
         <div className={classes.container}>
             {levels.map(level => {
                 const isSelected = selected.indexOf(level.id) !== -1;

--- a/src/components/periods/PeriodTypeSelect.js
+++ b/src/components/periods/PeriodTypeSelect.js
@@ -2,9 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import SelectField from '../core/SelectField';
-import { periodTypes, relativePeriods } from '../../constants/periods';
-
-let periods;
+import { getPeriodTypes, getRelativePeriods } from '../../constants/periods';
 
 class PeriodTypeSelect extends Component {
     static propTypes = {
@@ -23,7 +21,7 @@ class PeriodTypeSelect extends Component {
         };
 
         if (!value && period) {
-            if (relativePeriods.find(p => p.id === period.id)) {
+            if (getRelativePeriods().find(p => p.id === period.id)) {
                 // false will not clear the period dropdown
                 onChange(relativePeriodType, false);
             }
@@ -36,18 +34,10 @@ class PeriodTypeSelect extends Component {
     render() {
         const { value, onChange, style, errorText } = this.props;
 
-        if (!periods) {
-            // Translate period names
-            periods = periodTypes.map(({ id, name }) => ({
-                id,
-                name: i18n.t(name),
-            }));
-        }
-
         return (
             <SelectField
                 label={i18n.t('Period type')}
-                items={periods}
+                items={getPeriodTypes()}
                 value={value}
                 onChange={onChange}
                 style={style}

--- a/src/components/periods/RelativePeriodSelect.js
+++ b/src/components/periods/RelativePeriodSelect.js
@@ -1,10 +1,8 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import SelectField from '../core/SelectField';
-import { relativePeriods } from '../../constants/periods';
-
-let periods;
+import { getRelativePeriods } from '../../constants/periods';
 
 const RelativePeriodSelect = ({
     startEndDates,
@@ -15,24 +13,19 @@ const RelativePeriodSelect = ({
 }) => {
     const value = period ? period.id : null;
 
-    if (!periods) {
-        // Create periods array on first run
-        periods = (startEndDates
-            ? [
-                  {
-                      // Used in event layer dialog
-                      id: 'START_END_DATES',
-                      name: 'Start/end dates',
-                  },
-              ]
-            : []
-        )
-            .concat(relativePeriods)
-            .map(({ id, name }) => ({
-                id,
-                name: i18n.t(name), // Translate period names
-            }));
-    }
+    const periods = useMemo(
+        () =>
+            (startEndDates
+                ? [
+                      {
+                          id: 'START_END_DATES',
+                          name: i18n.t('Start/end dates'),
+                      },
+                  ]
+                : []
+            ).concat(getRelativePeriods()),
+        []
+    );
 
     return (
         <SelectField

--- a/src/components/periods/RenderingStrategy.js
+++ b/src/components/periods/RenderingStrategy.js
@@ -80,7 +80,7 @@ class RenderingStrategy extends Component {
         return (
             <FormControl component="fieldset" className={classes.control}>
                 <FormLabel component="legend" className={classes.label}>
-                    Display periods
+                    {i18n.t('Display periods')}
                 </FormLabel>
                 <RadioGroup
                     aria-label="Period display"
@@ -91,18 +91,18 @@ class RenderingStrategy extends Component {
                     <FormControlLabel
                         value="SINGLE"
                         control={<Radio className={classes.radio} />}
-                        label="Single (aggregate)"
+                        label={i18n.t('Single (aggregate)')}
                     />
                     <FormControlLabel
                         value="TIMELINE"
                         control={<Radio className={classes.radio} />}
-                        label="Timeline"
+                        label={i18n.t('Timeline')}
                         disabled={hasOtherTimelineLayers}
                     />
                     <FormControlLabel
                         value="SPLIT_BY_PERIOD"
                         control={<Radio className={classes.radio} />}
-                        label="Split map views"
+                        label={i18n.t('Split map views')}
                         disabled={
                             hasOtherLayers ||
                             invalidSplitViewPeriods.includes(period.id)

--- a/src/constants/aggregationTypes.js
+++ b/src/constants/aggregationTypes.js
@@ -1,10 +1,12 @@
-export const aggregationTypes = [
-    { id: 'DEFAULT', name: 'By data element' },
-    { id: 'COUNT', name: 'Count' },
-    { id: 'AVERAGE', name: 'Average' },
-    { id: 'SUM', name: 'Sum' },
-    { id: 'STDDEV', name: 'Standard deviation' },
-    { id: 'VARIANCE', name: 'Variance' },
-    { id: 'MIN', name: 'Min' },
-    { id: 'MAX', name: 'Max' },
+import i18n from '@dhis2/d2-i18n';
+
+export const getAggregationTypes = () => [
+    { id: 'DEFAULT', name: i18n.t('By data element') },
+    { id: 'COUNT', name: i18n.t('Count') },
+    { id: 'AVERAGE', name: i18n.t('Average') },
+    { id: 'SUM', name: i18n.t('Sum') },
+    { id: 'STDDEV', name: i18n.t('Standard deviation') },
+    { id: 'VARIANCE', name: i18n.t('Variance') },
+    { id: 'MIN', name: i18n.t('Min') },
+    { id: 'MAX', name: i18n.t('Max') },
 ];

--- a/src/constants/layers.js
+++ b/src/constants/layers.js
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n';
 import { formatDate } from '../util/time';
 
 export const DEFAULT_START_DATE = formatDate(
@@ -29,14 +30,14 @@ export const CLASSIFICATION_PREDEFINED = 1;
 export const CLASSIFICATION_EQUAL_INTERVALS = 2;
 export const CLASSIFICATION_EQUAL_COUNTS = 3;
 
-export const classificationTypes = [
+export const getClassificationTypes = () => [
     {
         id: CLASSIFICATION_EQUAL_INTERVALS,
-        name: 'Equal intervals',
+        name: i18n.t('Equal intervals'),
     },
     {
         id: CLASSIFICATION_EQUAL_COUNTS,
-        name: 'Equal counts',
+        name: i18n.t('Equal counts'),
     },
 ];
 

--- a/src/constants/periods.js
+++ b/src/constants/periods.js
@@ -1,54 +1,56 @@
-export const periodTypes = [
-    { id: 'relativePeriods', name: 'Relative' },
-    { id: 'Daily', name: 'Daily' },
-    { id: 'Weekly', name: 'Weekly' },
-    { id: 'Monthly', name: 'Monthly' },
-    { id: 'BiMonthly', name: 'Bi-monthly' },
-    { id: 'Quarterly', name: 'Quarterly' },
-    { id: 'SixMonthly', name: 'Six-monthly' },
-    { id: 'SixMonthlyApril', name: 'Six-monthly April' },
-    { id: 'Yearly', name: 'Yearly' },
-    { id: 'FinancialOctober', name: 'Financial year (Start October)' },
-    { id: 'FinancialJuly', name: 'Financial year (Start July)' },
-    { id: 'FinancialApril', name: 'Financial year (Start April)' },
-    { id: 'StartEndDates', name: 'Start/end dates' },
+import i18n from '@dhis2/d2-i18n';
+
+export const getPeriodTypes = () => [
+    { id: 'relativePeriods', name: i18n.t('Relative') },
+    { id: 'Daily', name: i18n.t('Daily') },
+    { id: 'Weekly', name: i18n.t('Weekly') },
+    { id: 'Monthly', name: i18n.t('Monthly') },
+    { id: 'BiMonthly', name: i18n.t('Bi-monthly)') },
+    { id: 'Quarterly', name: i18n.t('Quarterly') },
+    { id: 'SixMonthly', name: i18n.t('Six-monthly') },
+    { id: 'SixMonthlyApril', name: i18n.t('Six-monthly April') },
+    { id: 'Yearly', name: i18n.t('Yearly') },
+    { id: 'FinancialOctober', name: i18n.t('Financial year (Start October)') },
+    { id: 'FinancialJuly', name: i18n.t('Financial year (Start July)') },
+    { id: 'FinancialApril', name: i18n.t('Financial year (Start April)') },
+    { id: 'StartEndDates', name: i18n.t('Start/end dates') },
 ];
 
-export const relativePeriods = [
-    { id: 'TODAY', name: 'Today' },
-    { id: 'YESTERDAY', name: 'Yesterday' },
-    { id: 'LAST_3_DAYS', name: 'Last 3 days' },
-    { id: 'LAST_7_DAYS', name: 'Last 7 days' },
-    { id: 'LAST_14_DAYS', name: 'Last 14 days' },
-    { id: 'THIS_WEEK', name: 'This week' },
-    { id: 'LAST_WEEK', name: 'Last week' },
-    { id: 'LAST_4_WEEKS', name: 'Last 4 weeks' },
-    { id: 'LAST_12_WEEKS', name: 'Last 12 weeks' },
-    { id: 'LAST_52_WEEKS', name: 'Last 52 weeks' },
-    { id: 'WEEKS_THIS_YEAR', name: 'Weeks this year' },
-    { id: 'THIS_MONTH', name: 'This month' },
-    { id: 'LAST_MONTH', name: 'Last month' },
-    { id: 'LAST_3_MONTHS', name: 'Last 3 months' },
-    { id: 'LAST_6_MONTHS', name: 'Last 6 months' },
-    { id: 'LAST_12_MONTHS', name: 'Last 12 months' },
-    { id: 'MONTHS_THIS_YEAR', name: 'Months this year' },
-    { id: 'THIS_BIMONTH', name: 'This bi-month' },
-    { id: 'LAST_BIMONTH', name: 'Last bi-month' },
-    { id: 'LAST_6_BIMONTHS', name: 'Last 6 bi-months' },
-    { id: 'BIMONTHS_THIS_YEAR', name: 'Bi-months this year' },
-    { id: 'THIS_QUARTER', name: 'This quarter' },
-    { id: 'LAST_QUARTER', name: 'Last quarter' },
-    { id: 'LAST_4_QUARTERS', name: 'Last 4 quarters' },
-    { id: 'QUARTERS_THIS_YEAR', name: 'Quarters this year' },
-    { id: 'THIS_SIX_MONTH', name: 'This six-month' },
-    { id: 'LAST_SIX_MONTH', name: 'Last six-month' },
-    { id: 'LAST_2_SIXMONTHS', name: 'Last 2 six-months' },
-    { id: 'THIS_YEAR', name: 'This year' },
-    { id: 'LAST_YEAR', name: 'Last year' },
-    { id: 'LAST_5_YEARS', name: 'Last 5 years' },
-    { id: 'THIS_FINANCIAL_YEAR', name: 'This financial year' },
-    { id: 'LAST_FINANCIAL_YEAR', name: 'Last financial year' },
-    { id: 'LAST_5_FINANCIAL_YEARS', name: 'Last 5 financial years' },
+export const getRelativePeriods = () => [
+    { id: 'TODAY', name: i18n.t('Today') },
+    { id: 'YESTERDAY', name: i18n.t('Yesterday') },
+    { id: 'LAST_3_DAYS', name: i18n.t('Last 3 days') },
+    { id: 'LAST_7_DAYS', name: i18n.t('Last 7 days') },
+    { id: 'LAST_14_DAYS', name: i18n.t('Last 14 days') },
+    { id: 'THIS_WEEK', name: i18n.t('This week') },
+    { id: 'LAST_WEEK', name: i18n.t('Last week') },
+    { id: 'LAST_4_WEEKS', name: i18n.t('Last 4 weeks') },
+    { id: 'LAST_12_WEEKS', name: i18n.t('Last 12 weeks') },
+    { id: 'LAST_52_WEEKS', name: i18n.t('Last 52 weeks') },
+    { id: 'WEEKS_THIS_YEAR', name: i18n.t('Weeks this year') },
+    { id: 'THIS_MONTH', name: i18n.t('This month') },
+    { id: 'LAST_MONTH', name: i18n.t('Last month') },
+    { id: 'LAST_3_MONTHS', name: i18n.t('Last 3 months') },
+    { id: 'LAST_6_MONTHS', name: i18n.t('Last 6 months') },
+    { id: 'LAST_12_MONTHS', name: i18n.t('Last 12 months') },
+    { id: 'MONTHS_THIS_YEAR', name: i18n.t('Months this year') },
+    { id: 'THIS_BIMONTH', name: i18n.t('This bi-month') },
+    { id: 'LAST_BIMONTH', name: i18n.t('Last bi-month') },
+    { id: 'LAST_6_BIMONTHS', name: i18n.t('Last 6 bi-months') },
+    { id: 'BIMONTHS_THIS_YEAR', name: i18n.t('Bi-months this year') },
+    { id: 'THIS_QUARTER', name: i18n.t('This quarter') },
+    { id: 'LAST_QUARTER', name: i18n.t('Last quarter') },
+    { id: 'LAST_4_QUARTERS', name: i18n.t('Last 4 quarters') },
+    { id: 'QUARTERS_THIS_YEAR', name: i18n.t('Quarters this year') },
+    { id: 'THIS_SIX_MONTH', name: i18n.t('This six-month') },
+    { id: 'LAST_SIX_MONTH', name: i18n.t('Last six-month') },
+    { id: 'LAST_2_SIXMONTHS', name: i18n.t('Last 2 six-months') },
+    { id: 'THIS_YEAR', name: i18n.t('This year') },
+    { id: 'LAST_YEAR', name: i18n.t('Last year') },
+    { id: 'LAST_5_YEARS', name: i18n.t('Last 5 years') },
+    { id: 'THIS_FINANCIAL_YEAR', name: i18n.t('This financial year') },
+    { id: 'LAST_FINANCIAL_YEAR', name: i18n.t('Last financial year') },
+    { id: 'LAST_5_FINANCIAL_YEARS', name: i18n.t('Last 5 financial years') },
 ];
 
 // Periods that will only produce a single map (not for timeline/split view)
@@ -73,13 +75,13 @@ export const singleMapPeriods = [
 export const invalidSplitViewPeriods = ['LAST_52_WEEKS', 'WEEKS_THIS_YEAR'];
 
 // All period names
-export const periodNames = {
-    ...periodTypes.reduce((obj, { id, name }) => {
+export const getPeriodNames = () => ({
+    ...getPeriodTypes().reduce((obj, { id, name }) => {
         obj[id] = name;
         return obj;
     }, {}),
-    ...relativePeriods.reduce((obj, { id, name }) => {
+    ...getRelativePeriods().reduce((obj, { id, name }) => {
         obj[id] = name;
         return obj;
     }, {}),
-};
+});

--- a/src/epics/favorites.js
+++ b/src/epics/favorites.js
@@ -22,12 +22,12 @@ export const saveFavorite = (action$, store) =>
             config
         ).then(() =>
             setMessage(
-                `${i18n.t('Favorite')} "${config.name}" ${i18n.t('is saved')}.`
+                i18n.t('Map "{{name}}" is saved.', { name: config.name })
             )
         );
     });
 
-// Save new favorite
+// Save new map
 export const saveNewFavorite = (action$, store) =>
     action$
         .ofType(types.FAVORITE_SAVE_NEW)
@@ -59,11 +59,7 @@ export const saveNewFavorite = (action$, store) =>
             name
                 ? [
                       setMapProps({ id, name, description }),
-                      setMessage(
-                          `${i18n.t('Favorite')} "${name}" ${i18n.t(
-                              'is saved'
-                          )}.`
-                      ),
+                      setMessage(i18n.t('Map "{{name}}" is saved.', { name })),
                   ]
                 : [setMessage(`${i18n.t('Error')}: ${message}`)]
         );

--- a/src/epics/favorites.js
+++ b/src/epics/favorites.js
@@ -6,6 +6,8 @@ import { setMessage } from '../actions/message';
 import { apiFetch } from '../util/api';
 import { cleanMapConfig } from '../util/favorites';
 
+const getSavedMessage = name => i18n.t('Map "{{name}}" is saved.', { name });
+
 // Save existing favorite
 export const saveFavorite = (action$, store) =>
     action$.ofType(types.FAVORITE_SAVE).concatMap(() => {
@@ -20,11 +22,7 @@ export const saveFavorite = (action$, store) =>
             `/maps/${config.id}?skipTranslations=true&skipSharing=true`,
             'PUT',
             config
-        ).then(() =>
-            setMessage(
-                i18n.t('Map "{{name}}" is saved.', { name: config.name })
-            )
-        );
+        ).then(() => setMessage(getSavedMessage(config.name)));
     });
 
 // Save new map
@@ -59,7 +57,7 @@ export const saveNewFavorite = (action$, store) =>
             name
                 ? [
                       setMapProps({ id, name, description }),
-                      setMessage(i18n.t('Map "{{name}}" is saved.', { name })),
+                      setMessage(getSavedMessage(name)),
                   ]
                 : [setMessage(`${i18n.t('Error')}: ${message}`)]
         );

--- a/src/epics/layers.js
+++ b/src/epics/layers.js
@@ -7,7 +7,7 @@ import { errorActionCreator } from '../actions/helpers';
 import { fetchLayer } from '../loaders/layers';
 import { drillUpDown } from '../util/map';
 import { getPeriodFromFilters } from '../util/analytics';
-import { relativePeriods } from '../constants/periods';
+import { getRelativePeriods } from '../constants/periods';
 
 const isNewLayer = config => config.id === undefined;
 
@@ -50,7 +50,8 @@ export const setRelativePeriodDate = (action$, store) =>
                 .map.mapViews.filter(config => {
                     const period = getPeriodFromFilters(config.filters);
                     return (
-                        period && relativePeriods.find(p => p.id === period.id)
+                        period &&
+                        getRelativePeriods().find(p => p.id === period.id)
                     );
                 })
                 .map(config => ({

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -1,18 +1,20 @@
-const datasets = {
+import i18n from '@dhis2/d2-i18n';
+
+const getDatasets = () => ({
     'USGS/SRTMGL1_003': {
-        name: 'Elevation',
+        name: i18n.t('Elevation'),
         band: 'elevation',
         mask: true,
         legend: {
-            unit: 'metres',
-            description: 'Elevation above sea-level.',
+            unit: i18n.t('metres'),
+            description: i18n.t('Elevation above sea-level.'),
             source: 'NASA / USGS / JPL-Caltech / Google Earth Engine',
             sourceUrl:
                 'https://explorer.earthengine.google.com/#detail/USGS%2FSRTMGL1_003',
         },
     },
     'WorldPop/POP': {
-        name: 'Population density',
+        name: i18n.t('Population density'),
         aggregation: 'mosaic',
         mask: true,
         methods: {
@@ -24,46 +26,49 @@ const datasets = {
             return Math.round(value);
         },
         legend: {
-            unit: 'people per km²',
-            description:
-                'Population density estimates with national totals adjusted to match UN population division estimates.',
+            unit: i18n.t('people per km²'),
+            description: i18n.t(
+                'Population density estimates with national totals adjusted to match UN population division estimates.'
+            ),
             source: 'WorldPop / Google Earth Engine',
             sourceUrl:
                 'https://explorer.earthengine.google.com/#detail/WorldPop%2FPOP',
         },
     },
     'NOAA/DMSP-OLS/NIGHTTIME_LIGHTS': {
-        name: 'Nighttime lights',
+        name: i18n.t('Nighttime lights'),
         band: 'stable_lights',
         mask: true,
         popup: '{name}: {value}',
         legend: {
-            unit: 'light intensity',
-            description:
-                'Light intensity from cities, towns, and other sites with persistent lighting, including gas flares.',
+            unit: i18n.t('light intensity'),
+            description: i18n.t(
+                'Light intensity from cities, towns, and other sites with persistent lighting, including gas flares.'
+            ),
             source: 'NOAA / Google Earth Engine',
             sourceUrl:
                 'https://explorer.earthengine.google.com/#detail/NOAA%2FDMSP-OLS%2FNIGHTTIME_LIGHTS',
         },
     },
     'UCSB-CHG/CHIRPS/PENTAD': {
-        name: 'Precipitation',
+        name: i18n.t('Precipitation'),
         band: 'precipitation',
         mask: true,
         value(value) {
             return value.toFixed(1);
         },
         legend: {
-            unit: 'millimeter',
-            description:
-                'Precipitation collected from satellite and weather stations on the ground.',
+            unit: i18n.t('millimeter'),
+            description: i18n.t(
+                'Precipitation collected from satellite and weather stations on the ground.'
+            ),
             source: 'UCSB / CHG / Google Earth Engine',
             sourceUrl:
                 'https://explorer.earthengine.google.com/#detail/UCSB-CHG%2FCHIRPS%2FPENTAD',
         },
     },
     'MODIS/006/MOD11A2': {
-        name: 'Temperature',
+        name: i18n.t('Temperature'),
         band: 'LST_Day_1km',
         mask: true,
         methods: {
@@ -76,16 +81,17 @@ const datasets = {
         },
         popup: '{name}: {value}{unit}',
         legend: {
-            unit: '°C during daytime',
-            description:
-                'Land surface temperatures collected from satellite. Blank spots will appear in areas with a persistent cloud cover.',
+            unit: i18n.t('°C during daytime'),
+            description: i18n.t(
+                'Land surface temperatures collected from satellite. Blank spots will appear in areas with a persistent cloud cover.'
+            ),
             source: 'NASA LP DAAC / Google Earth Engine',
             sourceUrl:
                 'https://explorer.earthengine.google.com/#detail/MODIS%2FMOD11A2',
         },
     },
     'MODIS/051/MCD12Q1': {
-        name: 'Landcover',
+        name: i18n.t('Landcover'),
         band: 'Land_Cover_Type_1',
         params: {
             min: 0,
@@ -95,91 +101,94 @@ const datasets = {
         },
         mask: false,
         legend: {
-            description: 'Distinct landcover types collected from satellites.',
+            description: i18n.t(
+                'Distinct landcover types collected from satellites.'
+            ),
             source: 'NASA LP DAAC / Google Earth Engine',
             sourceUrl:
                 'https://code.earthengine.google.com/dataset/MODIS/051/MCD12Q1',
             items: [
                 {
                     color: '#aec3d6',
-                    name: 'Water',
+                    name: i18n.t('Water'),
                 },
                 {
                     color: '#162103',
-                    name: 'Evergreen Needleleaf forest',
+                    name: i18n.t('Evergreen Needleleaf forest'),
                 },
                 {
                     color: '#235123',
-                    name: 'Evergreen Broadleaf forest',
+                    name: i18n.t('Evergreen Broadleaf forest'),
                 },
                 {
                     color: '#399b38',
-                    name: 'Deciduous Needleleaf forest',
+                    name: i18n.t('Deciduous Needleleaf forest'),
                 },
                 {
                     color: '#38eb38',
-                    name: 'Deciduous Broadleaf forest',
+                    name: i18n.t('Deciduous Broadleaf forest'),
                 },
                 {
                     color: '#39723b',
-                    name: 'Mixed forest',
+                    name: i18n.t('Mixed forest'),
                 },
                 {
                     color: '#6a2424',
-                    name: 'Closed shrublands',
+                    name: i18n.t('Closed shrublands'),
                 },
                 {
                     color: '#c3a55f',
-                    name: 'Open shrublands',
+                    name: i18n.t('Open shrublands'),
                 },
                 {
                     color: '#b76124',
-                    name: 'Woody savannas',
+                    name: i18n.t('Woody savannas'),
                 },
                 {
                     color: '#d99125',
-                    name: 'Savannas',
+                    name: i18n.t('Savannas'),
                 },
                 {
                     color: '#92af1f',
-                    name: 'Grasslands',
+                    name: i18n.t('Grasslands'),
                 },
                 {
                     color: '#10104c',
-                    name: 'Permanent wetlands',
+                    name: i18n.t('Permanent wetlands'),
                 },
                 {
                     color: '#cdb400',
-                    name: 'Croplands',
+                    name: i18n.t('Croplands'),
                 },
                 {
                     color: '#cc0202',
-                    name: 'Urban and built-up',
+                    name: i18n.t('Urban and built-up'),
                 },
                 {
                     color: '#332808',
-                    name: 'Cropland/Natural vegetation mosaic',
+                    name: i18n.t('Cropland/Natural vegetation mosaic'),
                 },
                 {
                     color: '#d7cdcc',
-                    name: 'Snow and ice',
+                    name: i18n.t('Snow and ice'),
                 },
                 {
                     color: '#f7e174',
-                    name: 'Barren or sparsely vegetated',
+                    name: i18n.t('Barren or sparsely vegetated'),
                 },
                 {
                     color: '#743411',
-                    name: 'Unclassified',
+                    name: i18n.t('Unclassified'),
                 },
             ],
         },
         popup: '{name}: {value}',
     },
-};
+});
 
 // Returns a promise
 const earthEngineLoader = async config => {
+    const datasets = getDatasets();
     let layerConfig = {};
     let dataset;
 

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -139,7 +139,7 @@ const thematicLoader = async config => {
 
             alert = createAlert(
                 orgUnits.length === 1
-                    ? names[orgUnits[0].id] || i18n.t(orgUnits[0].name)
+                    ? names[orgUnits[0].id] || orgUnits[0].name
                     : i18n.t('Selected org units'),
                 i18n.t('No coordinates found')
             );

--- a/src/reducers/layers.js
+++ b/src/reducers/layers.js
@@ -1,41 +1,42 @@
+import i18n from '@dhis2/d2-i18n';
 import * as types from '../constants/actionTypes';
 
-const defaultLayers = [
+const defaultLayers = () => [
     {
         layer: 'thematic',
-        type: 'Thematic',
+        type: i18n.t('Thematic'),
         img: 'images/thematic.png',
         opacity: 0.9,
     },
     {
         layer: 'event',
-        type: 'Events',
+        type: i18n.t('Events'),
         img: 'images/events.png',
         opacity: 0.8,
         eventClustering: true,
     },
     {
         layer: 'trackedEntity',
-        type: 'Tracked entities',
+        type: i18n.t('Tracked entities'),
         img: 'images/trackedentities.png',
         opacity: 0.5,
     },
     {
         layer: 'facility',
-        type: 'Facilities',
+        type: i18n.t('Facilities'),
         img: 'images/facilities.png',
         opacity: 1,
     },
     {
         layer: 'boundary',
-        type: 'Boundaries',
+        type: i18n.t('Boundaries'),
         img: 'images/boundaries.png',
         opacity: 1,
     },
     {
         layer: 'earthEngine',
         datasetId: 'WorldPop/POP',
-        type: 'Population density',
+        type: i18n.t('Population density'),
         img: 'images/population.png',
         params: {
             min: 0,
@@ -47,7 +48,7 @@ const defaultLayers = [
     {
         layer: 'earthEngine',
         datasetId: 'USGS/SRTMGL1_003',
-        type: 'Elevation',
+        type: i18n.t('Elevation'),
         img: 'images/elevation.png',
         params: {
             min: 0,
@@ -59,7 +60,7 @@ const defaultLayers = [
     {
         layer: 'earthEngine',
         datasetId: 'MODIS/006/MOD11A2',
-        type: 'Temperature',
+        type: i18n.t('Temperature'),
         img: 'images/temperature.png',
         params: {
             min: 0,
@@ -71,7 +72,7 @@ const defaultLayers = [
     {
         layer: 'earthEngine',
         datasetId: 'UCSB-CHG/CHIRPS/PENTAD',
-        type: 'Precipitation',
+        type: i18n.t('Precipitation'),
         img: 'images/precipitation.png',
         params: {
             min: 0,
@@ -83,14 +84,14 @@ const defaultLayers = [
     {
         layer: 'earthEngine',
         datasetId: 'MODIS/051/MCD12Q1',
-        type: 'Landcover',
+        type: i18n.t('Landcover'),
         img: 'images/landcover.png',
         opacity: 0.9,
     },
     {
         layer: 'earthEngine',
         datasetId: 'NOAA/DMSP-OLS/NIGHTTIME_LIGHTS',
-        type: 'Nighttime lights',
+        type: i18n.t('Nighttime lights'),
         img: 'images/nighttime.png',
         params: {
             min: 0,
@@ -101,11 +102,13 @@ const defaultLayers = [
     },
 ];
 
-const layers = (state = defaultLayers, action) => {
+const layers = (state, action) => {
+    const prevState = state || defaultLayers();
+
     switch (action.type) {
         case types.EXTERNAL_LAYER_ADD:
             return [
-                ...state,
+                ...prevState,
                 {
                     ...action.payload,
                     isVisible: true,
@@ -113,10 +116,10 @@ const layers = (state = defaultLayers, action) => {
             ];
 
         case types.EXTERNAL_LAYER_REMOVE:
-            return state.filter(layer => layer.id !== action.id);
+            return prevState.filter(layer => layer.id !== action.id);
 
         default:
-            return state;
+            return prevState;
     }
 };
 

--- a/src/util/analytics.js
+++ b/src/util/analytics.js
@@ -148,7 +148,7 @@ export const removePeriodFromFilters = (filters = []) => [
     ...filters.filter(f => f.dimension !== 'pe'),
 ];
 
-export const getPeriodNameFromId = id => i18n.t(periodNames[id]);
+export const getPeriodNameFromId = id => periodNames()[id];
 
 export const setFiltersFromPeriod = (filters, period) => [
     ...removePeriodFromFilters(filters),


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8658

The PR wraps non-translatable strings in `i18n.t()`. It is also a larger refactor to avoid using variables directly in `i18n.t()`, as these strings are not identified when the localisation files are generated.

This regex can be used to identify translation strings in Visual Studio Code which are not properly formatted: `i18n.t\([^'"]`