### PR TITLE
fix: add missing translation strings

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-05-12T22:15:44.081Z\n"
-"PO-Revision-Date: 2020-05-12T22:15:44.081Z\n"
+"POT-Creation-Date: 2020-05-28T11:58:20.945Z\n"
+"PO-Revision-Date: 2020-05-28T11:58:20.945Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -69,6 +69,9 @@ msgid "Data set"
 msgstr ""
 
 msgid "Index"
+msgstr ""
+
+msgid "Name"
 msgstr ""
 
 msgid "Value"
@@ -512,6 +515,9 @@ msgid "{{name}} deleted."
 msgstr ""
 
 msgid "Filters"
+msgstr ""
+
+msgid "Source"
 msgstr ""
 
 msgid "Edit"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "32.0.39",
+    "version": "32.0.40",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -104,7 +104,7 @@ class DataTable extends Component {
                 />
                 <Column
                     dataKey="name"
-                    label="Name"
+                    label={i18n.t('Name')}
                     width={100}
                     headerRenderer={props => (
                         <ColumnHeader type="string" {...props} />

--- a/src/components/layers/legend/Legend.js
+++ b/src/components/layers/legend/Legend.js
@@ -73,7 +73,7 @@ const Legend = ({
         )}
         {source && (
             <div className={classes.source}>
-                Source:&nbsp;
+                {i18n.t('Source')}:&nbsp;
                 {sourceUrl ? (
                     <a href={sourceUrl}>{source}</a>
                 ) : (


### PR DESCRIPTION
2.32 backport of #786 (excluding the maps-gl update which is not present in this version)