### PR TITLE
fix: rename period names import

### DIFF
--- a/src/components/edit/LayerEdit.js
+++ b/src/components/edit/LayerEdit.js
@@ -104,7 +104,7 @@ class LayerEdit extends Component {
 
         const title = layer.id
             ? i18n.t('Edit {{name}} layer', { name })
-            : i18n.t('Add {{name}} layer', { name });
+            : i18n.t('Add new {{name}} layer', { name });
 
         return (
             <Dialog open={true} maxWidth="md" data-test="layeredit">

--- a/src/util/analytics.js
+++ b/src/util/analytics.js
@@ -1,7 +1,7 @@
 import i18n from '@dhis2/d2-i18n';
 import { sortBy, negate } from 'lodash/fp';
 import { isValidUid } from 'd2/uid';
-import { periodNames } from '../constants/periods';
+import { getPeriodNames } from '../constants/periods';
 import { dimConf } from '../constants/dimension';
 
 /* DIMENSIONS */
@@ -148,7 +148,7 @@ export const removePeriodFromFilters = (filters = []) => [
     ...filters.filter(f => f.dimension !== 'pe'),
 ];
 
-export const getPeriodNameFromId = id => periodNames()[id];
+export const getPeriodNameFromId = id => getPeriodNames()[id];
 
 export const setFiltersFromPeriod = (filters, period) => [
     ...removePeriodFromFilters(filters),


### PR DESCRIPTION
Small correction from #590: the `periodNames` import needs to be renamed to `getPeriodNames` after it was wrapped in a function:  https://github.com/dhis2/maps-app/blob/master/src/constants/periods.js#L78