### PR TITLE
fix: require legend set selection (DHIS2-9314)

### DIFF
--- a/src/components/classification/LegendSetSelect.js
+++ b/src/components/classification/LegendSetSelect.js
@@ -14,6 +14,7 @@ export class LegendSetSelect extends Component {
     static propTypes = {
         legendSet: PropTypes.object,
         legendSets: PropTypes.array,
+        legendSetError: PropTypes.string,
         loadLegendSets: PropTypes.func.isRequired,
         setLegendSet: PropTypes.func.isRequired,
     };
@@ -27,7 +28,12 @@ export class LegendSetSelect extends Component {
     }
 
     render() {
-        const { legendSet, legendSets, setLegendSet } = this.props;
+        const {
+            legendSet,
+            legendSets,
+            legendSetError,
+            setLegendSet,
+        } = this.props;
 
         return (
             <SelectField
@@ -35,6 +41,7 @@ export class LegendSetSelect extends Component {
                 loading={legendSets ? false : true}
                 items={legendSets}
                 value={legendSet ? legendSet.id : null}
+                errorText={legendSetError}
                 onChange={setLegendSet}
                 style={style}
             />

--- a/src/components/classification/NumericLegendStyle.js
+++ b/src/components/classification/NumericLegendStyle.js
@@ -20,6 +20,7 @@ const NumericLegendStyle = props => {
         dataItem,
         setClassification,
         setLegendSet,
+        legendSetError,
         style,
     } = props;
 
@@ -49,7 +50,7 @@ const NumericLegendStyle = props => {
             {isSingleColor ? (
                 <SingleColor />
             ) : isPredefined ? (
-                <LegendSetSelect />
+                <LegendSetSelect legendSetError={legendSetError} />
             ) : (
                 <Classification />
             )}
@@ -62,6 +63,7 @@ NumericLegendStyle.propTypes = {
     method: PropTypes.number,
     colorScale: PropTypes.string,
     legendSet: PropTypes.object,
+    legendSetError: PropTypes.string,
     dataItem: PropTypes.object,
     setClassification: PropTypes.func.isRequired,
     setLegendSet: PropTypes.func.isRequired,

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -109,6 +109,7 @@ export class ThematicDialog extends Component {
         labelFontStyle: PropTypes.string,
         labelFontWeight: PropTypes.string,
         legendSet: PropTypes.object,
+        method: PropTypes.number,
         indicatorGroup: PropTypes.object,
         dataElementGroup: PropTypes.object,
         noDataColor: PropTypes.string,
@@ -297,6 +298,7 @@ export class ThematicDialog extends Component {
             periodTypeError,
             periodError,
             orgUnitsError,
+            legendSetError,
         } = this.state;
 
         const orgUnits = getOrgUnitsFromRows(rows);
@@ -612,6 +614,7 @@ export class ThematicDialog extends Component {
                                 <NumericLegendStyle
                                     mapType={thematicMapType}
                                     dataItem={dataItem}
+                                    legendSetError={legendSetError}
                                     style={styles.select}
                                 />
                             </div>
@@ -646,6 +649,8 @@ export class ThematicDialog extends Component {
             endDate,
             radiusLow,
             radiusHigh,
+            method,
+            legendSet,
         } = this.props;
         const dataItem = getDataItemFromColumns(columns);
         const period = getPeriodFromFilters(filters);
@@ -741,6 +746,14 @@ export class ThematicDialog extends Component {
                 'orgUnitsError',
                 i18n.t('No organisation units are selected'),
                 'orgunits'
+            );
+        }
+
+        if (method === CLASSIFICATION_PREDEFINED && !legendSet) {
+            return this.setErrorState(
+                'legendSetError',
+                i18n.t('No legend set is selected'),
+                'style'
             );
         }
 

--- a/src/components/orgunits/SelectedOrgUnits.js
+++ b/src/components/orgunits/SelectedOrgUnits.js
@@ -68,7 +68,7 @@ SelectedOrgUnits.propTypes = {
     mode: PropTypes.string,
     units: PropTypes.string,
     rows: PropTypes.array,
-    error: PropTypes.object,
+    error: PropTypes.string,
 };
 
 export default SelectedOrgUnits;


### PR DESCRIPTION
If the user selects "Predefined color legend" it is also required to select a legend set. 

Fixes: https://jira.dhis2.org/browse/DHIS2-9314

<img width="294" alt="Screenshot 2020-08-21 at 22 26 00" src="https://user-images.githubusercontent.com/548708/90931847-c59f3d80-e3fd-11ea-828b-5a8686567e92.png">
