### PR TITLE
chore: upgrade to v35 of web api

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 node_modules/
 build/
 webpack.config.js
+src/locales/index.js
 *.spec.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "35.0.0",
+    "version": "35.0.1",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/app.js
+++ b/src/app.js
@@ -31,7 +31,7 @@ getManifest('manifest.webapp')
                 : DHIS_CONFIG.baseUrl;
 
         config.appUrl = baseUrl; // Base url for switching between apps
-        config.baseUrl = `${baseUrl}/api/34`; // Base url for Web API requests
+        config.baseUrl = `${baseUrl}/api/35`; // Base url for Web API requests
 
         config.context = manifest.activities.dhis; // Added temporarily for util/api.js
 

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -47,7 +47,7 @@ export class App extends Component {
             <Provider
                 config={{
                     baseUrl: DHIS_CONFIG.baseUrl,
-                    apiVersion: '34',
+                    apiVersion: '35',
                 }}
             >
                 <FatalErrorBoundary>

--- a/src/map.js
+++ b/src/map.js
@@ -21,7 +21,7 @@ import { translateConfig } from './util/favorites';
 import { defaultBasemaps } from './constants/basemaps';
 import { version } from '../package.json'; // TODO: Remove version logging
 
-const apiVersion = 34;
+const apiVersion = 35;
 
 log.info(`Maps plugin: ${version}`); // TODO: Remove version logging
 


### PR DESCRIPTION
Use the same web api version as the app version. 