### PR TITLE
fix: allow negative values in legend (DHIS2-9701)

### DIFF
--- a/src/util/classify.js
+++ b/src/util/classify.js
@@ -1,5 +1,6 @@
 // Utils for thematic mapping
-import { format, precisionRound } from 'd3-format';
+import { precisionRound } from 'd3-format';
+import { numberPrecision } from './numbers';
 import {
     CLASSIFICATION_EQUAL_INTERVALS,
     CLASSIFICATION_EQUAL_COUNTS,
@@ -47,16 +48,15 @@ export const getEqualIntervals = (minValue, maxValue, numClasses) => {
     const bins = [];
     const binSize = (maxValue - minValue) / numClasses;
     const precision = precisionRound(binSize, maxValue);
-
-    const valueFormat = format(`.${precision}f`);
+    const valueFormat = numberPrecision(precision);
 
     for (let i = 0; i < numClasses; i++) {
         const startValue = minValue + i * binSize;
         const endValue = i < numClasses - 1 ? startValue + binSize : maxValue;
 
         bins.push({
-            startValue: Number(valueFormat(startValue)),
-            endValue: Number(valueFormat(endValue)),
+            startValue: valueFormat(startValue),
+            endValue: valueFormat(endValue),
         });
     }
 
@@ -72,7 +72,7 @@ export const getQuantiles = (values, numClasses) => {
         (maxValue - minValue) / numClasses,
         maxValue
     );
-    const valueFormat = format(`.${precision}f`);
+    const valueFormat = numberPrecision(precision);
 
     let binLastValPos = binCount === 0 ? 0 : binCount;
 
@@ -88,7 +88,7 @@ export const getQuantiles = (values, numClasses) => {
     return bins
         .filter(bin => bin !== undefined)
         .map((value, index) => ({
-            startValue: Number(valueFormat(value)),
-            endValue: Number(valueFormat(bins[index + 1] || maxValue)),
+            startValue: valueFormat(value),
+            endValue: valueFormat(bins[index + 1] || maxValue),
         }));
 };

--- a/src/util/numbers.js
+++ b/src/util/numbers.js
@@ -13,3 +13,9 @@ export const formatCount = count => {
 
     return num || count;
 };
+
+// Rounds a number to d decimals
+export const numberPrecision = d => {
+    const m = Math.pow(10, d);
+    return n => Math.round(n * m) / m;
+};


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-9701

The bug appeared after upgrading the d3-format dependency to the latest version (v2.0.0). In this version the minus sign was changed: https://github.com/d3/d3-format/issues/62

It works in earlier versions which are used in v34 and v33 branches. 

d3-format now uses a minus sign (&#8722;) which returns NaN when using Number() to convert from a string. It would work if hyphen-minus (&#45;) was used. 

The fix was to round the numbers in JavaScript using Math.round, which also allowed us to skip the string to number casting. 

We are still using precisionRound to find the optimal number of decimals. 

Automatic legend with equal intervals:
<img width="881" alt="Screenshot 2020-10-06 at 12 41 43" src="https://user-images.githubusercontent.com/548708/95191715-693b8600-07d1-11eb-894c-a8364b15648e.png">

Automatic legend with equal counts:
<img width="881" alt="Screenshot 2020-10-06 at 12 41 58" src="https://user-images.githubusercontent.com/548708/95191723-6ccf0d00-07d1-11eb-8430-13c42f030bfa.png">

Aggregation type = Count:
<img width="881" alt="Screenshot 2020-10-06 at 13 25 13" src="https://user-images.githubusercontent.com/548708/95195874-70659280-07d7-11eb-8257-fa9745710bd8.png">


We should consolidate number formatting across the apps i future released.  