### PR TITLE
fix: set width of fullscreen container

### DIFF
--- a/src/components/map/MapContainer.js
+++ b/src/components/map/MapContainer.js
@@ -16,6 +16,8 @@ import {
 const styles = {
     container: {
         height: '100%',
+        width: '100%',
+        backgroundColor: '#fff',
     },
     download: {
         // Roboto font is not loaded by dom-to-image => switch to Arial

--- a/src/components/map/MapContainer.js
+++ b/src/components/map/MapContainer.js
@@ -17,7 +17,6 @@ const styles = {
     container: {
         height: '100%',
         width: '100%',
-        backgroundColor: '#fff',
     },
     download: {
         // Roboto font is not loaded by dom-to-image => switch to Arial

--- a/src/components/plugin/Plugin.js
+++ b/src/components/plugin/Plugin.js
@@ -12,6 +12,7 @@ const styles = {
     root: {
         position: 'relative',
         height: '100%',
+        width: '100%',
         fontFamily: 'Roboto, Helvetica, Arial, sans-serif',
     },
 };


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8713

The reason fullscreen was not working in Safari is that div elements don't have width 100% by default, so the fix was to add it, both to the app container and the plugin. 

Map in app opened in fullscreen in Safari:
<img width="2048" alt="Screenshot 2020-04-24 at 16 18 46 (3)" src="https://user-images.githubusercontent.com/548708/80222600-6562df80-8647-11ea-87c0-6b778858017d.png">

Plugin map opened in fullscreen in Safari:
<img width="2048" alt="Screenshot 2020-04-24 at 16 18 10 (3)" src="https://user-images.githubusercontent.com/548708/80222595-6267ef00-8647-11ea-9245-41a64fc2d2ab.png">

Before this fix the fullscreen in Safari was black, as the map container didn't take any horizontal space. 
