### PR TITLE
fix: only remove date field if undefined

### DIFF
--- a/src/components/periods/StartEndDates.js
+++ b/src/components/periods/StartEndDates.js
@@ -17,7 +17,7 @@ const StartEndDates = props => {
         }
     }, [startDate, endDate, setStartDate, setEndDate]);
 
-    return startDate && endDate ? (
+    return startDate !== undefined && endDate !== undefined ? (
         <Fragment>
             <DatePicker
                 label={i18n.t('Start date')}


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-9592

Before this fix, the date field is removed if the user is entering a date directly - if the date is invalid while typing an empty string is returned would not pass this check 

`return startDate && endDate ?`

The fix was to check for undefined so empty strings will pass. 
