### PR TITLE
fix: set single map rendering strategy as default (DHIS2-9543)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "35.0.7",
+    "version": "35.0.8",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -132,7 +132,11 @@ class ThematicLayer extends Layer {
 
     // Set initial period
     setPeriod(callback) {
-        const { period, periods, renderingStrategy } = this.props;
+        const {
+            period,
+            periods,
+            renderingStrategy = RENDERING_STRATEGY_SINGLE,
+        } = this.props;
 
         if (!period && !periods) {
             return;


### PR DESCRIPTION
This PR avoids setting initial period when rendering strategy is single map. 

Fixes: https://jira.dhis2.org/browse/DHIS2-9543