### PR TITLE
Remove functionality to show TEI relationships outside program

### DIFF
--- a/src/components/edit/trackedEntity/TrackedEntityDialog.js
+++ b/src/components/edit/trackedEntity/TrackedEntityDialog.js
@@ -181,7 +181,7 @@ export class TrackedEntityDialog extends Component {
             relatedPointColor,
             relatedPointRadius,
             relationshipLineColor,
-            relationshipOutsideProgram,
+            // relationshipOutsideProgram,
         } = this.props;
 
         const {
@@ -190,7 +190,7 @@ export class TrackedEntityDialog extends Component {
             setProgramStatus,
             setFollowUpStatus,
             setTrackedEntityRelationshipType,
-            setTrackedEntityRelationshipOutsideProgram,
+            // setTrackedEntityRelationshipOutsideProgram,
             toggleOrgUnit,
             setOrgUnitMode,
             setEventPointColor,
@@ -330,7 +330,7 @@ export class TrackedEntityDialog extends Component {
                                                 margin: '0 0 0 48px',
                                             }}
                                         />
-                                        {program && (
+                                        {/*program && (
                                             <Checkbox
                                                 label={i18n.t(
                                                     'Include relationships that connect entities outside "{{program}}" program',
@@ -349,7 +349,7 @@ export class TrackedEntityDialog extends Component {
                                                     marginTop: 30,
                                                 }}
                                             />
-                                        )}
+                                        )*/}
                                     </Fragment>
                                 )}
                             </div>

--- a/src/loaders/trackedEntityLoader.js
+++ b/src/loaders/trackedEntityLoader.js
@@ -64,7 +64,6 @@ const trackedEntityLoader = async config => {
         relatedPointColor,
         relatedPointRadius,
         relationshipLineColor,
-        relationshipOutsideProgram,
     } = config;
 
     const name = program ? program.name : i18n.t('Tracked entity');
@@ -163,7 +162,6 @@ const trackedEntityLoader = async config => {
         const dataWithRels = await getDataWithRelationships(
             instances,
             relationshipType,
-            relationshipOutsideProgram,
             {
                 orgUnits,
                 organisationUnitSelectionMode,


### PR DESCRIPTION
Partly reverts changes from #993 (2. Show TEI relationships outside program)

This functionality was made as a change just before 2.35 soft freeze and not well tested, partly because of limited demo data. 
The code has bugs: https://jira.dhis2.org/browse/DHIS2-9634

It is safer to remove the support for TEI relationships outside program than to fix it just before a major release, as the implementation is quite complex. 

Most of the functionality is kept in code, so it can be enabled again at a later stage. 