### PR TITLE
fix: add missing translations (DHIS2-8658)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-05-12T20:38:15.293Z\n"
-"PO-Revision-Date: 2020-05-12T20:38:15.294Z\n"
+"POT-Creation-Date: 2020-05-12T20:48:33.602Z\n"
+"PO-Revision-Date: 2020-05-12T20:48:33.602Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -468,6 +468,9 @@ msgid "Indicator group"
 msgstr ""
 
 msgid "Interpretations"
+msgstr ""
+
+msgid "External basemap"
 msgstr ""
 
 msgid "Basemap"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-05-05T09:18:51.686Z\n"
-"PO-Revision-Date: 2020-05-05T09:18:51.687Z\n"
+"POT-Creation-Date: 2020-05-12T20:38:15.293Z\n"
+"PO-Revision-Date: 2020-05-12T20:38:15.294Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -24,6 +24,9 @@ msgid "Automatic"
 msgstr ""
 
 msgid "Predefined"
+msgstr ""
+
+msgid "Size"
 msgstr ""
 
 msgid "Data element group"
@@ -276,6 +279,24 @@ msgid "Remember to select the organisation unit level containing the facilities.
 msgstr ""
 
 msgid "Group set is required"
+msgstr ""
+
+msgid "event"
+msgstr ""
+
+msgid "tracked entity"
+msgstr ""
+
+msgid "facility"
+msgstr ""
+
+msgid "thematic"
+msgstr ""
+
+msgid "boundary"
+msgstr ""
+
+msgid "Earth Engine"
 msgstr ""
 
 msgid "Edit {{name}} layer"
@@ -595,6 +616,9 @@ msgstr ""
 msgid "Exit fullscreen"
 msgstr ""
 
+msgid "Finish measurement"
+msgstr ""
+
 msgid "ha"
 msgstr ""
 
@@ -760,6 +784,30 @@ msgid "Standard deviation"
 msgstr ""
 
 msgid "Variance"
+msgstr ""
+
+msgid "OSM Light"
+msgstr ""
+
+msgid "OSM Detailed"
+msgstr ""
+
+msgid "Google Streets"
+msgstr ""
+
+msgid "Google Hybrid"
+msgstr ""
+
+msgid "Bing Road"
+msgstr ""
+
+msgid "Bing Dark"
+msgstr ""
+
+msgid "Bing Aerial"
+msgstr ""
+
+msgid "Bing Aerial Labels"
 msgstr ""
 
 msgid "Equal intervals"

--- a/src/components/core/FontStyle.js
+++ b/src/components/core/FontStyle.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import i18n from '@dhis2/d2-i18n';
 import { withStyles } from '@material-ui/core/styles';
 import { IconButton } from '@material-ui/core';
 import BoldIcon from '@material-ui/icons/FormatBold';
@@ -42,7 +43,7 @@ const FontStyle = ({
             <TextField
                 id="size"
                 type="number"
-                label="Size"
+                label={i18n.t('Size')}
                 value={parseInt(
                     size !== undefined ? size : LABEL_FONT_SIZE,
                     10

--- a/src/components/edit/LayerEdit.js
+++ b/src/components/edit/LayerEdit.js
@@ -27,14 +27,14 @@ const layerType = {
     earthEngine: EarthEngineDialog,
 };
 
-const layerName = {
-    event: 'event',
-    trackedEntity: 'tracked entity',
-    facility: 'facility',
-    thematic: 'thematic',
-    boundary: 'boundary',
-    earthEngine: 'Earth Engine',
-};
+const layerName = () => ({
+    event: i18n.t('event'),
+    trackedEntity: i18n.t('tracked entity'),
+    facility: i18n.t('facility'),
+    thematic: i18n.t('thematic'),
+    boundary: i18n.t('boundary'),
+    earthEngine: i18n.t('Earth Engine'),
+});
 
 const styles = {
     title: {
@@ -95,7 +95,7 @@ class LayerEdit extends Component {
         }
 
         const type = layer.layer;
-        const name = layerName[type];
+        const name = layerName()[type];
         const LayerDialog = layerType[type];
 
         if (!LayerDialog) {

--- a/src/components/layers/basemaps/Basemap.js
+++ b/src/components/layers/basemaps/Basemap.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import i18n from '@dhis2/d2-i18n';
 import { withStyles } from '@material-ui/core/styles';
 
 const styles = theme => ({
@@ -54,38 +55,35 @@ const styles = theme => ({
     },
 });
 
-// TODO: Use ImageSelect.js component for selectable image
-const Basemap = ({ classes, id, img, name, isSelected, onClick }) => {
-    return (
+const Basemap = ({ classes, id, img, name, isSelected, onClick }) => (
+    <div
+        className={classes.container}
+        title={name}
+        onClick={() => onClick(id)}
+        data-test="basemaplistitem"
+    >
         <div
-            className={classes.container}
-            title={name}
-            onClick={() => onClick(id)}
-            data-test="basemaplistitem"
+            className={`${classes.imageContainer} ${
+                isSelected ? classes.selected : ''
+            }`}
+            data-test="basemaplistitem-img"
         >
-            <div
-                className={`${classes.imageContainer} ${
-                    isSelected ? classes.selected : ''
-                }`}
-                data-test="basemaplistitem-img"
-            >
-                {img ? (
-                    <img src={img} className={classes.image} />
-                ) : (
-                    <div className={classes.noImage}>External basemap</div>
-                )}
-            </div>
-            <div
-                className={`${classes.name} ${
-                    isSelected ? classes.nameSelected : ''
-                }`}
-                data-test="basemaplistitem-name"
-            >
-                {name}
-            </div>
+            {img ? (
+                <img src={img} className={classes.image} />
+            ) : (
+                <div className={classes.noImage}>External basemap</div>
+            )}
         </div>
-    );
-};
+        <div
+            className={`${classes.name} ${
+                isSelected ? classes.nameSelected : ''
+            }`}
+            data-test="basemaplistitem-name"
+        >
+            {i18n.t(name)}
+        </div>
+    </div>
+);
 
 Basemap.propTypes = {
     classes: PropTypes.object.isRequired,

--- a/src/components/layers/basemaps/Basemap.js
+++ b/src/components/layers/basemaps/Basemap.js
@@ -55,35 +55,40 @@ const styles = theme => ({
     },
 });
 
-const Basemap = ({ classes, id, img, name, isSelected, onClick }) => (
-    <div
-        className={classes.container}
-        title={name}
-        onClick={() => onClick(id)}
-        data-test="basemaplistitem"
-    >
+// TODO: Use ImageSelect.js component for selectable image
+const Basemap = ({ classes, id, img, name, isSelected, onClick }) => {
+    return (
         <div
-            className={`${classes.imageContainer} ${
-                isSelected ? classes.selected : ''
-            }`}
-            data-test="basemaplistitem-img"
+            className={classes.container}
+            title={name}
+            onClick={() => onClick(id)}
+            data-test="basemaplistitem"
         >
-            {img ? (
-                <img src={img} className={classes.image} />
-            ) : (
-                <div className={classes.noImage}>External basemap</div>
-            )}
+            <div
+                className={`${classes.imageContainer} ${
+                    isSelected ? classes.selected : ''
+                }`}
+                data-test="basemaplistitem-img"
+            >
+                {img ? (
+                    <img src={img} className={classes.image} />
+                ) : (
+                    <div className={classes.noImage}>
+                        {i18n.t('External basemap')}
+                    </div>
+                )}
+            </div>
+            <div
+                className={`${classes.name} ${
+                    isSelected ? classes.nameSelected : ''
+                }`}
+                data-test="basemaplistitem-name"
+            >
+                {i18n.t(name)}
+            </div>
         </div>
-        <div
-            className={`${classes.name} ${
-                isSelected ? classes.nameSelected : ''
-            }`}
-            data-test="basemaplistitem-name"
-        >
-            {i18n.t(name)}
-        </div>
-    </div>
-);
+    );
+};
 
 Basemap.propTypes = {
     classes: PropTypes.object.isRequired,

--- a/src/components/layers/basemaps/BasemapCard.js
+++ b/src/components/layers/basemaps/BasemapCard.js
@@ -86,7 +86,7 @@ const BasemapCard = props => {
                     title: classes.title,
                     subheader: classes.subheader,
                 }}
-                title={name}
+                title={i18n.t(name)}
                 subheader={subtitle}
                 action={
                     <Tooltip

--- a/src/components/map/mapLocale.js
+++ b/src/components/map/mapLocale.js
@@ -14,6 +14,7 @@ const getMapLocale = () => ({
     Distance: i18n.t('Distance'),
     'Enter fullscreen': i18n.t('Enter fullscreen'),
     'Exit fullscreen': i18n.t('Exit fullscreen'),
+    'Finish measurement': i18n.t('Finish measurement'),
     ha: i18n.t('ha'),
     km: i18n.t('km'),
     'Measure distances and areas': i18n.t('Measure distances and areas'),

--- a/src/constants/basemaps.js
+++ b/src/constants/basemaps.js
@@ -1,7 +1,9 @@
-export const defaultBasemaps = [
+import i18n from '@dhis2/d2-i18n';
+
+export const defaultBasemaps = () => [
     {
         id: 'osmLight',
-        name: 'OSM Light',
+        name: i18n.t('OSM Light'),
         img: 'images/osmlight.png',
         config: {
             type: 'tileLayer',
@@ -13,7 +15,7 @@ export const defaultBasemaps = [
     },
     {
         id: 'openStreetMap',
-        name: 'OSM Detailed',
+        name: i18n.t('OSM Detailed'),
         img: 'images/osm.png',
         config: {
             type: 'tileLayer',
@@ -24,7 +26,7 @@ export const defaultBasemaps = [
     },
     {
         id: 'googleStreets',
-        name: 'Google Streets',
+        name: i18n.t('Google Streets'),
         img: 'images/googlestreets.png',
         config: {
             type: 'googleLayer',
@@ -33,7 +35,7 @@ export const defaultBasemaps = [
     },
     {
         id: 'googleHybrid',
-        name: 'Google Hybrid',
+        name: i18n.t('Google Hybrid'),
         img: 'images/googlehybrid.jpeg',
         config: {
             type: 'googleLayer',
@@ -42,7 +44,7 @@ export const defaultBasemaps = [
     },
     {
         id: 'bingLight',
-        name: 'Bing Road',
+        name: i18n.t('Bing Road'),
         img: 'images/bingroad.png',
         config: {
             type: 'bingLayer',
@@ -53,7 +55,7 @@ export const defaultBasemaps = [
     },
     {
         id: 'bingDark',
-        name: 'Bing Dark',
+        name: i18n.t('Bing Dark'),
         img: 'images/bingdark.png',
         config: {
             type: 'bingLayer',
@@ -62,7 +64,7 @@ export const defaultBasemaps = [
     },
     {
         id: 'bingAerial',
-        name: 'Bing Aerial',
+        name: i18n.t('Bing Aerial'),
         img: 'images/bingaerial.jpeg',
         config: {
             type: 'bingLayer',
@@ -71,7 +73,7 @@ export const defaultBasemaps = [
     },
     {
         id: 'bingHybrid',
-        name: 'Bing Aerial Labels',
+        name: i18n.t('Bing Aerial Labels'),
         img: 'images/binghybrid.jpeg',
         config: {
             type: 'bingLayer',

--- a/src/map.js
+++ b/src/map.js
@@ -133,7 +133,7 @@ const PluginContainer = () => {
                     },
                 };
             } else {
-                basemap = defaultBasemaps.find(map => map.id === basemapId);
+                basemap = defaultBasemaps().find(map => map.id === basemapId);
             }
 
             if (basemapId.substring(0, 4) === 'bing') {

--- a/src/reducers/basemaps.js
+++ b/src/reducers/basemaps.js
@@ -2,7 +2,7 @@ import { defaultBasemaps } from '../constants/basemaps';
 
 import * as types from '../constants/actionTypes';
 
-const basemaps = (state = defaultBasemaps, action) => {
+const basemaps = (state = defaultBasemaps(), action) => {
     switch (action.type) {
         case types.BASEMAP_ADD:
             return [...state, action.payload];

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -12,7 +12,6 @@ const defaultState = {
         isVisible: true,
         isExpanded: true,
         opacity: 1,
-        subtitle: 'Basemap',
     },
     mapViews: [],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -14570,4 +14570,3 @@ yauzl@2.4.1:
   integrity sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=
   dependencies:
     fd-slicer "~1.0.1"
-    

--- a/yarn.lock
+++ b/yarn.lock
@@ -14570,3 +14570,4 @@ yauzl@2.4.1:
   integrity sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=
   dependencies:
     fd-slicer "~1.0.1"
+    

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,12 +76,12 @@
     js-tokens "^4.0.0"
 
 "@babel/runtime-corejs2@^7.4.5":
-  version "7.8.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.8.4.tgz#e4ed23a8be40fa26b97fb649deaba8144c987593"
-  integrity sha512-7jU2FgNqNHX6yTuU/Dr/vH5/O8eVL9U85MG5aDw1LzGfCvvhXC1shdXfVzCQDsoY967yrAKeLujRv7l8BU+dZA==
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.9.6.tgz#acd5d6351384cc2828dc211aa5426a90476bf4a8"
+  integrity sha512-TcdM3xc7weMrwTawuG3BTjtVE3mQLXUPQ9CxTbSKOrhn3QAcqCJ2fz+IIv25wztzUnhNZat7hr655YJa61F3zg==
   dependencies:
     core-js "^2.6.5"
-    regenerator-runtime "^0.13.2"
+    regenerator-runtime "^0.13.4"
 
 "@babel/runtime-corejs3@^7.8.3":
   version "7.9.6"
@@ -3857,9 +3857,9 @@ crypto-browserify@^3.11.0:
     randomfill "^1.0.3"
 
 css-box-model@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.0.tgz#3a26377b4162b3200d2ede4b064ec5b6a75186d0"
-  integrity sha512-lri0br+jSNV0kkkiGEp9y9y3Njq2PmpqbeGWRFQJuZteZzY9iC9GZhQ8Y4WpPwM/2YocjHePxy14igJY7YKzkA==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
+  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
   dependencies:
     tiny-invariant "^1.0.6"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,12 +76,12 @@
     js-tokens "^4.0.0"
 
 "@babel/runtime-corejs2@^7.4.5":
-  version "7.9.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.9.6.tgz#acd5d6351384cc2828dc211aa5426a90476bf4a8"
-  integrity sha512-TcdM3xc7weMrwTawuG3BTjtVE3mQLXUPQ9CxTbSKOrhn3QAcqCJ2fz+IIv25wztzUnhNZat7hr655YJa61F3zg==
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.8.4.tgz#e4ed23a8be40fa26b97fb649deaba8144c987593"
+  integrity sha512-7jU2FgNqNHX6yTuU/Dr/vH5/O8eVL9U85MG5aDw1LzGfCvvhXC1shdXfVzCQDsoY967yrAKeLujRv7l8BU+dZA==
   dependencies:
     core-js "^2.6.5"
-    regenerator-runtime "^0.13.4"
+    regenerator-runtime "^0.13.2"
 
 "@babel/runtime-corejs3@^7.8.3":
   version "7.9.6"
@@ -3857,9 +3857,9 @@ crypto-browserify@^3.11.0:
     randomfill "^1.0.3"
 
 css-box-model@^1.1.2:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.1.tgz#59951d3b81fd6b2074a62d49444415b0d2b4d7c1"
-  integrity sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-box-model/-/css-box-model-1.2.0.tgz#3a26377b4162b3200d2ede4b064ec5b6a75186d0"
+  integrity sha512-lri0br+jSNV0kkkiGEp9y9y3Njq2PmpqbeGWRFQJuZteZzY9iC9GZhQ8Y4WpPwM/2YocjHePxy14igJY7YKzkA==
   dependencies:
     tiny-invariant "^1.0.6"
 


### PR DESCRIPTION
This PR adds i18n support for strings that couldn't be translated in the maps app. 

`i18n.t(name)` will not be discovered by the translation system, but all names are translated in basemaps.js, but this reducer is evaluated before the language setting is available. Will fix better when we switch to the app plattform. 

`subtitle: 'Basemap'` is removed as this is the default value defined here: https://github.com/dhis2/maps-app/blob/master/src/components/layers/basemaps/BasemapCard.js#L71