### PR TITLE
fix: avoid app crash if missing period id (2.35.0 backport)

### DIFF
--- a/src/components/map/ThematicLayer.js
+++ b/src/components/map/ThematicLayer.js
@@ -183,7 +183,7 @@ class ThematicLayer extends Layer {
     render() {
         const { periods, renderingStrategy, filters } = this.props;
         const { period, popup } = this.state;
-        const { id } = getPeriodFromFilters(filters);
+        const { id } = getPeriodFromFilters(filters) || {};
 
         return (
             <Fragment>


### PR DESCRIPTION
2.35.0 backport of #1054