### PR TITLE
chore: replace MUI Checkbox with @dhis2/ui Checkbox (DHIS2-9699)

### DIFF
--- a/src/components/core/Checkbox.js
+++ b/src/components/core/Checkbox.js
@@ -1,50 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
-import { Checkbox as MuiCheckbox, FormControlLabel } from '@material-ui/core';
+import { Checkbox as UiCheckbox } from '@dhis2/ui';
+import cx from 'classnames';
+import styles from './styles/Checkbox.module.css';
 
-const styles = {
-    root: {
-        margin: '12px 0',
-    },
-};
-
-// Wrapper around MUI Checkbox with label support
+// Wrapper around @dhis2/ui checkbox for unified handling and styling
 const Checkbox = ({
     label,
     checked = false,
-    onCheck,
     disabled,
-    classes,
+    onChange,
     className,
-    style,
 }) => (
-    <FormControlLabel
-        label={label}
-        control={
-            <MuiCheckbox
-                color="primary"
-                checked={checked}
-                onChange={(event, isChecked) => onCheck(isChecked)}
-                disabled={disabled}
-            />
-        }
-        classes={classes}
-        className={className}
-        style={style}
-    />
+    <div className={cx(styles.checkbox, className)}>
+        <UiCheckbox
+            label={label}
+            checked={checked}
+            disabled={disabled}
+            onChange={({ checked }) => onChange(checked)}
+        />
+    </div>
 );
 
 Checkbox.propTypes = {
     label: PropTypes.string,
     checked: PropTypes.bool,
-    onCheck: PropTypes.func.isRequired,
-    style: PropTypes.object,
-    labelStyle: PropTypes.object,
-    iconStyle: PropTypes.object,
     disabled: PropTypes.bool,
+    onChange: PropTypes.func.isRequired,
     className: PropTypes.string,
-    classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(Checkbox);
+export default Checkbox;

--- a/src/components/core/styles/Checkbox.module.css
+++ b/src/components/core/styles/Checkbox.module.css
@@ -1,0 +1,3 @@
+.checkbox {
+    padding: var(--spacers-dp12) var(--spacers-dp8);
+}

--- a/src/components/download/DownloadDialog.js
+++ b/src/components/download/DownloadDialog.js
@@ -7,10 +7,10 @@ import {
     ModalTitle,
     ModalContent,
     ModalActions,
-    Checkbox,
     Button,
     ButtonStrip,
 } from '@dhis2/ui';
+import Checkbox from '../core/Checkbox';
 import LegendPosition from './LegendPosition';
 import {
     toggleDownloadDialog,
@@ -70,26 +70,20 @@ export class DownloadDialog extends Component {
                     <div className={styles.modalContent}>
                         {isSupported ? (
                             <Fragment>
-                                <div className={styles.checkbox}>
-                                    <Checkbox
-                                        label={i18n.t('Show name')}
-                                        checked={showName}
-                                        disabled={!hasName}
-                                        onChange={({ checked }) =>
-                                            toggleDownloadShowName(checked)
-                                        }
-                                    />
-                                </div>
-                                <div className={styles.checkbox}>
-                                    <Checkbox
-                                        label={i18n.t('Show legend')}
-                                        checked={showLegend}
-                                        disabled={!hasLegend}
-                                        onChange={({ checked }) =>
-                                            toggleDownloadShowLegend(checked)
-                                        }
-                                    />
-                                </div>
+                                <Checkbox
+                                    label={i18n.t('Show name')}
+                                    checked={showName}
+                                    disabled={!hasName}
+                                    onChange={toggleDownloadShowName}
+                                    // className={styles.checkbox}
+                                />
+                                <Checkbox
+                                    label={i18n.t('Show legend')}
+                                    checked={showLegend}
+                                    disabled={!hasLegend}
+                                    onChange={toggleDownloadShowLegend}
+                                    // className={styles.checkbox}
+                                />
                                 {hasLegend && showLegend && (
                                     <LegendPosition
                                         position={legendPosition}

--- a/src/components/download/DownloadDialog.js
+++ b/src/components/download/DownloadDialog.js
@@ -75,14 +75,12 @@ export class DownloadDialog extends Component {
                                     checked={showName}
                                     disabled={!hasName}
                                     onChange={toggleDownloadShowName}
-                                    // className={styles.checkbox}
                                 />
                                 <Checkbox
                                     label={i18n.t('Show legend')}
                                     checked={showLegend}
                                     disabled={!hasLegend}
                                     onChange={toggleDownloadShowLegend}
-                                    // className={styles.checkbox}
                                 />
                                 {hasLegend && showLegend && (
                                     <LegendPosition

--- a/src/components/download/__tests__/DownloadDialog.spec.js
+++ b/src/components/download/__tests__/DownloadDialog.spec.js
@@ -137,10 +137,10 @@ describe('DownloadDialog', () => {
         });
         const checkbox = wrapper.find('Checkbox').at(0);
 
-        checkbox.simulate('change', { checked: true });
+        checkbox.simulate('change', true);
         expect(toggleDownloadShowNameSpy).toHaveBeenCalledWith(true);
 
-        checkbox.simulate('change', { checked: false });
+        checkbox.simulate('change', false);
         expect(toggleDownloadShowNameSpy).toHaveBeenCalledWith(false);
     });
 
@@ -189,10 +189,10 @@ describe('DownloadDialog', () => {
         });
         const checkbox = wrapper.find('Checkbox').at(1);
 
-        checkbox.simulate('change', { checked: true });
+        checkbox.simulate('change', true);
         expect(toggleDownloadShowLegendSpy).toHaveBeenCalledWith(true);
 
-        checkbox.simulate('change', { checked: false });
+        checkbox.simulate('change', false);
         expect(toggleDownloadShowLegendSpy).toHaveBeenCalledWith(false);
     });
 

--- a/src/components/download/__tests__/__snapshots__/DownloadDialog.spec.js.snap
+++ b/src/components/download/__tests__/__snapshots__/DownloadDialog.spec.js.snap
@@ -18,28 +18,18 @@ exports[`DownloadDialog Should match snapshot when showDialog is true 1`] = `
     <div
       className="modalContent"
     >
-      <div
-        className="checkbox"
-      >
-        <Checkbox
-          checked={false}
-          dataTest="dhis2-uicore-checkbox"
-          disabled={true}
-          label="Show name"
-          onChange={[Function]}
-        />
-      </div>
-      <div
-        className="checkbox"
-      >
-        <Checkbox
-          checked={false}
-          dataTest="dhis2-uicore-checkbox"
-          disabled={true}
-          label="Show legend"
-          onChange={[Function]}
-        />
-      </div>
+      <Checkbox
+        checked={false}
+        disabled={true}
+        label="Show name"
+        onChange={[Function]}
+      />
+      <Checkbox
+        checked={false}
+        disabled={true}
+        label="Show legend"
+        onChange={[Function]}
+      />
     </div>
   </ModalContent>
   <ModalActions

--- a/src/components/edit/BoundaryDialog.js
+++ b/src/components/edit/BoundaryDialog.js
@@ -142,7 +142,7 @@ class BoundaryDialog extends Component {
                                     <Checkbox
                                         label={i18n.t('Labels')}
                                         checked={labels}
-                                        onCheck={setLabels}
+                                        onChange={setLabels}
                                         className={styles.labelsCheckbox}
                                     />
                                     {labels && (

--- a/src/components/edit/FacilityDialog.js
+++ b/src/components/edit/FacilityDialog.js
@@ -205,7 +205,7 @@ class FacilityDialog extends Component {
                                 <Checkbox
                                     label={i18n.t('Labels')}
                                     checked={labels}
-                                    onCheck={setLabels}
+                                    onChange={setLabels}
                                     className={styles.checkboxInline}
                                 />
                                 {labels && (
@@ -226,7 +226,7 @@ class FacilityDialog extends Component {
                                 <Checkbox
                                     label={i18n.t('Buffer')}
                                     checked={showBuffer}
-                                    onCheck={this.onShowBufferClick.bind(this)}
+                                    onChange={this.onShowBufferClick.bind(this)}
                                     className={styles.checkboxInline}
                                 />
                                 {showBuffer && (

--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -351,6 +351,7 @@ export class EventDialog extends Component {
                                             value={areaRadius || ''}
                                             onChange={setAreaRadius}
                                             disabled={eventClustering}
+                                            className={styles.flexInnerColumn}
                                         />
                                     )}
                                 </div>

--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -342,7 +342,7 @@ export class EventDialog extends Component {
                                         onChange={this.onShowBufferClick.bind(
                                             this
                                         )}
-                                        className={styles.flexInnerColumn}
+                                        className={styles.checkboxInline}
                                         disabled={eventClustering}
                                     />
                                     {showBuffer && (
@@ -350,7 +350,6 @@ export class EventDialog extends Component {
                                             label={i18n.t('Radius in meters')}
                                             value={areaRadius || ''}
                                             onChange={setAreaRadius}
-                                            className={styles.flexInnerColumn}
                                             disabled={eventClustering}
                                         />
                                     )}

--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -339,7 +339,7 @@ export class EventDialog extends Component {
                                     <Checkbox
                                         label={i18n.t('Buffer')}
                                         checked={showBuffer}
-                                        onCheck={this.onShowBufferClick.bind(
+                                        onChange={this.onShowBufferClick.bind(
                                             this
                                         )}
                                         className={styles.flexInnerColumn}

--- a/src/components/edit/styles/LayerDialog.module.css
+++ b/src/components/edit/styles/LayerDialog.module.css
@@ -68,11 +68,11 @@
 
 .checkboxInline {
     height: 70px;
-    padding-right: 40px;
+    margin: 24px 40px 0 0;
 }
 
 .fontInline {
-    margin: -20px 0 20px;
+    margin: -10px 0 10px;
 }
 
 .fontBlock {
@@ -82,6 +82,10 @@
 .numberField {
     composes: flexInnerColumn;
     max-width: 140px;
+}
+
+.checkbox {
+    margin: 8px 0 0 -8px;
 }
 
 /* Tracked entity */
@@ -95,8 +99,7 @@
 /* Boundary */
 
 .radius {
-    margin-left: var(--spacers-dp12);
-    width: 127px;
+    width: 120px;
 }
 
 .boundaryFont {

--- a/src/components/edit/styles/LayerDialog.module.css
+++ b/src/components/edit/styles/LayerDialog.module.css
@@ -76,7 +76,7 @@
 }
 
 .fontBlock {
-    margin: -24px 8px 0 42px;
+    margin: -12px 8px 8px 38px;
 }
 
 .numberField {

--- a/src/components/edit/thematic/NoDataColor.js
+++ b/src/components/edit/thematic/NoDataColor.js
@@ -4,6 +4,7 @@ import i18n from '@dhis2/d2-i18n';
 import Checkbox from '../../core/Checkbox';
 import ColorPicker from '../../core/ColorPicker';
 import { NO_DATA_COLOR } from '../../../constants/layers';
+import styles from './styles/NoDataColor.module.css';
 
 const NoDataColor = ({ value, onChange, className }) => {
     const onCheck = useCallback(
@@ -16,11 +17,8 @@ const NoDataColor = ({ value, onChange, className }) => {
             <Checkbox
                 label={i18n.t('Show no data')}
                 checked={!!value}
-                onCheck={onCheck}
-                style={{
-                    margin: '0 40px 0 -4px',
-                    height: 60,
-                }}
+                onChange={onCheck}
+                className={styles.checkbox}
             />
             {value && (
                 <ColorPicker
@@ -28,10 +26,7 @@ const NoDataColor = ({ value, onChange, className }) => {
                     color={value}
                     onChange={onChange}
                     width={50}
-                    style={{
-                        display: 'inline-block',
-                        marginTop: -6,
-                    }}
+                    className={styles.colorPicker}
                 />
             )}
         </div>

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -548,7 +548,7 @@ export class ThematicDialog extends Component {
                                     <Checkbox
                                         label={i18n.t('Labels')}
                                         checked={labels}
-                                        onCheck={setLabels}
+                                        onChange={setLabels}
                                     />
                                 </div>
                                 {labels && (

--- a/src/components/edit/thematic/styles/NoDataColor.module.css
+++ b/src/components/edit/thematic/styles/NoDataColor.module.css
@@ -1,0 +1,9 @@
+.checkbox {
+    margin: 0 40px 0 -4px;
+    height: 60px;
+}
+
+.colorPicker {
+    display: inline-block;
+    margin-top: -6px;
+}

--- a/src/components/edit/thematic/styles/NoDataColor.module.css
+++ b/src/components/edit/thematic/styles/NoDataColor.module.css
@@ -1,5 +1,5 @@
 .checkbox {
-    margin: 0 40px 0 -4px;
+    margin-right: 40px;
     height: 60px;
 }
 

--- a/src/components/edit/trackedEntity/TrackedEntityDialog.js
+++ b/src/components/edit/trackedEntity/TrackedEntityDialog.js
@@ -235,7 +235,7 @@ export class TrackedEntityDialog extends Component {
                                 <Checkbox
                                     label={i18n.t('Follow up')}
                                     checked={followUp}
-                                    onCheck={setFollowUpStatus}
+                                    onChange={setFollowUpStatus}
                                     className={styles.checkbox}
                                 />
                             )}
@@ -283,7 +283,7 @@ export class TrackedEntityDialog extends Component {
                                     checked={
                                         this.state.showRelationshipsChecked
                                     }
-                                    onCheck={checked => {
+                                    onChange={checked => {
                                         if (!checked) {
                                             setTrackedEntityRelationshipType(
                                                 null
@@ -324,7 +324,7 @@ export class TrackedEntityDialog extends Component {
                                                     relationshipOutsideProgram ===
                                                     true
                                                 }
-                                                onCheck={
+                                                onChange={
                                                     setTrackedEntityRelationshipOutsideProgram
                                                 }
                                                 style={{
@@ -416,7 +416,7 @@ export class TrackedEntityDialog extends Component {
                                     <Checkbox
                                         label={i18n.t('Buffer')}
                                         checked={showBuffer}
-                                        onCheck={this.onShowBufferClick}
+                                        onChange={this.onShowBufferClick}
                                         className={styles.flexInnerColumn}
                                     />
                                     {showBuffer && (

--- a/src/components/edit/trackedEntity/TrackedEntityDialog.js
+++ b/src/components/edit/trackedEntity/TrackedEntityDialog.js
@@ -417,14 +417,14 @@ export class TrackedEntityDialog extends Component {
                                         label={i18n.t('Buffer')}
                                         checked={showBuffer}
                                         onChange={this.onShowBufferClick}
-                                        className={styles.flexInnerColumn}
+                                        className={styles.checkboxInline}
                                     />
                                     {showBuffer && (
                                         <NumberField
                                             label={i18n.t('Radius in meters')}
                                             value={areaRadius || ''}
                                             onChange={setAreaRadius}
-                                            className={styles.flexInnerColumn}
+                                            className={styles.radius}
                                         />
                                     )}
                                 </div>

--- a/src/components/filter/FilterSelect.js
+++ b/src/components/filter/FilterSelect.js
@@ -113,7 +113,9 @@ export class FilterSelect extends Component {
                     key="checkbox"
                     label={i18n.t('Yes')}
                     checked={value == 1 ? true : false}
-                    onCheck={isChecked => onChange(isChecked ? 'IN:1' : 'IN:0')}
+                    onChange={isChecked =>
+                        onChange(isChecked ? 'IN:1' : 'IN:0')
+                    }
                 />
             ) : null,
             valueType === 'DATE' ? (

--- a/src/components/layers/download/EventDownloadInputs.js
+++ b/src/components/layers/download/EventDownloadInputs.js
@@ -47,7 +47,7 @@ export const EventDownloadInputs = ({
                 }}
                 label={i18n.t('Use human-readable keys')}
                 checked={humanReadableChecked}
-                onCheck={onCheckHumanReadable}
+                onChange={onCheckHumanReadable}
             />
         </div>
     </Fragment>

--- a/src/components/layers/download/__tests__/EventDownloadInputs.spec.js
+++ b/src/components/layers/download/__tests__/EventDownloadInputs.spec.js
@@ -27,10 +27,8 @@ describe('EventDownloadInputs', () => {
         expect(wrapper.find('SelectField').length).toBe(1);
         expect(wrapper.find('SelectField').prop('value')).toBe(0);
 
-        expect(wrapper.find('WithStyles(Checkbox)').length).toBe(1);
-        expect(wrapper.find('WithStyles(Checkbox)').prop('checked')).toBe(
-            false
-        );
+        expect(wrapper.find('Checkbox').length).toBe(1);
+        expect(wrapper.find('Checkbox').prop('checked')).toBe(false);
     });
 
     it('Should respect controlled inputs', () => {
@@ -40,8 +38,8 @@ describe('EventDownloadInputs', () => {
         });
         expect(wrapper.find('SelectField').prop('value')).toBe(2);
 
-        expect(wrapper.find('WithStyles(Checkbox)').length).toBe(1);
-        expect(wrapper.find('WithStyles(Checkbox)').prop('checked')).toBe(true);
+        expect(wrapper.find('Checkbox').length).toBe(1);
+        expect(wrapper.find('Checkbox').prop('checked')).toBe(true);
     });
 
     // it('Should toggle checked in onCheckHumanReadable callback when clicking the checkbox', () => {


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-9699

This PR switches from MUI Checkbox to @dhis2/ui Checkbox.

I decided to keep the wrapper component to avoid a div around every checkbox to apply styles, and to make event handling simpler. 

Some examples after this PR: 

<img width="277" alt="Screenshot 2020-10-28 at 18 21 55" src="https://user-images.githubusercontent.com/548708/97472922-aca99000-194a-11eb-953f-cc7c6bf0a175.png">

---

<img width="351" alt="Screenshot 2020-10-28 at 18 22 41" src="https://user-images.githubusercontent.com/548708/97472932-addabd00-194a-11eb-8192-332b21541dfc.png">

---

<img width="377" alt="Screenshot 2020-10-28 at 18 23 09" src="https://user-images.githubusercontent.com/548708/97472936-ae735380-194a-11eb-8ce5-ce19415accca.png">
