### PR TITLE
fix: show layer name for when loading fails, 2.33 backport (DHIS2-8479)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-11-20T11:07:38.479Z\n"
-"PO-Revision-Date: 2019-11-20T11:07:38.479Z\n"
+"POT-Creation-Date: 2020-04-29T15:19:40.591Z\n"
+"PO-Revision-Date: 2020-04-29T15:19:40.591Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -616,6 +616,9 @@ msgid "No data found"
 msgstr ""
 
 msgid "Facilities"
+msgstr ""
+
+msgid "Thematic layer"
 msgstr ""
 
 msgid "Selected org units"

--- a/src/components/plugin/Plugin.js
+++ b/src/components/plugin/Plugin.js
@@ -16,10 +16,7 @@ const styles = {
     },
 };
 
-const defaultBounds = [
-    [-18.7, -34.9],
-    [50.2, 35.9],
-];
+const defaultBounds = [[-18.7, -34.9], [50.2, 35.9]];
 
 class Plugin extends Component {
     static propTypes = {

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -26,6 +26,18 @@ import {
 } from '../constants/layers';
 
 const thematicLoader = async config => {
+    const {
+        columns,
+        rows,
+        radiusLow = DEFAULT_RADIUS_LOW,
+        radiusHigh = DEFAULT_RADIUS_HIGH,
+        classes,
+        colorScale,
+        renderingStrategy = 'SINGLE',
+    } = config;
+
+    const dataItem = getDataItemFromColumns(columns);
+
     let error;
 
     const response = await loadData(config).catch(err => {
@@ -40,23 +52,14 @@ const thematicLoader = async config => {
                       alerts: [createAlert(i18n.t('Error'), error.message)],
                   }
                 : {}),
+            name: dataItem ? dataItem.name : i18n.t('Thematic layer'),
+            isExpanded: true,
             isLoaded: true,
             isVisible: true,
         };
     }
 
     const [features, data] = response;
-
-    const {
-        columns,
-        rows,
-        radiusLow = DEFAULT_RADIUS_LOW,
-        radiusHigh = DEFAULT_RADIUS_HIGH,
-        classes,
-        colorScale,
-        renderingStrategy = 'SINGLE',
-    } = config;
-
     const isSingle = renderingStrategy === 'SINGLE';
     const period = getPeriodFromFilters(config.filters);
     const periods = getPeriodsFromMetaData(data.metaData);
@@ -70,7 +73,6 @@ const thematicLoader = async config => {
     const orderedValues = getOrderedValues(data);
     const minValue = orderedValues[0];
     const maxValue = orderedValues[orderedValues.length - 1];
-    const dataItem = getDataItemFromColumns(columns);
     const name = names[dataItem.id];
     let legendSet = config.legendSet;
     let method = legendSet ? CLASSIFICATION_PREDEFINED : config.method; // Favorites often have wrong method


### PR DESCRIPTION
This is a partly backport of https://jira.dhis2.org/browse/DHIS2-8479

Original PR: #496 

The app crash is not present in Maps 2.33, but we don't show the layer name in the left panel if the loading fails: 

<img width="483" alt="Screenshot 2020-04-28 at 21 36 52" src="https://user-images.githubusercontent.com/548708/80530269-0a0f5500-8999-11ea-930c-69b0c48a1017.png">

With this PR, the layer name will show and the panel will be expanded: 

<img width="497" alt="Screenshot 2020-04-28 at 21 38 42" src="https://user-images.githubusercontent.com/548708/80530319-20b5ac00-8999-11ea-92a5-461fe9c31c07.png">

This makes it easier for the user to edit and correct the layer. 