### PR TITLE
chore: refactor period select to use @dhis2/ui and css modules

### DIFF
--- a/src/components/orgunits/styles/OrgUnitDialog.module.css
+++ b/src/components/orgunits/styles/OrgUnitDialog.module.css
@@ -17,5 +17,4 @@
 .data {
     float: left;
     width: 345px;
-    margin-top: -12px;
 }

--- a/src/components/periods/PeriodSelect.js
+++ b/src/components/periods/PeriodSelect.js
@@ -85,12 +85,14 @@ class PeriodSelect extends Component {
                     <div className={styles.stepper}>
                         <Tooltip content={i18n.t('Previous year')}>
                             <Button
+                                secondary
                                 icon={<LeftIcon />}
                                 onClick={this.previousYear}
                             />
                         </Tooltip>
                         <Tooltip content={i18n.t('Next year')}>
                             <Button
+                                secondary
                                 icon={<RightIcon />}
                                 onClick={this.nextYear}
                             />

--- a/src/components/periods/PeriodSelect.js
+++ b/src/components/periods/PeriodSelect.js
@@ -1,37 +1,19 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
-import SelectField from '../core/SelectField';
-import { IconButton } from '@material-ui/core';
+import { Button, Tooltip } from '@dhis2/ui';
 import LeftIcon from '@material-ui/icons/ChevronLeft';
 import RightIcon from '@material-ui/icons/ChevronRight';
+import cx from 'classnames';
 import { filterFuturePeriods } from 'd2/period/helpers';
+import SelectField from '../core/SelectField';
 import { createPeriods } from '../../util/periods';
 import { getYear } from '../../util/time';
-
-const styles = () => ({
-    select: {
-        margin: '12px 0',
-        width: 'calc(100% - 60px)',
-    },
-    stepper: {
-        display: 'inline-block',
-        verticalAlign: 'top',
-        marginTop: 34,
-        marginLeft: 12,
-    },
-    button: {
-        width: 24,
-        height: 24,
-        padding: 0,
-    },
-});
+import styles from './styles/PeriodSelect.module.css';
 
 class PeriodSelect extends Component {
     static propTypes = {
-        classes: PropTypes.object.isRequired,
         locale: PropTypes.string,
         periodType: PropTypes.string,
         period: PropTypes.shape({
@@ -74,7 +56,6 @@ class PeriodSelect extends Component {
 
     render() {
         const {
-            classes,
             periodType,
             period,
             onChange,
@@ -82,39 +63,39 @@ class PeriodSelect extends Component {
             errorText,
         } = this.props;
         const { periods } = this.state;
-        const value = period ? period.id : null;
 
         if (!periods) {
             return null;
         }
 
+        const value =
+            period && periods.some(p => p.id === period.id) ? period.id : null;
+
         return (
-            <div className={className} style={{ height: 100 }}>
-                <SelectField
-                    label={i18n.t('Period')}
-                    items={periods}
-                    value={value}
-                    onChange={onChange}
-                    errorText={!value && errorText ? errorText : null}
-                />
+            <div className={cx(styles.periodSelect, className)}>
+                <div className={styles.select}>
+                    <SelectField
+                        label={i18n.t('Period')}
+                        items={periods}
+                        value={value}
+                        onChange={onChange}
+                        errorText={!value && errorText ? errorText : null}
+                    />
+                </div>
                 {periodType && (
-                    <div className={classes.stepper}>
-                        <IconButton
-                            tooltip={i18n.t('Previous year')}
-                            onClick={this.previousYear}
-                            className={classes.button}
-                            disableTouchRipple={true}
-                        >
-                            <LeftIcon />
-                        </IconButton>
-                        <IconButton
-                            tooltip={i18n.t('Next year')}
-                            onClick={this.nextYear}
-                            className={classes.button}
-                            disableTouchRipple={true}
-                        >
-                            <RightIcon />
-                        </IconButton>
+                    <div className={styles.stepper}>
+                        <Tooltip content={i18n.t('Previous year')}>
+                            <Button
+                                icon={<LeftIcon />}
+                                onClick={this.previousYear}
+                            />
+                        </Tooltip>
+                        <Tooltip content={i18n.t('Next year')}>
+                            <Button
+                                icon={<RightIcon />}
+                                onClick={this.nextYear}
+                            />
+                        </Tooltip>
                     </div>
                 )}
             </div>
@@ -156,4 +137,4 @@ class PeriodSelect extends Component {
 
 export default connect(({ settings }) => ({
     locale: settings.user.keyUiLocale,
-}))(withStyles(styles)(PeriodSelect));
+}))(PeriodSelect);

--- a/src/components/periods/PeriodSelect.js
+++ b/src/components/periods/PeriodSelect.js
@@ -73,15 +73,14 @@ class PeriodSelect extends Component {
 
         return (
             <div className={cx(styles.periodSelect, className)}>
-                <div className={styles.select}>
-                    <SelectField
-                        label={i18n.t('Period')}
-                        items={periods}
-                        value={value}
-                        onChange={onChange}
-                        errorText={!value && errorText ? errorText : null}
-                    />
-                </div>
+                <SelectField
+                    label={i18n.t('Period')}
+                    items={periods}
+                    value={value}
+                    onChange={onChange}
+                    errorText={!value && errorText ? errorText : null}
+                    className={styles.select}
+                />
                 {periodType && (
                     <div className={styles.stepper}>
                         <Tooltip content={i18n.t('Previous year')}>

--- a/src/components/periods/styles/PeriodSelect.module.css
+++ b/src/components/periods/styles/PeriodSelect.module.css
@@ -4,9 +4,13 @@
 }
 
 .select {
-    width: calc(100% - 80px);
+    width: calc(100% - 84px);
 }
 
 .stepper {
     margin: 0 0 10px 4px;
+}
+
+.stepper > span:first-child {
+    margin-right: 4px;
 }

--- a/src/components/periods/styles/PeriodSelect.module.css
+++ b/src/components/periods/styles/PeriodSelect.module.css
@@ -1,0 +1,12 @@
+.periodSelect {
+    display: flex;
+    align-items: flex-end;
+}
+
+.select {
+    width: calc(100% - 80px);
+}
+
+.stepper {
+    margin: 0 0 10px 4px;
+}


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-9699

This PR replaces MUI buttons with @dhis2/ui buttons, and switches to CSS Modules for the period select. 

The tooltip is not showing correctly due to the same placement issue as earlier (which is hopefully fixed when we get rid of all MUI styles, we are not merging to master yet). 

After this PR: 

<img width="592" alt="Screenshot 2020-10-28 at 17 03 46" src="https://user-images.githubusercontent.com/548708/97463005-9813ca80-193f-11eb-9a06-ccce0ab60d6c.png">

Before: 

![Screenshot 2020-10-28 at 12 31 37](https://user-images.githubusercontent.com/548708/97430698-8fa89900-1919-11eb-8e76-222b47cb20c1.png)

After this PR: 

<img width="610" alt="Screenshot 2020-10-28 at 17 04 55" src="https://user-images.githubusercontent.com/548708/97463327-eb861880-193f-11eb-995f-4830d55f5659.png">

Before:

![Screenshot 2020-10-28 at 12 32 51](https://user-images.githubusercontent.com/548708/97430854-c1b9fb00-1919-11eb-9de7-a8cf9d88a0bf.png)
