### PR TITLE
fix: set proper base url for production

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "33.0.27",
+    "version": "33.0.28",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -6,6 +6,7 @@ import { Provider } from '@dhis2/app-runtime';
 import { HeaderBar } from '@dhis2/ui-widgets';
 import { CssReset } from '@dhis2/ui-core';
 import mui3theme from '@dhis2/d2-ui-core/theme/mui3.theme';
+import { config } from 'd2';
 import AppMenu from './AppMenu';
 import LayersPanel from '../layers/LayersPanel';
 import LayersToggle from '../layers/LayersToggle';
@@ -43,7 +44,7 @@ export class App extends Component {
         return (
             <Provider
                 config={{
-                    baseUrl: DHIS_CONFIG.baseUrl,
+                    baseUrl: config.appUrl,
                     apiVersion: '33',
                 }}
             >


### PR DESCRIPTION
This PR solves an issue with api requests sent from the headerbar in production. The base url is not set properly: 

<img width="625" alt="Screenshot 2020-05-28 at 11 17 59" src="https://user-images.githubusercontent.com/548708/83123415-2952ec80-a0d5-11ea-9dea-db8b578502f6.png">

This fix uses the URL defined here: https://github.com/dhis2/maps-app/blob/v33/src/app.js#L34 (excludes the `/api/xx` part which is added by the app-runtime Provider). 

We're moving away from d2 config, but for 2.33 we can still use it to avoid defining the base url multiple places. 