### PR TITLE
chore: switch to @dhis2/ui InputField for date picker (DHIS2-9699)

### DIFF
--- a/src/components/core/DatePicker.js
+++ b/src/components/core/DatePicker.js
@@ -1,37 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
-import { TextField } from '@material-ui/core';
+import { InputField } from '@dhis2/ui';
 import { formatDate } from '../../util/time';
+import styles from './styles/DatePicker.module.css';
 
-const styles = {
-    root: {
-        margin: '12px 0',
-    },
-};
-
-// DatePicker not yet supported in Material-UI: https://github.com/mui-org/material-ui/issues/4787
+// DatePicker not yet supported in @dhis2/ui
 // Fallback on browser native
-const DatePicker = ({ label, value, onChange, classes, style }) => (
-    <TextField
-        type="date"
-        label={label}
-        defaultValue={formatDate(value)}
-        onChange={event => onChange(event.target.value)}
-        style={style}
-        classes={classes}
-        InputLabelProps={{
-            shrink: true,
-        }}
-    />
+const DatePicker = ({ label, value, onChange, style }) => (
+    <div className={styles.datePicker} style={style}>
+        <InputField
+            type="date"
+            label={label}
+            value={formatDate(value)}
+            onChange={({ value }) => onChange(value)}
+        />
+    </div>
 );
 
 DatePicker.propTypes = {
     label: PropTypes.string.isRequired,
     value: PropTypes.string,
     onChange: PropTypes.func.isRequired,
-    classes: PropTypes.object.isRequired,
     style: PropTypes.object,
 };
 
-export default withStyles(styles)(DatePicker);
+export default DatePicker;

--- a/src/components/core/styles/DatePicker.module.css
+++ b/src/components/core/styles/DatePicker.module.css
@@ -1,0 +1,3 @@
+.datePicker {
+    margin: var(--spacers-dp8) 0;
+}


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-9699

This PR switches from MUI TextField to @dhis2/ui InputField for the date picker. We don't yet have a custom date picker so this is still using browser native. 

We also plan to switch to the period selector used in DV, but I don't want to mix that in the MUI -> @dhis2/ui work. 

After this PR: 

<img width="596" alt="Screenshot 2020-10-24 at 11 44 40" src="https://user-images.githubusercontent.com/548708/97078748-8607f400-15ee-11eb-9598-1f24c4b7520f.png">
<img width="597" alt="Screenshot 2020-10-24 at 11 44 59" src="https://user-images.githubusercontent.com/548708/97078749-87392100-15ee-11eb-9ba2-7ef55467c666.png">
<img width="598" alt="Screenshot 2020-10-24 at 11 45 16" src="https://user-images.githubusercontent.com/548708/97078751-87392100-15ee-11eb-8fc4-4b89899565d1.png">

Before this PR:

<img width="597" alt="Screenshot 2020-10-24 at 11 47 37" src="https://user-images.githubusercontent.com/548708/97078789-d4b58e00-15ee-11eb-92ab-3f262a43a592.png">
<img width="595" alt="Screenshot 2020-10-24 at 11 47 53" src="https://user-images.githubusercontent.com/548708/97078790-d54e2480-15ee-11eb-8cad-d5bcef410b74.png">
<img width="596" alt="Screenshot 2020-10-24 at 11 48 06" src="https://user-images.githubusercontent.com/548708/97078791-d67f5180-15ee-11eb-9b8b-1314a1d58ecd.png">
