### PR TITLE
chore: switch to @dhis2/ui modals (DHIS2-9699)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-21T08:07:40.821Z\n"
-"PO-Revision-Date: 2020-09-21T08:07:40.821Z\n"
+"POT-Creation-Date: 2020-10-19T07:59:10.931Z\n"
+"PO-Revision-Date: 2020-10-19T07:59:10.931Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Period"
 msgstr ""
 
-msgid "Organisation units"
+msgid "Organisation Units"
 msgstr ""
 
 msgid "Style"
@@ -230,7 +230,7 @@ msgstr ""
 msgid "Valid range is"
 msgstr ""
 
-msgid "Group set"
+msgid "Group Set"
 msgstr ""
 
 msgid "Remember to select the organisation unit level containing the facilities."
@@ -275,13 +275,10 @@ msgstr ""
 msgid "Add layer"
 msgstr ""
 
-msgid "data"
+msgid "Data"
 msgstr ""
 
-msgid "period"
-msgstr ""
-
-msgid "Org units"
+msgid "Org Units"
 msgstr ""
 
 msgid "Filter"
@@ -383,7 +380,7 @@ msgstr ""
 msgid "Program status"
 msgstr ""
 
-msgid "relationships"
+msgid "Relationships"
 msgstr ""
 
 msgid "Follow up"
@@ -698,6 +695,9 @@ msgid "No data found for this period."
 msgstr ""
 
 msgid "Select groups"
+msgstr ""
+
+msgid "Group set"
 msgstr ""
 
 msgid "Select levels"

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -51,7 +51,7 @@ export class App extends Component {
             >
                 <FatalErrorBoundary>
                     <CssReset />
-                    <CssVariables colors spacers />
+                    <CssVariables colors spacers theme />
                     <HeaderBar appName={i18n.t('Maps')} />
                     <MuiThemeProvider theme={theme}>
                         <AppMenu />

--- a/src/components/edit/LayerEdit.js
+++ b/src/components/edit/LayerEdit.js
@@ -44,7 +44,6 @@ class LayerEdit extends Component {
         loadLayer: PropTypes.func.isRequired,
         cancelLayer: PropTypes.func.isRequired,
         setLayerLoading: PropTypes.func.isRequired,
-        classes: PropTypes.object.isRequired,
     };
 
     state = {

--- a/src/components/edit/LayerEdit.js
+++ b/src/components/edit/LayerEdit.js
@@ -2,14 +2,14 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
-import { withStyles } from '@material-ui/core/styles';
 import {
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogActions,
+    Modal,
+    ModalTitle,
+    ModalContent,
+    ModalActions,
     Button,
-} from '@material-ui/core';
+    ButtonStrip,
+} from '@dhis2/ui';
 import EventDialog from './event/EventDialog';
 import TrackedEntityDialog from './trackedEntity/TrackedEntityDialog';
 import FacilityDialog from './FacilityDialog';
@@ -17,6 +17,7 @@ import ThematicDialog from './thematic/ThematicDialog';
 import BoundaryDialog from './BoundaryDialog';
 import EarthEngineDialog from './EarthEngineDialog';
 import { loadLayer, cancelLayer, setLayerLoading } from '../../actions/layers';
+import styles from './styles/LayerEdit.module.css';
 
 const layerType = {
     event: EventDialog,
@@ -35,17 +36,6 @@ const layerName = () => ({
     boundary: i18n.t('boundary'),
     earthEngine: i18n.t('Earth Engine'),
 });
-
-const styles = {
-    title: {
-        padding: '20px 24px 4px 24px',
-        fontSize: 16,
-        fontWeight: 'bold',
-    },
-    content: {
-        minHeight: 300,
-    },
-};
 
 class LayerEdit extends Component {
     static propTypes = {
@@ -89,7 +79,7 @@ class LayerEdit extends Component {
     };
 
     render() {
-        const { layer, defaultPeriod, cancelLayer, classes } = this.props;
+        const { layer, defaultPeriod, cancelLayer } = this.props;
 
         if (!layer) {
             return null;
@@ -108,36 +98,37 @@ class LayerEdit extends Component {
             : i18n.t('Add new {{name}} layer', { name });
 
         return (
-            <Dialog open={true} maxWidth="md" data-test="layeredit">
-                <DialogTitle disableTypography={true} className={classes.title}>
-                    {title}
-                </DialogTitle>
-                <DialogContent className={classes.content}>
-                    <LayerDialog
-                        {...layer}
-                        defaultPeriod={defaultPeriod}
-                        validateLayer={this.state.validateLayer}
-                        onLayerValidation={this.onLayerValidation}
-                    />
-                </DialogContent>
-                <DialogActions>
-                    <Button color="primary" onClick={() => cancelLayer()}>
-                        {i18n.t('Cancel')}
-                    </Button>
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={() => this.validateLayer()}
-                        data-test="layeredit-addbtn"
-                    >
-                        {i18n.t(
-                            layer.id
-                                ? i18n.t('Update layer')
-                                : i18n.t('Add layer')
-                        )}
-                    </Button>
-                </DialogActions>
-            </Dialog>
+            <Modal position="middle" dataTest="layeredit">
+                <ModalTitle>{title}</ModalTitle>
+                <ModalContent>
+                    <div className={styles.content}>
+                        <LayerDialog
+                            {...layer}
+                            defaultPeriod={defaultPeriod}
+                            validateLayer={this.state.validateLayer}
+                            onLayerValidation={this.onLayerValidation}
+                        />
+                    </div>
+                </ModalContent>
+                <ModalActions>
+                    <ButtonStrip end>
+                        <Button secondary onClick={cancelLayer}>
+                            {i18n.t('Cancel')}
+                        </Button>
+                        <Button
+                            primary
+                            onClick={() => this.validateLayer()}
+                            dataTest="layeredit-addbtn"
+                        >
+                            {i18n.t(
+                                layer.id
+                                    ? i18n.t('Update layer')
+                                    : i18n.t('Add layer')
+                            )}
+                        </Button>
+                    </ButtonStrip>
+                </ModalActions>
+            </Modal>
         );
     }
 
@@ -159,4 +150,4 @@ export default connect(
         defaultPeriod: settings.system.keyAnalysisRelativePeriod,
     }),
     { loadLayer, cancelLayer, setLayerLoading }
-)(withStyles(styles)(LayerEdit));
+)(LayerEdit);

--- a/src/components/edit/styles/LayerEdit.module.css
+++ b/src/components/edit/styles/LayerEdit.module.css
@@ -1,0 +1,3 @@
+.content {
+    min-height: 300px;
+}

--- a/src/components/layers/download/DataDownloadDialog.js
+++ b/src/components/layers/download/DataDownloadDialog.js
@@ -58,14 +58,7 @@ export class DataDownloadDialog extends Component {
     };
 
     render() {
-        const {
-            open,
-            layer,
-            downloading,
-            error,
-
-            closeDialog,
-        } = this.props;
+        const { open, layer, downloading, error, closeDialog } = this.props;
 
         if (!open || !layer) {
             return null;

--- a/src/components/layers/download/DataDownloadDialog.js
+++ b/src/components/layers/download/DataDownloadDialog.js
@@ -2,12 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
-import {
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogActions,
-} from '@material-ui/core';
+import { Modal, ModalTitle, ModalContent, ModalActions } from '@dhis2/ui';
 
 import {
     META_DATA_FORMAT_ID,
@@ -80,11 +75,9 @@ export class DataDownloadDialog extends Component {
             isEventLayer = layerType === 'event';
 
         return (
-            <Dialog open={open} onClose={closeDialog} maxWidth="md">
-                <DialogTitle disableTypography={true}>
-                    {i18n.t('Download Layer Data')}
-                </DialogTitle>
-                <DialogContent>
+            <Modal position="middle" onClose={closeDialog}>
+                <ModalTitle>{i18n.t('Download Layer Data')}</ModalTitle>
+                <ModalContent>
                     <DataDownloadDialogContent
                         isEventLayer={isEventLayer}
                         error={error}
@@ -97,15 +90,15 @@ export class DataDownloadDialog extends Component {
                         onChangeFormatOption={this.onChangeFormatOption}
                         onCheckHumanReadable={this.onCheckHumanReadable}
                     />
-                </DialogContent>
-                <DialogActions>
+                </ModalContent>
+                <ModalActions>
                     <DataDownloadDialogActions
                         downloading={downloading}
                         onStartClick={this.onStartDownload}
                         onCancelClick={closeDialog}
                     />
-                </DialogActions>
-            </Dialog>
+                </ModalActions>
+            </Modal>
         );
     }
 }

--- a/src/components/layers/download/DataDownloadDialogActions.js
+++ b/src/components/layers/download/DataDownloadDialogActions.js
@@ -1,61 +1,31 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
-import { Button } from '@material-ui/core';
-import CircularProgress from '@material-ui/core/CircularProgress';
+import { Button, ButtonStrip, CircularLoader } from '@dhis2/ui';
 import i18n from '@dhis2/d2-i18n';
-
-const styles = {
-    wrapper: {
-        position: 'relative',
-    },
-    btnProgress: {
-        position: 'absolute',
-        top: '50%',
-        left: '50%',
-        marginTop: -12,
-        marginLeft: -12,
-    },
-};
+import styles from './styles/DataDownloadDialogActions.module.css';
 
 export const DataDownloadDialogActions = ({
-    classes,
-
     downloading,
     onStartClick,
     onCancelClick,
 }) => (
-    <Fragment>
-        <Button
-            variant="text"
-            color="primary"
-            onClick={onCancelClick}
-            disabled={downloading}
-        >
+    <ButtonStrip end>
+        <Button secondary onClick={onCancelClick} disabled={downloading}>
             {i18n.t('Cancel')}
         </Button>
-        <div className={classes.wrapper}>
-            <Button
-                variant="contained"
-                color="primary"
-                onClick={onStartClick}
-                disabled={downloading}
-            >
-                {i18n.t('Download')}
-            </Button>
+        <Button primary onClick={onStartClick} disabled={downloading}>
+            {i18n.t('Download')}
             {downloading && (
-                <CircularProgress size={24} className={classes.btnProgress} />
+                <CircularLoader small className={styles.btnProgress} />
             )}
-        </div>
-    </Fragment>
+        </Button>
+    </ButtonStrip>
 );
 
 DataDownloadDialogActions.propTypes = {
-    classes: PropTypes.object.isRequired,
-
     downloading: PropTypes.bool.isRequired,
     onStartClick: PropTypes.func.isRequired,
     onCancelClick: PropTypes.func.isRequired,
 };
 
-export default withStyles(styles)(DataDownloadDialogActions);
+export default DataDownloadDialogActions;

--- a/src/components/layers/download/DataDownloadDialogContent.js
+++ b/src/components/layers/download/DataDownloadDialogContent.js
@@ -1,38 +1,12 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core';
 import ErrorIcon from '@material-ui/icons/ErrorOutline';
 import InfoIcon from '@material-ui/icons/InfoOutlined';
 import i18n from '@dhis2/d2-i18n';
 import EventDownloadInputs from './EventDownloadInputs';
-
-const styles = theme => ({
-    contentDiv: {
-        marginBottom: theme.spacing(1.5),
-    },
-    inputContainer: {
-        marginTop: theme.spacing(4),
-    },
-    infoDiv: {
-        height: theme.spacing(2.5), // Ensure that we have enough buffer around the svg icon to prevent unnecessary scrollbars
-        display: 'flex',
-        alignItems: 'center',
-        fontSize: '0.85em',
-        color: theme.palette.text.secondary,
-    },
-    icon: {
-        fontSize: '1.125em',
-        marginRight: theme.spacing(1),
-    },
-    error: {
-        marginTop: theme.spacing(1.5),
-        color: theme.palette.error.main,
-    },
-});
+import styles from './styles/DataDownloadDialogContent.module.css';
 
 export const DataDownloadDialogContent = ({
-    classes,
-
     isEventLayer,
     error,
 
@@ -45,19 +19,19 @@ export const DataDownloadDialogContent = ({
     onCheckHumanReadable,
 }) => (
     <Fragment>
-        <div className={classes.contentDiv}>
+        <div className={styles.contentDiv}>
             {i18n.t('Downloading GeoJSON data for "{{layerName}}"', {
                 layerName: layerName,
             })}
         </div>
-        <div className={classes.infoDiv}>
-            <InfoIcon className={classes.icon} />
+        <div className={styles.infoDiv}>
+            <InfoIcon className={styles.icon} />
             {i18n.t(
                 'GeoJSON is supported by most GIS software, including QGIS and ArcGIS Desktop.'
             )}
         </div>
         {isEventLayer && (
-            <div className={classes.inputContainer}>
+            <div className={styles.inputContainer}>
                 <EventDownloadInputs
                     selectedFormatOption={selectedFormatOption}
                     humanReadableChecked={humanReadableChecked}
@@ -68,8 +42,8 @@ export const DataDownloadDialogContent = ({
             </div>
         )}
         {error && (
-            <div className={classes.error}>
-                <ErrorIcon className={classes.icon} />
+            <div className={styles.error}>
+                <ErrorIcon className={styles.icon} />
                 {i18n.t('Data download failed.')}
             </div>
         )}
@@ -77,8 +51,6 @@ export const DataDownloadDialogContent = ({
 );
 
 DataDownloadDialogContent.propTypes = {
-    classes: PropTypes.object.isRequired,
-
     isEventLayer: PropTypes.bool.isRequired,
     error: PropTypes.string,
 
@@ -95,4 +67,4 @@ DataDownloadDialogContent.defaultProps = {
     selectedFormatOption: 0,
 };
 
-export default withStyles(styles)(DataDownloadDialogContent);
+export default DataDownloadDialogContent;

--- a/src/components/layers/download/DataDownloadDialogContent.js
+++ b/src/components/layers/download/DataDownloadDialogContent.js
@@ -25,7 +25,7 @@ export const DataDownloadDialogContent = ({
             })}
         </div>
         <div className={styles.infoDiv}>
-            <InfoIcon className={styles.icon} />
+            <InfoIcon fontSize="small" className={styles.icon} />
             {i18n.t(
                 'GeoJSON is supported by most GIS software, including QGIS and ArcGIS Desktop.'
             )}
@@ -43,7 +43,7 @@ export const DataDownloadDialogContent = ({
         )}
         {error && (
             <div className={styles.error}>
-                <ErrorIcon className={styles.icon} />
+                <ErrorIcon fontSize="small" className={styles.icon} />
                 {i18n.t('Data download failed.')}
             </div>
         )}

--- a/src/components/layers/download/__tests__/DataDownloadDialog.spec.js
+++ b/src/components/layers/download/__tests__/DataDownloadDialog.spec.js
@@ -16,7 +16,6 @@ describe('DataDownloadDialogContent', () => {
     const renderComponent = props =>
         shallow(
             <DataDownloadDialog
-                classes={{}}
                 open={false}
                 downloading={false}
                 error={null}
@@ -27,8 +26,8 @@ describe('DataDownloadDialogContent', () => {
             />
         );
 
-    const dummyEventLayer = { layer: 'event' };
-    const dummyThematicLayer = { layer: 'thematic' };
+    const dummyEventLayer = { layer: 'event', name: 'Event layer' };
+    const dummyThematicLayer = { layer: 'thematic', name: 'Thematic layer' };
 
     it('Should render null when not open', () => {
         const wrapper = renderComponent();
@@ -47,23 +46,16 @@ describe('DataDownloadDialogContent', () => {
             open: true,
             layer: dummyEventLayer,
         });
+
         expect(wrapper.isEmptyRender()).toBe(false);
-        expect(wrapper.find('WithStyles(ForwardRef(Dialog))').length).toBe(1);
+        expect(wrapper.find('Modal').length).toBe(1);
+        expect(wrapper.find('DataDownloadDialogContent').length).toBe(1);
+        expect(wrapper.find('DataDownloadDialogActions').length).toBe(1);
         expect(
-            wrapper.find('WithStyles(DataDownloadDialogContent)').length
-        ).toBe(1);
-        expect(
-            wrapper.find('WithStyles(DataDownloadDialogActions)').length
-        ).toBe(1);
-        expect(
-            wrapper
-                .find('WithStyles(DataDownloadDialogActions)')
-                .prop('downloading')
+            wrapper.find('DataDownloadDialogActions').prop('downloading')
         ).toBe(false);
         expect(
-            wrapper
-                .find('WithStyles(DataDownloadDialogContent)')
-                .prop('isEventLayer')
+            wrapper.find('DataDownloadDialogContent').prop('isEventLayer')
         ).toBe(true);
     });
 
@@ -74,9 +66,7 @@ describe('DataDownloadDialogContent', () => {
         });
         expect(wrapper.isEmptyRender()).toBe(false);
         expect(
-            wrapper
-                .find('WithStyles(DataDownloadDialogContent)')
-                .prop('isEventLayer')
+            wrapper.find('DataDownloadDialogContent').prop('isEventLayer')
         ).toBe(false);
     });
     it('Should default state to selectedFormatOption=2 and humanReadableChecked=true', () => {
@@ -88,13 +78,13 @@ describe('DataDownloadDialogContent', () => {
         expect(wrapper.state().selectedFormatOption).toBe(2);
         expect(
             wrapper
-                .find('WithStyles(DataDownloadDialogContent)')
+                .find('DataDownloadDialogContent')
                 .prop('selectedFormatOption')
         ).toBe(3); // 1-indexed
         expect(wrapper.state().humanReadableChecked).toBe(true);
         expect(
             wrapper
-                .find('WithStyles(DataDownloadDialogContent)')
+                .find('DataDownloadDialogContent')
                 .prop('humanReadableChecked')
         ).toBe(true);
     });
@@ -125,9 +115,7 @@ describe('DataDownloadDialogContent', () => {
             downloading: true,
         });
         expect(
-            wrapper
-                .find('WithStyles(DataDownloadDialogActions)')
-                .prop('downloading')
+            wrapper.find('DataDownloadDialogActions').prop('downloading')
         ).toBe(true);
     });
 });

--- a/src/components/layers/download/__tests__/DataDownloadDialogActions.spec.js
+++ b/src/components/layers/download/__tests__/DataDownloadDialogActions.spec.js
@@ -6,7 +6,6 @@ describe('DataDownloadDialogActions', () => {
     const renderComponent = props =>
         shallow(
             <DataDownloadDialogActions
-                classes={{}}
                 downloading={false}
                 onStartClick={() => null}
                 onCancelClick={() => null}
@@ -16,10 +15,8 @@ describe('DataDownloadDialogActions', () => {
 
     it('Should render two buttons and NO loading spinner', () => {
         const wrapper = renderComponent();
-        expect(wrapper.find('WithStyles(ForwardRef(Button))').length).toBe(2);
-        expect(
-            wrapper.find('WithStyles(ForwardRef(CircularProgress))').length
-        ).toBe(0);
+        expect(wrapper.find('Button').length).toBe(2);
+        expect(wrapper.find('CircularLoader').length).toBe(0);
     });
 
     it('Should disable buttons and show loading spinner when loading', () => {
@@ -28,19 +25,17 @@ describe('DataDownloadDialogActions', () => {
         });
         expect(
             wrapper
-                .find('WithStyles(ForwardRef(Button))')
+                .find('Button')
                 .at(0)
                 .prop('disabled')
         ).toBe(true);
         expect(
             wrapper
-                .find('WithStyles(ForwardRef(Button))')
+                .find('Button')
                 .at(1)
                 .prop('disabled')
         ).toBe(true);
-        expect(
-            wrapper.find('WithStyles(ForwardRef(CircularProgress))').length
-        ).toBe(1);
+        expect(wrapper.find('CircularLoader').length).toBe(1);
     });
 
     it('Should call onStartClick', () => {
@@ -49,9 +44,7 @@ describe('DataDownloadDialogActions', () => {
             onStartClick: fn,
         });
 
-        wrapper
-            .find('WithStyles(ForwardRef(Button))[variant="contained"]')
-            .simulate('click');
+        wrapper.find('Button[primary=true]').simulate('click');
         expect(fn).toHaveBeenCalled();
     });
 
@@ -59,9 +52,7 @@ describe('DataDownloadDialogActions', () => {
         const fn = jest.fn();
         const wrapper = renderComponent({ onCancelClick: fn });
 
-        wrapper
-            .find('WithStyles(ForwardRef(Button))[variant="text"]')
-            .simulate('click');
+        wrapper.find('Button[secondary=true]').simulate('click');
         expect(fn).toHaveBeenCalled();
     });
 });

--- a/src/components/layers/download/__tests__/DataDownloadDialogContent.spec.js
+++ b/src/components/layers/download/__tests__/DataDownloadDialogContent.spec.js
@@ -11,7 +11,6 @@ describe('DataDownloadDialogContent', () => {
     const renderOuterComponent = props =>
         shallow(
             <DataDownloadDialogContent
-                classes={{}}
                 isEventLayer={false}
                 error={null}
                 layerName={'Test Layer'}

--- a/src/components/layers/download/styles/DataDownloadDialogActions.module.css
+++ b/src/components/layers/download/styles/DataDownloadDialogActions.module.css
@@ -1,0 +1,5 @@
+.btnProgress {
+    position: 'absolute';
+    top: -10px;
+    left: calc(50% - 25px);
+}

--- a/src/components/layers/download/styles/DataDownloadDialogActions.module.css
+++ b/src/components/layers/download/styles/DataDownloadDialogActions.module.css
@@ -1,5 +1,5 @@
 .btnProgress {
-    position: 'absolute';
+    position: absolute;
     top: -10px;
     left: calc(50% - 25px);
 }

--- a/src/components/layers/download/styles/DataDownloadDialogContent.module.css
+++ b/src/components/layers/download/styles/DataDownloadDialogContent.module.css
@@ -8,12 +8,11 @@
 
 .infoDiv {
     height: var(
-        --spacers-dp20
+        --spacers-dp24
     ); /* Ensure that we have enough buffer around the svg icon to prevent unnecessary scrollbars */
     display: flex;
     align-items: center;
     font-size: 0.85em;
-    color: black; /* theme.palette.text.secondary; */
 }
 
 .icon {
@@ -23,5 +22,5 @@
 
 .error {
     margin-top: var(--spacers-dp12);
-    color: red; /* theme.palette.error.main, */
+    color: var(--warning);
 }

--- a/src/components/layers/download/styles/DataDownloadDialogContent.module.css
+++ b/src/components/layers/download/styles/DataDownloadDialogContent.module.css
@@ -1,0 +1,27 @@
+.contentDiv {
+    margin-bottom: var(--spacers-dp12);
+}
+
+.inputContainer {
+    margin-top: var(--spacers-dp32);
+}
+
+.infoDiv {
+    height: var(
+        --spacers-dp20
+    ); /* Ensure that we have enough buffer around the svg icon to prevent unnecessary scrollbars */
+    display: flex;
+    align-items: center;
+    font-size: 0.85em;
+    color: black; /* theme.palette.text.secondary; */
+}
+
+.icon {
+    font-size: 1.125em;
+    margin-right: var(--spacers-dp8);
+}
+
+.error {
+    margin-top: var(--spacers-dp12);
+    color: red; /* theme.palette.error.main, */
+}

--- a/src/components/layers/download/styles/DataDownloadDialogContent.module.css
+++ b/src/components/layers/download/styles/DataDownloadDialogContent.module.css
@@ -13,14 +13,15 @@
     display: flex;
     align-items: center;
     font-size: 0.85em;
+    color: var(--colors-grey800);
 }
 
 .icon {
-    font-size: 1.125em;
     margin-right: var(--spacers-dp8);
+    vertical-align: bottom;
 }
 
 .error {
     margin-top: var(--spacers-dp12);
-    color: var(--warning);
+    color: var(--theme-warning);
 }

--- a/src/components/openAs/OpenAsMapDialog.js
+++ b/src/components/openAs/OpenAsMapDialog.js
@@ -1,15 +1,15 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
-import { withStyles } from '@material-ui/core/styles';
 import {
-    Dialog,
-    DialogTitle,
-    DialogContent,
-    DialogActions,
+    Modal,
+    ModalTitle,
+    ModalContent,
+    ModalActions,
     Button,
-} from '@material-ui/core';
+    ButtonStrip,
+} from '@dhis2/ui';
 import SelectField from '../core/SelectField';
 import { loadLayer } from '../../actions/layers';
 import { clearAnalyticalObject } from '../../actions/analyticalObject';
@@ -17,17 +17,7 @@ import {
     getDataDimensionsFromAnalyticalObject,
     getThematicLayerFromAnalyticalObject,
 } from '../../util/analyticalObject';
-
-const styles = {
-    content: {
-        minHeight: 80,
-    },
-    description: {
-        fontSize: 14,
-        lineHeight: '20px',
-        paddingBottom: 8,
-    },
-};
+import styles from './styles/OpenAsMapDialog.module.css';
 
 export class OpenAsMapDialog extends Component {
     static propTypes = {
@@ -35,7 +25,6 @@ export class OpenAsMapDialog extends Component {
         ao: PropTypes.object,
         loadLayer: PropTypes.func.isRequired,
         clearAnalyticalObject: PropTypes.func.isRequired,
-        classes: PropTypes.object.isRequired,
     };
 
     state = {
@@ -60,7 +49,7 @@ export class OpenAsMapDialog extends Component {
     }
 
     render() {
-        const { ao, showDialog, clearAnalyticalObject, classes } = this.props;
+        const { ao, showDialog, clearAnalyticalObject } = this.props;
         const { selectedDataDims } = this.state;
 
         if (!showDialog) {
@@ -71,14 +60,12 @@ export class OpenAsMapDialog extends Component {
         const disableProceedBtn = !selectedDataDims.length;
 
         return (
-            <Dialog open={showDialog} onClose={this.onClose}>
-                <DialogTitle disableTypography={true}>
-                    {i18n.t('Open as map')}
-                </DialogTitle>
-                <DialogContent className={classes.content}>
+            <Modal small position="middle" onClose={this.onClose}>
+                <ModalTitle>{i18n.t('Open as map')}</ModalTitle>
+                <ModalContent>
                     {dataDims.length > 1 && (
-                        <Fragment>
-                            <div className={classes.description}>
+                        <div className={styles.content}>
+                            <div className={styles.description}>
                                 {i18n.t(
                                     'This chart/table contains {{numItems}} data items. Choose which items you want to import from the list below. Each data item will be created as a map layer.',
                                     {
@@ -93,22 +80,24 @@ export class OpenAsMapDialog extends Component {
                                 multiple={true}
                                 onChange={this.onSelectDataDim}
                             />
-                        </Fragment>
+                        </div>
                     )}
-                </DialogContent>
-                <DialogActions>
-                    <Button color="primary" onClick={clearAnalyticalObject}>
-                        {i18n.t('Cancel')}
-                    </Button>
-                    <Button
-                        disabled={disableProceedBtn}
-                        color="primary"
-                        onClick={this.onProceedClick}
-                    >
-                        {i18n.t('Proceed')}
-                    </Button>
-                </DialogActions>
-            </Dialog>
+                </ModalContent>
+                <ModalActions>
+                    <ButtonStrip end>
+                        <Button secondary onClick={clearAnalyticalObject}>
+                            {i18n.t('Cancel')}
+                        </Button>
+                        <Button
+                            disabled={disableProceedBtn}
+                            primary
+                            onClick={this.onProceedClick}
+                        >
+                            {i18n.t('Proceed')}
+                        </Button>
+                    </ButtonStrip>
+                </ModalActions>
+            </Modal>
         );
     }
 
@@ -147,4 +136,4 @@ export default connect(
         loadLayer,
         clearAnalyticalObject,
     }
-)(withStyles(styles)(OpenAsMapDialog));
+)(OpenAsMapDialog);

--- a/src/components/openAs/styles/OpenAsMapDialog.module.css
+++ b/src/components/openAs/styles/OpenAsMapDialog.module.css
@@ -1,0 +1,9 @@
+.content {
+    min-height: 80px;
+}
+
+.description {
+    font-size: 14px;
+    line-height: 20px;
+    padding-bottom: 8px;
+}


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-9699

The primary focus for this PR is to is to switch from Material UI dialogs to @dhis2/ui modals. There will still be Material UI components within the modals that will be replaced in later PRs. 

The updated components are: 
- Layer dialog (add/edit layer)
- Layer download dialog
- Open as map dialog

There are also som updated translations that originates in a previous PR #1147 

Layer modal after this PR (@dhis2/ui modal and buttons): 

<img width="613" alt="Screenshot 2020-10-19 at 12 10 31" src="https://user-images.githubusercontent.com/548708/96431733-38f9db80-1204-11eb-9ebf-56735dbe974b.png">

Layer dialog before this PR: 

<img width="611" alt="Screenshot 2020-10-19 at 12 13 08" src="https://user-images.githubusercontent.com/548708/96431955-8aa26600-1204-11eb-8add-4774e1b4f476.png">

Open as map modal after this PR (@dhis2/ui modal and buttons): 

<img width="412" alt="Screenshot 2020-10-19 at 13 02 13" src="https://user-images.githubusercontent.com/548708/96442468-7ada5000-120b-11eb-9fbb-0e6bd457007e.png">

Open as map dialog before this PR: 

<img width="415" alt="Screenshot 2020-10-19 at 13 01 48" src="https://user-images.githubusercontent.com/548708/96442493-83cb2180-120b-11eb-8c98-9d3bfce70fa9.png">

Layer download modal after this PR (@dhis2/ui modal and buttons): 

<img width="618" alt="Screenshot 2020-10-19 at 12 49 09" src="https://user-images.githubusercontent.com/548708/96441382-ba07a180-1209-11eb-9540-57c03c871c4d.png">

In "download state": 

<img width="614" alt="Screenshot 2020-10-19 at 12 53 05" src="https://user-images.githubusercontent.com/548708/96442228-10c1ab00-120b-11eb-84a4-6f71d32f3caa.png">

Showing error: 

<img width="609" alt="Screenshot 2020-10-19 at 12 59 02" src="https://user-images.githubusercontent.com/548708/96442254-1b7c4000-120b-11eb-81ba-d0451086e2b4.png">

Layer download before PR: 

<img width="616" alt="Screenshot 2020-10-19 at 12 49 27" src="https://user-images.githubusercontent.com/548708/96441398-bffd8280-1209-11eb-94d5-1e77ca5b5ea3.png">

There are issues with z-index with this PR, so it will not be merged to master but a separate branch (chore/dhis2/ui) where these issues will be fixed before merging to master. 

<img width="740" alt="Screenshot 2020-10-19 at 12 31 20" src="https://user-images.githubusercontent.com/548708/96441456-d6a3d980-1209-11eb-8d1d-d32153ad3dcc.png">

