### PR TITLE
fix: plugin rendering class names 2.34 backport (DHIS2-8880)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "34.0.28",
+    "version": "34.0.29",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/map.js
+++ b/src/map.js
@@ -15,6 +15,7 @@ import {
     getExternalLayer,
     getBingMapsApiKey,
 } from './util/requests';
+import { getRenderingStrategy } from './util/analytics';
 import { fetchLayer } from './loaders/layers';
 import { translateConfig } from './util/favorites';
 import { defaultBasemaps } from './constants/basemaps';
@@ -166,12 +167,13 @@ const PluginContainer = () => {
     function drawMap(config) {
         if (config.el && !isUnmounted(config.el)) {
             const domEl = document.getElementById(config.el);
+            const rendering = getRenderingStrategy(config);
 
             if (domEl) {
                 const ref = createRef();
 
                 const generateClassName = createGenerateClassName({
-                    productionPrefix: 'map-plugin-',
+                    productionPrefix: `map-plugin-${rendering}`,
                 });
 
                 render(

--- a/src/util/analytics.js
+++ b/src/util/analytics.js
@@ -283,3 +283,17 @@ export const getApiResponseNames = ({ metaData, headers }) => ({
     true: i18n.t('Yes'),
     false: i18n.t('No'),
 });
+
+// Returns the rendering strategy used
+export const getRenderingStrategy = ({ mapViews }) => {
+    if (Array.isArray(mapViews)) {
+        if (mapViews.some(view => view.renderingStrategy === 'TIMELINE')) {
+            return 'timeline';
+        } else if (
+            mapViews.some(view => view.renderingStrategy === 'SPLIT_BY_PERIOD')
+        ) {
+            return 'split-by-period';
+        }
+    }
+    return 'single';
+};


### PR DESCRIPTION
2.34 backport of #755 

Fixes: https://jira.dhis2.org/browse/DHIS2-8880

I've tested that the fix works fine in master/v35: 
<img width="1429" alt="Screenshot 2020-05-20 at 22 29 27" src="https://user-images.githubusercontent.com/548708/82495498-78a08800-9aeb-11ea-86c8-b80a4b80afed.png">
