### PR TITLE
fix: show TEIs regardless of relationship

### DIFF
--- a/src/components/edit/trackedEntity/TrackedEntityDialog.js
+++ b/src/components/edit/trackedEntity/TrackedEntityDialog.js
@@ -181,7 +181,7 @@ export class TrackedEntityDialog extends Component {
             relatedPointColor,
             relatedPointRadius,
             relationshipLineColor,
-            relationshipOutsideProgram,
+            // relationshipOutsideProgram,
         } = this.props;
 
         const {
@@ -190,7 +190,7 @@ export class TrackedEntityDialog extends Component {
             setProgramStatus,
             setFollowUpStatus,
             setTrackedEntityRelationshipType,
-            setTrackedEntityRelationshipOutsideProgram,
+            // setTrackedEntityRelationshipOutsideProgram,
             toggleOrgUnit,
             setOrgUnitMode,
             setEventPointColor,
@@ -330,7 +330,7 @@ export class TrackedEntityDialog extends Component {
                                                 margin: '0 0 0 48px',
                                             }}
                                         />
-                                        {program && (
+                                        {/*program && (
                                             <Checkbox
                                                 label={i18n.t(
                                                     'Include relationships that connect entities outside "{{program}}" program',
@@ -349,7 +349,7 @@ export class TrackedEntityDialog extends Component {
                                                     marginTop: 30,
                                                 }}
                                             />
-                                        )}
+                                        )*/}
                                     </Fragment>
                                 )}
                             </div>

--- a/src/components/map/TrackedEntityLayer.js
+++ b/src/components/map/TrackedEntityLayer.js
@@ -147,6 +147,7 @@ class TrackedEntityLayer extends Layer {
             group.addLayer(relationshipConfig);
             group.addLayer(secondaryConfig);
         }
+
         group.addLayer(config);
 
         this.layer = group;

--- a/src/loaders/trackedEntityLoader.js
+++ b/src/loaders/trackedEntityLoader.js
@@ -134,8 +134,7 @@ const trackedEntityLoader = async config => {
         );
     }
 
-    const data = toGeoJson(instances);
-    let relationships, secondaryData;
+    let data, relationships, secondaryData;
 
     if (relationshipTypeID) {
         const relationshipType = await apiFetch(
@@ -171,8 +170,17 @@ const trackedEntityLoader = async config => {
             }
         );
 
+        // Show all TEIs expect those that are shown as secondary instances
+        data = toGeoJson(
+            instances.filter(
+                tei => !dataWithRels.secondary.find(s => s.id === tei.id)
+            )
+        );
+
         relationships = dataWithRels.relationships;
         secondaryData = toGeoJson(dataWithRels.secondary);
+    } else {
+        data = toGeoJson(instances);
     }
 
     if (explanation) {

--- a/src/loaders/trackedEntityLoader.js
+++ b/src/loaders/trackedEntityLoader.js
@@ -134,7 +134,8 @@ const trackedEntityLoader = async config => {
         );
     }
 
-    let data, relationships, secondaryData;
+    const data = toGeoJson(instances);
+    let relationships, secondaryData;
 
     if (relationshipTypeID) {
         const relationshipType = await apiFetch(
@@ -170,11 +171,8 @@ const trackedEntityLoader = async config => {
             }
         );
 
-        data = toGeoJson(dataWithRels.primary);
         relationships = dataWithRels.relationships;
         secondaryData = toGeoJson(dataWithRels.secondary);
-    } else {
-        data = toGeoJson(instances);
     }
 
     if (explanation) {

--- a/src/util/teiRelationshipsParser.js
+++ b/src/util/teiRelationshipsParser.js
@@ -7,7 +7,6 @@ export const fetchTEIs = async ({
     orgUnits,
     fields,
     organisationUnitSelectionMode,
-    targetIds,
 }) => {
     let url = `/trackedEntityInstances?skipPaging=true&fields=${fields}&ou=${orgUnits}`;
     if (organisationUnitSelectionMode) {
@@ -16,13 +15,9 @@ export const fetchTEIs = async ({
 
     url += `&trackedEntityType=${type.id}`;
 
-    const { trackedEntityInstances } = await apiFetch(url);
+    const data = await apiFetch(url);
 
-    return targetIds
-        ? trackedEntityInstances.filter(instance =>
-              targetIds.includes(instance.id)
-          )
-        : trackedEntityInstances;
+    return data.trackedEntityInstances;
 };
 
 const normalizeInstances = instances => {
@@ -56,15 +51,6 @@ const isIndexInstance = (instance, type) => {
     }
     return hasChildren;
 };
-
-const getTargetInstances = sourceInstances =>
-    sourceInstances.reduce(
-        (ids, instance) => [
-            ...ids,
-            ...instance.relationships.map(rel => parseTEInstanceId(rel.to)),
-        ],
-        []
-    );
 
 const getInstanceRelationships = (
     relationshipsById,
@@ -111,7 +97,6 @@ const fields = [
 export const getDataWithRelationships = async (
     sourceInstances,
     relationshipType,
-    relationshipOutsideProgram,
     { orgUnits, organisationUnitSelectionMode }
 ) => {
     const from = relationshipType.fromConstraint;
@@ -133,16 +118,13 @@ export const getDataWithRelationships = async (
         : sourceInstances;
 
     const targetInstances = normalizeInstances(
-        isRecursive && !relationshipOutsideProgram
+        isRecursive
             ? sourceInstances
             : await fetchTEIs({
                   type: to.trackedEntityType,
                   fields,
                   orgUnits,
                   organisationUnitSelectionMode,
-                  targetIds:
-                      relationshipOutsideProgram &&
-                      getTargetInstances(filteredSourceInstances),
               })
     );
 


### PR DESCRIPTION
If the user checks "Display Tracked Entity relationships" only TEIs having relationships will show on the map. This is not obvious for the user, and this fix will always show the same TEIs regardless if they take part in a relationship or not. 

The solution is to draw all TEIs (as we do when no relationships are shown). If a TEI take part as a secondary instance in a relationship (B) we will not draw it twice. Primary TEIs (A) and TEIs not present in a relationship will have the same style.   

Fixes: https://jira.dhis2.org/browse/DHIS2-9622

