### PR TITLE
chore: switch to material ui to @dhis2/ui for org unit dialog (DHIS2-9699)

### DIFF
--- a/src/components/orgunits/OrgUnitDialog.js
+++ b/src/components/orgunits/OrgUnitDialog.js
@@ -7,16 +7,10 @@ import {
     ModalTitle,
     ModalContent,
     ModalActions,
-    Table,
-    TableHead,
-    TableRowHead,
-    TableCellHead,
-    TableBody,
-    TableRow,
-    TableCell,
     Button,
 } from '@dhis2/ui';
 import PeriodSelect from '../periods/PeriodSelect';
+import OrgUnitDialogTable from './OrgUnitDialogTable';
 import { closeOrgUnit } from '../../actions/orgUnits';
 import { loadConfigurations, loadData } from '../../util/infrastructural';
 import styles from './styles/OrgUnitDialog.module.css';
@@ -105,42 +99,7 @@ export class OrgUnitDialog extends Component {
                                 period={period}
                                 onChange={this.onPeriodChange}
                             />
-                            {data && data.length ? (
-                                <Table>
-                                    <TableHead>
-                                        <TableRowHead>
-                                            <TableCellHead dense>
-                                                {i18n.t('Data element')}
-                                            </TableCellHead>
-                                            <TableCellHead
-                                                dense
-                                                className={styles.right}
-                                            >
-                                                {i18n.t('Value')}
-                                            </TableCellHead>
-                                        </TableRowHead>
-                                    </TableHead>
-                                    <TableBody>
-                                        {data.map(({ id, name, value }) => (
-                                            <TableRow key={id}>
-                                                <TableCell dense>
-                                                    {name}
-                                                </TableCell>
-                                                <TableCell
-                                                    dense
-                                                    className={styles.right}
-                                                >
-                                                    {value}
-                                                </TableCell>
-                                            </TableRow>
-                                        ))}
-                                    </TableBody>
-                                </Table>
-                            ) : (
-                                <div className={styles.nodata}>
-                                    {i18n.t('No data found for this period.')}
-                                </div>
-                            )}
+                            <OrgUnitDialogTable data={data} />
                         </div>
                     </div>
                 </ModalContent>

--- a/src/components/orgunits/OrgUnitDialog.js
+++ b/src/components/orgunits/OrgUnitDialog.js
@@ -2,61 +2,24 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
-import { withStyles } from '@material-ui/core/styles';
 import {
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogActions,
+    Modal,
+    ModalTitle,
+    ModalContent,
+    ModalActions,
+    Table,
+    TableHead,
+    TableRowHead,
+    TableCellHead,
+    TableBody,
+    TableRow,
+    TableCell,
     Button,
-} from '@material-ui/core';
+} from '@dhis2/ui';
 import PeriodSelect from '../periods/PeriodSelect';
 import { closeOrgUnit } from '../../actions/orgUnits';
 import { loadConfigurations, loadData } from '../../util/infrastructural';
-
-const styles = {
-    metadata: {
-        fontSize: 14,
-        marginTop: -10,
-        width: 200,
-        float: 'left',
-    },
-    heading: {
-        margin: '10px 0 2px 0',
-        fontWeight: 'bold',
-    },
-    data: {
-        float: 'left',
-        width: 345,
-        marginTop: -12,
-    },
-    nodata: {
-        fontStyle: 'italic',
-        padding: 5,
-        fontSize: 14,
-    },
-    table: {
-        display: 'block',
-        fontSize: 14,
-        width: 345,
-        maxHeight: 240,
-        overflowY: 'auto',
-        marginTop: -24,
-        '& th': {
-            fontWeight: 'bold',
-        },
-    },
-    left: {
-        textAlign: 'left',
-        width: 270,
-    },
-    right: {
-        textAlign: 'right',
-        verticalAlign: 'top',
-        width: 75,
-        paddingRight: 8,
-    },
-};
+import styles from './styles/OrgUnitDialog.module.css';
 
 export class OrgUnitDialog extends Component {
     static propTypes = {
@@ -68,7 +31,6 @@ export class OrgUnitDialog extends Component {
         }),
         organisationUnitGroups: PropTypes.object,
         closeOrgUnit: PropTypes.func.isRequired,
-        classes: PropTypes.object.isRequired,
     };
 
     state = {
@@ -113,14 +75,7 @@ export class OrgUnitDialog extends Component {
     };
 
     render() {
-        const {
-            id,
-            name,
-            code,
-            parent,
-            organisationUnitGroups,
-            classes,
-        } = this.props;
+        const { id, name, code, parent, organisationUnitGroups } = this.props;
         const { periodType, period, data } = this.state;
 
         if (!id) {
@@ -130,75 +85,78 @@ export class OrgUnitDialog extends Component {
         const groups = organisationUnitGroups.toArray();
 
         return (
-            <Dialog
-                maxWidth="md"
-                title={name}
-                open={true}
-                onClose={this.onClose}
-            >
-                <DialogTitle>{name}</DialogTitle>
-                <DialogContent>
-                    <div className={classes.metadata}>
-                        <h3 className={classes.heading}>
-                            {i18n.t('Parent unit')}
-                        </h3>
-                        {parent.name}
-                        <h3 className={classes.heading}>{i18n.t('Code')}</h3>
-                        {code}
-                        <h3 className={classes.heading}>{i18n.t('Groups')}</h3>
-                        {groups.map(group => (
-                            <div key={group.id}>{group.name}</div>
-                        ))}
+            <Modal position="middle" onClose={this.onClose}>
+                <ModalTitle>{name}</ModalTitle>
+                <ModalContent>
+                    <div className={styles.orgunit}>
+                        <div className={styles.metadata}>
+                            <h3>{i18n.t('Parent unit')}</h3>
+                            {parent.name}
+                            <h3>{i18n.t('Code')}</h3>
+                            {code}
+                            <h3>{i18n.t('Groups')}</h3>
+                            {groups.map(group => (
+                                <div key={group.id}>{group.name}</div>
+                            ))}
+                        </div>
+                        <div className={styles.data}>
+                            <PeriodSelect
+                                periodType={periodType}
+                                period={period}
+                                onChange={this.onPeriodChange}
+                            />
+                            {data && data.length ? (
+                                <Table>
+                                    <TableHead>
+                                        <TableRowHead>
+                                            <TableCellHead dense>
+                                                {i18n.t('Data element')}
+                                            </TableCellHead>
+                                            <TableCellHead
+                                                dense
+                                                className={styles.right}
+                                            >
+                                                {i18n.t('Value')}
+                                            </TableCellHead>
+                                        </TableRowHead>
+                                    </TableHead>
+                                    <TableBody>
+                                        {data.map(({ id, name, value }) => (
+                                            <TableRow key={id}>
+                                                <TableCell dense>
+                                                    {name}
+                                                </TableCell>
+                                                <TableCell
+                                                    dense
+                                                    className={styles.right}
+                                                >
+                                                    {value}
+                                                </TableCell>
+                                            </TableRow>
+                                        ))}
+                                    </TableBody>
+                                </Table>
+                            ) : (
+                                <div className={styles.nodata}>
+                                    {i18n.t('No data found for this period.')}
+                                </div>
+                            )}
+                        </div>
                     </div>
-                    <div className={classes.data}>
-                        <PeriodSelect
-                            periodType={periodType}
-                            period={period}
-                            onChange={this.onPeriodChange}
-                        />
-                        {data && data.length ? (
-                            <table className={classes.table}>
-                                <thead>
-                                    <tr>
-                                        <th className={classes.left}>
-                                            {i18n.t('Data element')}
-                                        </th>
-                                        <th className={classes.right}>
-                                            {i18n.t('Value')}
-                                        </th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {data.map(({ id, name, value }) => (
-                                        <tr key={id}>
-                                            <td>{name}</td>
-                                            <td className={classes.right}>
-                                                {value}
-                                            </td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
-                        ) : (
-                            <div className={classes.nodata}>
-                                {i18n.t('No data found for this period.')}
-                            </div>
-                        )}
-                    </div>
-                </DialogContent>
-                <DialogActions>
-                    <Button color="primary" onClick={this.onClose}>
+                </ModalContent>
+                <ModalActions>
+                    <Button secondary onClick={this.onClose}>
                         {i18n.t('Close')}
                     </Button>
-                </DialogActions>
-            </Dialog>
+                </ModalActions>
+            </Modal>
         );
     }
 }
 
 export default connect(
-    state => ({
-        ...state.orgUnit,
+    ({ orgUnit }) => ({
+        ...orgUnit,
     }),
     { closeOrgUnit }
-)(withStyles(styles)(OrgUnitDialog));
+)(OrgUnitDialog);

--- a/src/components/orgunits/OrgUnitDialogTable.js
+++ b/src/components/orgunits/OrgUnitDialogTable.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import i18n from '@dhis2/d2-i18n';
+import {
+    Table,
+    TableHead,
+    TableRowHead,
+    TableCellHead,
+    TableBody,
+    TableRow,
+    TableCell,
+} from '@dhis2/ui';
+import styles from './styles/OrgUnitDialogTable.module.css';
+
+const OrgUnitDataTable = ({ data }) =>
+    data && data.length ? (
+        <Table>
+            <TableHead>
+                <TableRowHead>
+                    <TableCellHead dense>
+                        {i18n.t('Data element')}
+                    </TableCellHead>
+                    <TableCellHead dense className={styles.right}>
+                        {i18n.t('Value')}
+                    </TableCellHead>
+                </TableRowHead>
+            </TableHead>
+            <TableBody>
+                {data.map(({ id, name, value }) => (
+                    <TableRow key={id}>
+                        <TableCell dense>{name}</TableCell>
+                        <TableCell dense className={styles.right}>
+                            {value}
+                        </TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+    ) : (
+        <div className={styles.nodata}>
+            {i18n.t('No data found for this period.')}
+        </div>
+    );
+
+OrgUnitDataTable.propTypes = {
+    data: PropTypes.array,
+};
+
+export default OrgUnitDataTable;

--- a/src/components/orgunits/__tests__/OrgUnitDialog.spec.js
+++ b/src/components/orgunits/__tests__/OrgUnitDialog.spec.js
@@ -1,15 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { unwrap } from '@material-ui/core/test-utils';
-import { Dialog } from '@material-ui/core';
-import OrgUnitDialog from '../OrgUnitDialog';
-
-// https://github.com/mui-org/material-ui/issues/11864
-const OrgUnitDialogNaked = unwrap(OrgUnitDialog);
+import { Modal } from '@dhis2/ui';
+import { OrgUnitDialog } from '../OrgUnitDialog';
 
 describe('Org unit dialog (infrastuctural data)', () => {
-    const renderWithProps = props =>
-        shallow(<OrgUnitDialogNaked classes={{}} {...props} />);
+    const renderWithProps = props => shallow(<OrgUnitDialog {...props} />);
     let props;
 
     beforeEach(() => {
@@ -30,8 +25,6 @@ describe('Org unit dialog (infrastuctural data)', () => {
     });
 
     it('renders a MUI Dialog if an org unit id is passed', () => {
-        expect(renderWithProps(props).find(Dialog).length).toBe(1);
+        expect(renderWithProps(props).find(Modal).length).toBe(1);
     });
-
-    // TODO: Check if loadConfigurations or loadData is called
 });

--- a/src/components/orgunits/styles/OrgUnitDialog.module.css
+++ b/src/components/orgunits/styles/OrgUnitDialog.module.css
@@ -19,13 +19,3 @@
     width: 345px;
     margin-top: -12px;
 }
-
-.nodata {
-    font-style: italic;
-    padding: var(--spacers-dp4);
-    font-size: 14px;
-}
-
-.right {
-    text-align: right;
-}

--- a/src/components/orgunits/styles/OrgUnitDialog.module.css
+++ b/src/components/orgunits/styles/OrgUnitDialog.module.css
@@ -22,7 +22,7 @@
 
 .nodata {
     font-style: italic;
-    padding: 5px;
+    padding: var(--spacers-dp4);
     font-size: 14px;
 }
 

--- a/src/components/orgunits/styles/OrgUnitDialog.module.css
+++ b/src/components/orgunits/styles/OrgUnitDialog.module.css
@@ -1,0 +1,31 @@
+.orgunit {
+    font-size: 14px;
+    margin-top: -12px;
+}
+
+.metadata {
+    width: 200px;
+    float: left;
+    line-height: 20px;
+}
+
+.metadata h3 {
+    font-size: 14px;
+    margin: var(--spacers-dp12) 0 0;
+}
+
+.data {
+    float: left;
+    width: 345px;
+    margin-top: -12px;
+}
+
+.nodata {
+    font-style: italic;
+    padding: 5px;
+    font-size: 14px;
+}
+
+.right {
+    text-align: right;
+}

--- a/src/components/orgunits/styles/OrgUnitDialogTable.module.css
+++ b/src/components/orgunits/styles/OrgUnitDialogTable.module.css
@@ -1,0 +1,9 @@
+.right {
+    text-align: right;
+}
+
+.nodata {
+    font-style: italic;
+    padding: var(--spacers-dp4);
+    font-size: 14px;
+}


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-9699

This PR replaces Material UI components and styles in the org unit dialog (right click an org unit and select "Show information"). The table from @dhis2/ui is used to show infrastructural data. 

After this PR: 

<img width="617" alt="Screenshot 2020-10-13 at 22 00 17" src="https://user-images.githubusercontent.com/548708/95909902-8bb83b00-0d9f-11eb-889b-11a944b48e76.png">

Before this PR:

<img width="659" alt="Screenshot 2020-10-13 at 22 00 26" src="https://user-images.githubusercontent.com/548708/95909925-970b6680-0d9f-11eb-9b8a-405789f4dc88.png">
