### PR TITLE
fix: keep created and lastUpdated map properties (DHIS2-9060)

### DIFF
--- a/src/util/favorites.js
+++ b/src/util/favorites.js
@@ -15,6 +15,8 @@ const validMapProperties = [
     'user',
     'zoom',
     'publicAccess',
+    'created',
+    'lastUpdated',
 ];
 
 const validLayerProperties = [
@@ -26,6 +28,7 @@ const validLayerProperties = [
     'colorScale',
     'columns',
     'config',
+    'created',
     'datasetId',
     'displayName',
     'endDate',
@@ -42,6 +45,7 @@ const validLayerProperties = [
     'labelFontStyle',
     'labelFontWeight',
     'labelFontColor',
+    'lastUpdated',
     'layer',
     'legendSet',
     'method',

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -35,6 +35,8 @@ const baseFields = [
     'zoom',
     'basemap',
     'publicAccess',
+    'created',
+    'lastUpdated',
 ];
 
 const analysisFields = async () => {
@@ -52,9 +54,7 @@ const analysisFields = async () => {
         'legendSet[id,displayName~rename(name)]',
         'trackedEntityType[id,displayName~rename(name)]',
         'organisationUnitSelectionMode',
-        '!lastUpdated',
         '!href',
-        '!created',
         '!publicAccess',
         '!rewindRelativePeriods',
         '!userOrganisationUnit',


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-9060

This PR fixes an issue reported by HISP India. They we're not allowed to resave the map as they had a constraint in the db that "created" and "lastupdated" could not be NULL (it is likely that other DHIS2 users have this restriction as well). The backend will set all properties to NULL if they are not passed with PUT request. This used to work, and I'm not sure if the backend logic was changed at some time. This could potentially set several fields unintentional to NULL, and @maikelarabori will check it out. Maybe we should switch to a PATCH request?

For Maps, we currently restrict the properties we load and save for a map. We should not change this behaviour for released versions as it might create other bugs. The fix here is to include "created" and "lastUpdated" properties both when we load and save a map, which should be safe.

Before this fix the created date is updated wrongly when not passed back in the PUT request:
![Screenshot 2020-06-22 at 13 56 44](https://user-images.githubusercontent.com/548708/85284928-48ecf300-b490-11ea-88b1-66b8d464d439.png)

After this fix the created date is kept:
![Screenshot 2020-06-22 at 13 56 20](https://user-images.githubusercontent.com/548708/85290657-a5084500-b499-11ea-9560-d5212cc679a2.png)



