### PR TITLE
fix: show layer name for when loading fails, 2.32 backport (DHIS2-8479)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2019-11-20T13:26:46.609Z\n"
-"PO-Revision-Date: 2019-11-20T13:26:46.609Z\n"
+"POT-Creation-Date: 2020-04-29T15:21:54.204Z\n"
+"PO-Revision-Date: 2020-04-29T15:21:54.205Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -601,6 +601,9 @@ msgid "No data found"
 msgstr ""
 
 msgid "Facilities"
+msgstr ""
+
+msgid "Thematic layer"
 msgstr ""
 
 msgid "Selected org units"

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -21,6 +21,17 @@ import { createAlert } from '../util/alerts';
 import { formatLocaleDate } from '../util/time';
 
 const thematicLoader = async config => {
+    const {
+        columns,
+        rows,
+        radiusLow,
+        radiusHigh,
+        classes,
+        colorScale,
+    } = config;
+
+    const dataItem = getDataItemFromColumns(columns);
+
     let error;
 
     const response = await loadData(config).catch(err => {
@@ -35,21 +46,14 @@ const thematicLoader = async config => {
                       alerts: [createAlert(i18n.t('Error'), error.message)],
                   }
                 : {}),
+            name: dataItem ? dataItem.name : i18n.t('Thematic layer'),
+            isExpanded: true,
             isLoaded: true,
             isVisible: true,
         };
     }
 
     const [features, data] = response;
-
-    const {
-        columns,
-        rows,
-        radiusLow,
-        radiusHigh,
-        classes,
-        colorScale,
-    } = config;
     const period = getPeriodFromFilters(config.filters);
     const dimensions = getValidDimensionsFromFilters(config.filters);
     const names = getApiResponseNames(data);
@@ -60,7 +64,6 @@ const thematicLoader = async config => {
     const orderedValues = getOrderedValues(data);
     const minValue = orderedValues[0];
     const maxValue = orderedValues[orderedValues.length - 1];
-    const dataItem = getDataItemFromColumns(columns);
     const name = names[dataItem.id];
     let legendSet = config.legendSet;
     let method = legendSet ? 1 : config.method; // Favorites often have wrong method


### PR DESCRIPTION
This is a partly backport of https://jira.dhis2.org/browse/DHIS2-8479

Original PR: #496

The app crash is not present in Maps 2.32, but we don't show the layer name in the left panel if the loading fails: 

<img width="540" alt="Screenshot 2020-04-28 at 22 03 11" src="https://user-images.githubusercontent.com/548708/80533325-bbb08500-899d-11ea-8ad8-f56b50a7931b.png">

With this PR, the layer name will show and the panel will be expanded: 

<img width="549" alt="Screenshot 2020-04-28 at 22 08 38" src="https://user-images.githubusercontent.com/548708/80533364-cb2fce00-899d-11ea-997f-5dc455c55a2d.png">

This makes it easier for the user to edit and correct the layer. 