### PR TITLE
fix: map plugin style handling (DHIS2-9315)

### DIFF
--- a/src/components/map/MapItem.js
+++ b/src/components/map/MapItem.js
@@ -4,13 +4,12 @@ import { withStyles } from '@material-ui/core/styles';
 import mapApi from './MapApi';
 
 const styles = () => ({
-    item: ({ count }) => ({
+    item: {
         position: 'relative',
         boxSizing: 'border-box',
-        width: count === 4 ? '50%' : '33.3333%',
         borderRight: '1px solid #aaa',
         borderBottom: '1px solid #aaa',
-    }),
+    },
 });
 
 class MapItem extends PureComponent {
@@ -74,11 +73,17 @@ class MapItem extends PureComponent {
     }
 
     render() {
-        const { children, classes } = this.props;
+        const { count, children, classes } = this.props;
         const { map } = this.state;
 
         return (
-            <div ref={node => (this.node = node)} className={classes.item}>
+            <div
+                ref={node => (this.node = node)}
+                className={classes.item}
+                style={{
+                    width: count === 4 ? '50%' : '33.3333%',
+                }}
+            >
                 {map && children}
             </div>
         );

--- a/src/map.js
+++ b/src/map.js
@@ -173,7 +173,7 @@ const PluginContainer = () => {
                 const ref = createRef();
 
                 const generateClassName = createGenerateClassName({
-                    productionPrefix: `map-plugin-${rendering}`,
+                    productionPrefix: `map-plugin-${rendering}-`,
                 });
 
                 render(


### PR DESCRIPTION
Fixes (hopefully): https://jira.dhis2.org/browse/DHIS2-9315

The problem is that elements get the wrong css classes assigned in production. 

Wit this PR we try to have one common style class, and move the prop based style handling to the style attribute.  