### PR TITLE
fix: plugin rendering class names (DHIS2-8880)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "34.0.26",
+    "version": "34.0.27",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/map.js
+++ b/src/map.js
@@ -15,6 +15,7 @@ import {
     getExternalLayer,
     getBingMapsApiKey,
 } from './util/requests';
+import { getRenderingStrategy } from './util/analytics';
 import { fetchLayer } from './loaders/layers';
 import { translateConfig } from './util/favorites';
 import { defaultBasemaps } from './constants/basemaps';
@@ -166,12 +167,13 @@ const PluginContainer = () => {
     function drawMap(config) {
         if (config.el && !isUnmounted(config.el)) {
             const domEl = document.getElementById(config.el);
+            const rendering = getRenderingStrategy(config);
 
             if (domEl) {
                 const ref = createRef();
 
                 const generateClassName = createGenerateClassName({
-                    productionPrefix: 'map-plugin-',
+                    productionPrefix: `map-plugin-${rendering}`,
                 });
 
                 render(

--- a/src/util/analytics.js
+++ b/src/util/analytics.js
@@ -283,3 +283,17 @@ export const getApiResponseNames = ({ metaData, headers }) => ({
     true: i18n.t('Yes'),
     false: i18n.t('No'),
 });
+
+// Returns the rendering strategy used
+export const getRenderingStrategy = ({ mapViews }) => {
+    if (Array.isArray(mapViews)) {
+        if (mapViews.some(view => view.renderingStrategy === 'TIMELINE')) {
+            return 'timeline';
+        } else if (
+            mapViews.some(view => view.renderingStrategy === 'SPLIT_BY_PERIOD')
+        ) {
+            return 'split-by-period';
+        }
+    }
+    return 'single';
+};


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-8880

Problem description: When multiple maps are included on the same dashboard the CSS class names are shared between different maps, while the styling is different between single, timeline and split view maps. 

The styles from the different map types are combined as they share the same class names (`map-plugin-x`):
<img width="1808" alt="Screenshot 2020-05-19 at 14 03 22" src="https://user-images.githubusercontent.com/548708/82324209-8e258d00-99d9-11ea-9eb1-e711273c7f69.png">

The suggested fix is to include "rendering strategy" in the class name prefix to avoid this naming conflict (`map-plugin-single-x`, `map-plugin-timeline-x`, `map-plugin-split-by-period-x`)

The fix is not yet tested on the Dashboard. Easier to test when this fix is merged. If the fix works, I will also backport to 2.34 and 2.33.