### PR TITLE
fix: allow uid to idenitfy org unit levels (TECH-427)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "abortcontroller-polyfill": "^1.5.0",
         "array-move": "^2.2.2",
         "babel-preset-stage-0": "^6.24.1",
-        "d2": "31.8.1",
+        "d2": "^31.8.2",
         "d2-utilizr": "^0.2.15",
         "d3-axis": "^1.0.12",
         "d3-color": "^1.4.1",

--- a/src/components/orgunits/OrgUnitLevelSelect.js
+++ b/src/components/orgunits/OrgUnitLevelSelect.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
 import { once, sortBy } from 'lodash/fp';
+import { isValidUid } from 'd2/uid';
 import SelectField from '../core/SelectField';
 import { loadOrgUnitLevels } from '../../actions/orgUnits';
 
@@ -14,7 +15,7 @@ const style = {
 export class OrgUnitLevelSelect extends Component {
     static propTypes = {
         defaultLevel: PropTypes.number,
-        orgUnitLevel: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+        orgUnitLevel: PropTypes.array,
         orgUnitLevels: PropTypes.array,
         loadOrgUnitLevels: PropTypes.func.isRequired,
         disabled: PropTypes.bool,
@@ -69,10 +70,7 @@ export class OrgUnitLevelSelect extends Component {
         let sortedOrgUnitLevels;
 
         if (orgUnitLevels) {
-            sortedOrgUnitLevels = sortBy(
-                item => item.level,
-                orgUnitLevels
-            ).map(({ level, name }) => ({ id: level.toString(), name })); // TODO
+            sortedOrgUnitLevels = sortBy(item => item.level, orgUnitLevels);
         }
 
         return (
@@ -80,7 +78,7 @@ export class OrgUnitLevelSelect extends Component {
                 label={i18n.t('Select levels')}
                 loading={orgUnitLevels ? false : true}
                 items={sortedOrgUnitLevels}
-                value={orgUnitLevel}
+                value={this.getOrgUnitLevelUid(orgUnitLevel)}
                 multiple={true}
                 onChange={onChange}
                 style={style}
@@ -89,11 +87,31 @@ export class OrgUnitLevelSelect extends Component {
             />
         );
     }
+
+    // Converts "LEVEL-x" to newer "LEVEL-uid" format
+    getOrgUnitLevelUid(orgUnitLevel = []) {
+        const { orgUnitLevels } = this.props;
+
+        return Array.isArray(orgUnitLevels)
+            ? orgUnitLevel
+                  .filter(level =>
+                      orgUnitLevels.find(
+                          l => l.id === level || l.level === Number(level)
+                      )
+                  )
+                  .map(level =>
+                      isValidUid(level)
+                          ? level
+                          : orgUnitLevels.find(l => l.level === Number(level))
+                                .id
+                  )
+            : [];
+    }
 }
 
 export default connect(
-    state => ({
-        orgUnitLevels: state.orgUnitLevels,
+    ({ orgUnitLevels }) => ({
+        orgUnitLevels,
     }),
     { loadOrgUnitLevels }
 )(OrgUnitLevelSelect);

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -301,6 +301,7 @@ const loadData = async config => {
         renderingStrategy = RENDERING_STRATEGY_SINGLE,
     } = config;
     const orgUnits = getOrgUnitsFromRows(rows);
+
     const period = getPeriodFromFilters(filters);
     const dimensions = getValidDimensionsFromFilters(config.filters);
     const dataItem = getDataItemFromColumns(columns);

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -301,7 +301,6 @@ const loadData = async config => {
         renderingStrategy = RENDERING_STRATEGY_SINGLE,
     } = config;
     const orgUnits = getOrgUnitsFromRows(rows);
-
     const period = getPeriodFromFilters(filters);
     const dimensions = getValidDimensionsFromFilters(config.filters);
     const dataItem = getDataItemFromColumns(columns);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4114,10 +4114,10 @@ d2-utilizr@^0.2.15:
     lodash.isset "^4.3.0"
     lodash.isstring "^4.0.1"
 
-d2@31.8.1:
-  version "31.8.1"
-  resolved "https://registry.yarnpkg.com/d2/-/d2-31.8.1.tgz#017372001f9c8d3379a74c71c0382c98e9d2fc26"
-  integrity sha512-UpS2gv3DS4Bg7MrQTMNkYv5cXJ0k9jsujgw/p4Ex+el3gzslTf7fTH2n4gIZt42+l1tKmrs/R7yiJPov5Cax3w==
+d2@^31.8.2:
+  version "31.8.2"
+  resolved "https://registry.yarnpkg.com/d2/-/d2-31.8.2.tgz#1b0f47a3686c01ecaa805d3dc44f056626d9baaf"
+  integrity sha512-eRmEf7+OslcdVSF4oFCBFBOwd2FEB8829xNqCz79PK49WkhYIy5c/cwEkwZd2sD5bJyeCyNoi3p4/42wC0AZ1Q==
   dependencies:
     isomorphic-fetch "^2.2.1"
 


### PR DESCRIPTION
This PR allows org unit levels to be formatted as "LEVEL-uid".

Fixes: https://jira.dhis2.org/browse/TECH-427

DHIS2 Maps has so far used the `LEVEL-x` ("LEVEL-2") format to identify org unit levels, and not `LEVEL-uid` ("LEVEL-wjP19dkFeIk") which is currently used by DV. 

With this PR, Maps will start to use `LEVEL-uid` for new maps created, but a converter is added to support the old format for maps that are already saved. 

This fix should be backported, so I've tried to make the changes minimal. 

The long term plan is to use a shared org unit selection component across the apps. 
