### PR TITLE
fix: additional checks for infrastructural data (DHIS2-9451)

### DIFF
--- a/src/util/infrastructural.js
+++ b/src/util/infrastructural.js
@@ -1,22 +1,24 @@
 import { getInstance as getD2 } from 'd2';
+import i18n from '@dhis2/d2-i18n';
 
 // Loads settings and data for the infrastuctural dialog for org units
-
 export const loadConfigurations = async () => {
     const d2 = await getD2();
     const api = d2.Api.getApi();
     const [
-        infrastructuralPeriodType = {},
-        infrastructuralIndicators = {},
-        infrastructuralDataElements = {},
+        infraPeriodType,
+        infraIndicators,
+        infraDataElements,
     ] = await Promise.all([
         api.get('configuration/infrastructuralPeriodType'),
         api.get('configuration/infrastructuralIndicators'),
         api.get('configuration/infrastructuralDataElements'),
     ]);
-    const periodType = infrastructuralPeriodType.id || 'Yearly';
-    const indicators = infrastructuralIndicators.indicators || [];
-    const dataElements = infrastructuralDataElements.dataElements || [];
+
+    const periodType =
+        (infraPeriodType && infraPeriodType.id) || i18n.t('Yearly');
+    const { indicators = [] } = infraIndicators || {};
+    const { dataElements = [] } = infraDataElements || {};
 
     return {
         periodType,


### PR DESCRIPTION
Infrastructural data (org unit right click -> "Show information") is not showing in Maps master/2.35.0 due to a backend bug. This PR is not fixing the backend issue, but adds some additional checks in case no data is returned from the Web API, resulting in a console error. The PR also fixes a missing period translation string. 

Related issue: https://jira.dhis2.org/browse/DHIS2-9451

Before this fix the dialog will show like this with an error in the console: 
<img width="1329" alt="Screenshot 2020-09-09 at 15 33 51" src="https://user-images.githubusercontent.com/548708/92605658-44c3bb00-f2b2-11ea-8317-775ec2937fcc.png">

After this fix (and without a backend fix) it will show: 
<img width="613" alt="Screenshot 2020-09-09 at 15 34 09" src="https://user-images.githubusercontent.com/548708/92605721-56a55e00-f2b2-11ea-9ce8-ab3d9373a1f5.png">

Backend bug: 
<img width="1057" alt="Screenshot 2020-09-09 at 15 35 37" src="https://user-images.githubusercontent.com/548708/92605580-2fe72780-f2b2-11ea-9139-0eebb38b47ef.png">