### PR TITLE
chore: switch to @dhis2/ui tabs (DHIS2-9699)

### DIFF
--- a/src/components/core/Tab.js
+++ b/src/components/core/Tab.js
@@ -1,15 +1,29 @@
-import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
-import { Tab as MuiTab } from '@material-ui/core';
+import React, { useContext, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { Tab as UiTab } from '@dhis2/ui';
+import { TabContext } from './Tabs';
 
-const styles = {
-    root: {
-        minWidth: 0,
-        fontSize: 14,
-    },
+const Tab = ({ value, dataTest, children }) => {
+    const { tab, onChange } = useContext(TabContext);
+
+    // onChange is from the parent component
+    const onClick = useCallback(() => {
+        if (value !== tab) {
+            onChange(value);
+        }
+    }, [value, tab, onChange]);
+
+    return (
+        <UiTab selected={value === tab} onClick={onClick} dataTest={dataTest}>
+            {children}
+        </UiTab>
+    );
 };
 
-// Styled wrapper around MUI Tab
-const Tab = props => <MuiTab {...props} />;
+Tab.propTypes = {
+    value: PropTypes.string.isRequired,
+    dataTest: PropTypes.string,
+    children: PropTypes.node.isRequired,
+};
 
-export default withStyles(styles)(Tab);
+export default Tab;

--- a/src/components/core/Tab.js
+++ b/src/components/core/Tab.js
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback } from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { Tab as UiTab } from '@dhis2/ui';
 import { TabContext } from './Tabs';
@@ -7,11 +7,11 @@ const Tab = ({ value, dataTest, children }) => {
     const { tab, onChange } = useContext(TabContext);
 
     // onChange is from the parent component
-    const onClick = useCallback(() => {
+    const onClick = () => {
         if (value !== tab) {
             onChange(value);
         }
-    }, [value, tab, onChange]);
+    };
 
     return (
         <UiTab selected={value === tab} onClick={onClick} dataTest={dataTest}>

--- a/src/components/core/Tabs.js
+++ b/src/components/core/Tabs.js
@@ -1,28 +1,32 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
-import { Tabs as MuiTabs } from '@material-ui/core';
+import { TabBar } from '@dhis2/ui';
 
-const styles = {
-    root: {
-        borderBottom: '1px solid rgb(221, 221, 221)',
-    },
+export const TabContext = React.createContext();
+
+const Tabs = ({ value, onChange, children }) => {
+    const [tab, setTab] = useState(value);
+
+    useEffect(() => {
+        if (value !== tab) {
+            setTab(value);
+        }
+    }, [value, tab]);
+
+    return (
+        <TabContext.Provider value={{ tab, onChange }}>
+            <TabBar fixed>{children}</TabBar>
+        </TabContext.Provider>
+    );
 };
-
-// Wrapper around MUI Tabs
-const Tabs = props => (
-    <MuiTabs
-        indicatorColor="primary"
-        textColor="primary"
-        variant="fullWidth"
-        {...props}
-        onChange={(event, tab) => props.onChange(tab)}
-    />
-);
 
 Tabs.propTypes = {
+    value: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
-    classes: PropTypes.object.isRequired,
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node,
+    ]).isRequired,
 };
 
-export default withStyles(styles)(Tabs);
+export default Tabs;

--- a/src/components/edit/BoundaryDialog.js
+++ b/src/components/edit/BoundaryDialog.js
@@ -118,11 +118,8 @@ class BoundaryDialog extends Component {
         return (
             <div data-test="boundarydialog">
                 <Tabs value={tab} onChange={tab => this.setState({ tab })}>
-                    <Tab
-                        value="orgunits"
-                        label={i18n.t('Organisation units')}
-                    />
-                    <Tab value="style" label={i18n.t('Style')} />
+                    <Tab value="orgunits">{i18n.t('Organisation Units')}</Tab>
+                    <Tab value="style">{i18n.t('Style')}</Tab>
                 </Tabs>
                 <div className={classes.tabContent}>
                     {tab === 'orgunits' && (

--- a/src/components/edit/EarthEngineDialog.js
+++ b/src/components/edit/EarthEngineDialog.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
 import { withStyles } from '@material-ui/core/styles';
-import Tabs from '../core/Tabs';
-import Tab from '../core/Tab';
 import TextField from '../core/TextField';
 import ColorScaleSelect from '../core/ColorScaleSelect';
 import Collection from '../earthengine/Collection';
@@ -167,13 +165,10 @@ class EarthEngineDialog extends Component {
             classes,
         } = this.props;
         const dataset = getDatasets()[datasetId];
-        const { tab, steps, filterError, rangeError, stepsError } = this.state;
+        const { steps, filterError, rangeError, stepsError } = this.state;
 
         return (
             <div>
-                <Tabs value={tab} onChange={tab => this.setState({ tab })}>
-                    <Tab value="style">{i18n.t('Style')}</Tab>
-                </Tabs>
                 <div className={classes.tabContent}>
                     <div className={classes.flexColumnFlow}>
                         <div className={classes.flexColumn}>

--- a/src/components/edit/EarthEngineDialog.js
+++ b/src/components/edit/EarthEngineDialog.js
@@ -172,7 +172,7 @@ class EarthEngineDialog extends Component {
         return (
             <div>
                 <Tabs value={tab} onChange={tab => this.setState({ tab })}>
-                    <Tab value="style" label={i18n.t('Style')} />
+                    <Tab value="style">{i18n.t('Style')}</Tab>
                 </Tabs>
                 <div className={classes.tabContent}>
                     <div className={classes.flexColumnFlow}>

--- a/src/components/edit/FacilityDialog.js
+++ b/src/components/edit/FacilityDialog.js
@@ -158,13 +158,14 @@ class FacilityDialog extends Component {
         return (
             <div data-test="facilitydialog">
                 <Tabs value={tab} onChange={tab => this.setState({ tab })}>
-                    <Tab value="group" label={i18n.t('Group set')} />
+                    <Tab value="group">{i18n.t('Group Set')}</Tab>
                     <Tab
                         value="orgunits"
-                        label={i18n.t('Organisation units')}
-                        data-test="facilitydialog-tabs-orgunits"
-                    />
-                    <Tab value="style" label={i18n.t('Style')} />
+                        dataTest="facilitydialog-tabs-orgunits"
+                    >
+                        {i18n.t('Organisation Units')}
+                    </Tab>
+                    <Tab value="style">{i18n.t('Style')}</Tab>
                 </Tabs>
                 <div className={classes.tabContent}>
                     {tab === 'group' && (

--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -204,11 +204,11 @@ export class EventDialog extends Component {
         return (
             <div data-test="eventdialog">
                 <Tabs value={tab} onChange={tab => this.setState({ tab })}>
-                    <Tab value="data" label={i18n.t('data')} />
-                    <Tab value="period" label={i18n.t('period')} />
-                    <Tab value="orgunits" label={i18n.t('Org units')} />
-                    <Tab value="filter" label={i18n.t('Filter')} />
-                    <Tab value="style" label={i18n.t('Style')} />
+                    <Tab value="data">{i18n.t('Data')}</Tab>
+                    <Tab value="period">{i18n.t('Period')}</Tab>
+                    <Tab value="orgunits">{i18n.t('Org Units')}</Tab>
+                    <Tab value="filter">{i18n.t('Filter')}</Tab>
+                    <Tab value="style">{i18n.t('Style')}</Tab>
                 </Tabs>
                 <div style={styles.tabContent} data-test="eventdialog-content">
                     {tab === 'data' && (

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -313,31 +313,24 @@ export class ThematicDialog extends Component {
         return (
             <div data-test="thematicdialog">
                 <Tabs value={tab} onChange={tab => this.setState({ tab })}>
-                    <Tab
-                        value="data"
-                        label={i18n.t('data')}
-                        data-test="thematicdialog-tabs-data"
-                    />
-                    <Tab
-                        value="period"
-                        label={i18n.t('period')}
-                        data-test="thematicdialog-tabs-period"
-                    />
+                    <Tab value="data" dataTest="thematicdialog-tabs-data">
+                        {i18n.t('Data')}
+                    </Tab>
+                    <Tab value="period" dataTest="thematicdialog-tabs-period">
+                        {i18n.t('Period')}
+                    </Tab>
                     <Tab
                         value="orgunits"
-                        label={i18n.t('Org units')}
-                        data-test="thematicdialog-tabs-orgunits"
-                    />
-                    <Tab
-                        value="filter"
-                        label={i18n.t('Filter')}
-                        data-test="thematicdialog-tabs-filter"
-                    />
-                    <Tab
-                        value="style"
-                        label={i18n.t('Style')}
-                        data-test="thematicdialog-tabs-style"
-                    />
+                        dataTest="thematicdialog-tabs-orgunits"
+                    >
+                        {i18n.t('Org Units')}
+                    </Tab>
+                    <Tab value="filter" dataTest="thematicdialog-tabs-filter">
+                        {i18n.t('Filter')}
+                    </Tab>
+                    <Tab value="style" dataTest="thematicdialog-tabs-style">
+                        {i18n.t('Style')}
+                    </Tab>
                 </Tabs>
                 <div style={styles.tabContent}>
                     {tab === 'data' && (

--- a/src/components/edit/trackedEntity/TrackedEntityDialog.js
+++ b/src/components/edit/trackedEntity/TrackedEntityDialog.js
@@ -214,14 +214,11 @@ export class TrackedEntityDialog extends Component {
         return (
             <div>
                 <Tabs value={tab} onChange={tab => this.setState({ tab })}>
-                    <Tab value="data" label={i18n.t('data')} />
-                    <Tab
-                        value="relationships"
-                        label={i18n.t('relationships')}
-                    />
-                    <Tab value="period" label={i18n.t('period')} />
-                    <Tab value="orgunits" label={i18n.t('Org units')} />
-                    <Tab value="style" label={i18n.t('Style')} />
+                    <Tab value="data">{i18n.t('Data')}</Tab>
+                    <Tab value="relationships">{i18n.t('Relationships')}</Tab>
+                    <Tab value="period">{i18n.t('Period')}</Tab>
+                    <Tab value="orgunits">{i18n.t('Org Units')}</Tab>
+                    <Tab value="style">{i18n.t('Style')}</Tab>
                 </Tabs>
                 <div className={classes.tabContent}>
                     {tab === 'data' && (


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-9699

This PR replaces Material UI tab components with equivalents from @dhis2/ui. Some wrapper components was created to have a single onChange handler which simplifies the code in the layer dialogs. Please note that only the tabs are updated, there are still several Material UI components in the layer dialogs (will be fixed in separate PRs). 

After this PR:

<img width="600" alt="Screenshot 2020-10-14 at 19 00 57" src="https://user-images.githubusercontent.com/548708/96021531-ddb89980-0e4f-11eb-8076-34581493e641.png">
<img width="599" alt="Screenshot 2020-10-14 at 19 01 11" src="https://user-images.githubusercontent.com/548708/96021536-dee9c680-0e4f-11eb-8cd4-b627f922503f.png">
<img width="598" alt="Screenshot 2020-10-14 at 19 01 24" src="https://user-images.githubusercontent.com/548708/96021537-dee9c680-0e4f-11eb-8d51-6d7906b16218.png">
<img width="597" alt="Screenshot 2020-10-14 at 19 01 38" src="https://user-images.githubusercontent.com/548708/96021539-df825d00-0e4f-11eb-89d2-0b283cc0930a.png">
<img width="596" alt="Screenshot 2020-10-14 at 19 01 55" src="https://user-images.githubusercontent.com/548708/96021541-df825d00-0e4f-11eb-9ef0-c9ac434248ff.png">
<img width="597" alt="Screenshot 2020-10-14 at 19 02 08" src="https://user-images.githubusercontent.com/548708/96021542-e01af380-0e4f-11eb-8ca7-c3775b940403.png">

Before this PR: 

<img width="595" alt="Screenshot 2020-10-14 at 19 03 24" src="https://user-images.githubusercontent.com/548708/96021719-207a7180-0e50-11eb-9bb6-56cadd340ec4.png">
<img width="595" alt="Screenshot 2020-10-14 at 19 03 35" src="https://user-images.githubusercontent.com/548708/96021723-21130800-0e50-11eb-851e-fff32b10cd19.png">
<img width="594" alt="Screenshot 2020-10-14 at 19 03 48" src="https://user-images.githubusercontent.com/548708/96021725-21ab9e80-0e50-11eb-8aaf-dd652470a38a.png">
<img width="597" alt="Screenshot 2020-10-14 at 19 04 01" src="https://user-images.githubusercontent.com/548708/96021728-22443500-0e50-11eb-8e3c-7eabdc7031a7.png">
<img width="595" alt="Screenshot 2020-10-14 at 19 04 13" src="https://user-images.githubusercontent.com/548708/96021730-22443500-0e50-11eb-8474-e3917d1f4360.png">
<img width="598" alt="Screenshot 2020-10-14 at 19 04 22" src="https://user-images.githubusercontent.com/548708/96021732-22dccb80-0e50-11eb-8c8a-9235a55a47ac.png">
