### PR TITLE
fix: unique class name prefix for each map plugin item (DHIS2-9593)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "35.0.10",
+    "version": "35.0.11",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/map.js
+++ b/src/map.js
@@ -6,7 +6,7 @@ import {
 } from '@material-ui/core/styles';
 import { union } from 'lodash/fp';
 import { init, config, getUserSettings } from 'd2';
-import { isValidUid } from 'd2/uid';
+import { isValidUid, generateUid } from 'd2/uid';
 import log from 'loglevel'; // TODO: Remove version logging
 import i18n from './locales';
 import Plugin from './components/plugin/Plugin';
@@ -15,7 +15,6 @@ import {
     getExternalLayer,
     getBingMapsApiKey,
 } from './util/requests';
-import { getRenderingStrategy } from './util/analytics';
 import { fetchLayer } from './loaders/layers';
 import { translateConfig } from './util/favorites';
 import { defaultBasemaps } from './constants/basemaps';
@@ -167,13 +166,15 @@ const PluginContainer = () => {
     function drawMap(config) {
         if (config.el && !isUnmounted(config.el)) {
             const domEl = document.getElementById(config.el);
-            const rendering = getRenderingStrategy(config);
 
             if (domEl) {
                 const ref = createRef();
 
+                // Used to avoid class names collisions when there are multiple maps on a dashboard
+                const id = config.id || generateUid();
+
                 const generateClassName = createGenerateClassName({
-                    productionPrefix: `map-plugin-${rendering}-`,
+                    productionPrefix: `map-plugin-${id}-`,
                 });
 
                 render(

--- a/src/map.js
+++ b/src/map.js
@@ -170,7 +170,7 @@ const PluginContainer = () => {
             if (domEl) {
                 const ref = createRef();
 
-                // Used to avoid class names collisions when multiple maps on a dashboard
+                // Used to avoid class names collisions with multiple maps on a dashboard
                 const id = config.id || generateUid();
 
                 const generateClassName = createGenerateClassName({

--- a/src/map.js
+++ b/src/map.js
@@ -170,7 +170,7 @@ const PluginContainer = () => {
             if (domEl) {
                 const ref = createRef();
 
-                // Used to avoid class names collisions when there are multiple maps on a dashboard
+                // Used to avoid class names collisions when multiple maps on a dashboard
                 const id = config.id || generateUid();
 
                 const generateClassName = createGenerateClassName({


### PR DESCRIPTION
This PR fixes an issue with colling class names when having multiple maps on the same dashboard. 

Fixes: https://jira.dhis2.org/browse/DHIS2-9593

The solution is to include an unique map id in the class prefix. The default is to use the id from the analytical object, if undefined, a new id will be generated. 

Including rendering method in the class prefix is obsolete when using unique ids, so it was removed. 

The plan is to only merge this fix to master and test it thoroughly on play dev before backporting. 

This is related to an issue with the styling solution in Material UI described here (mutiple react contexts): 
https://github.com/mui-org/material-ui/issues/8872#issuecomment-340043309

The plan is to stop using Material UI in future versions of DHIS2 Maps. 