### PR TITLE
chore: replace MUI Radio with @dhis2/ui Radio (DHIS2-9699)

### DIFF
--- a/src/components/classification/LegendTypeSelect.js
+++ b/src/components/classification/LegendTypeSelect.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
-import { RadioGroup } from '@material-ui/core';
+import RadioGroup from '../core/RadioGroup';
 import Radio from '../core/Radio';
 import { setClassification } from '../../actions/layerEdit';
 import {
@@ -11,40 +10,19 @@ import {
     CLASSIFICATION_EQUAL_COUNTS,
 } from '../../constants/layers';
 
-const styles = {
-    radioGroup: {
-        paddingBottom: 16,
-    },
-    radio: {
-        height: 36,
-    },
-};
-
 // Select between user defined (automatic), predefined or single color
-export const LegendTypeSelect = ({
-    mapType,
-    method,
-    setClassification,
-    classes,
-}) =>
+export const LegendTypeSelect = ({ mapType, method, setClassification }) =>
     method ? (
         <RadioGroup
-            name="method"
             value={
                 method === CLASSIFICATION_EQUAL_COUNTS
                     ? CLASSIFICATION_EQUAL_INTERVALS
                     : method
             }
-            onChange={(event, method) => setClassification(Number(method))}
-            className={classes.radioGroup}
+            onChange={method => setClassification(Number(method))}
         >
             {getLegendTypes(mapType === 'BUBBLE').map(({ id, name }) => (
-                <Radio
-                    key={id}
-                    value={id}
-                    label={name}
-                    className={classes.radio}
-                />
+                <Radio key={id} value={id} label={name} />
             ))}
         </RadioGroup>
     ) : null;
@@ -53,9 +31,6 @@ LegendTypeSelect.propTypes = {
     method: PropTypes.number,
     mapType: PropTypes.string,
     setClassification: PropTypes.func.isRequired,
-    classes: PropTypes.object.isRequired,
 };
 
-export default connect(null, { setClassification })(
-    withStyles(styles)(LegendTypeSelect)
-);
+export default connect(null, { setClassification })(LegendTypeSelect);

--- a/src/components/core/Radio.js
+++ b/src/components/core/Radio.js
@@ -1,9 +1,32 @@
-import React from 'react';
-import { Radio as MuiRadio, FormControlLabel } from '@material-ui/core';
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { Radio as UiRadio } from '@dhis2/ui';
+import { RadioContext } from './RadioGroup';
 
-// Wrapper around MUI Radio with label support
-const Radio = props => (
-    <FormControlLabel {...props} control={<MuiRadio color="primary" />} />
-);
+const Radio = ({ value, dataTest, label }) => {
+    const { radio, onChange } = useContext(RadioContext);
+
+    // onChange is from the parent component
+    const onClick = () => {
+        if (value !== radio) {
+            onChange(value);
+        }
+    };
+
+    return (
+        <UiRadio
+            label={label}
+            checked={value === radio}
+            onChange={onClick}
+            dataTest={dataTest}
+        />
+    );
+};
+
+Radio.propTypes = {
+    label: PropTypes.string.isRequired,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    dataTest: PropTypes.string,
+};
 
 export default Radio;

--- a/src/components/core/Radio.js
+++ b/src/components/core/Radio.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Radio as UiRadio } from '@dhis2/ui';
 import { RadioContext } from './RadioGroup';
 
-const Radio = ({ value, dataTest, label }) => {
+const Radio = ({ value, disabled, dataTest, label }) => {
     const { radio, onChange } = useContext(RadioContext);
 
     // onChange is from the parent component
@@ -16,6 +16,7 @@ const Radio = ({ value, dataTest, label }) => {
     return (
         <UiRadio
             label={label}
+            disabled={disabled}
             checked={value === radio}
             onChange={onClick}
             dataTest={dataTest}
@@ -25,6 +26,7 @@ const Radio = ({ value, dataTest, label }) => {
 
 Radio.propTypes = {
     label: PropTypes.string.isRequired,
+    disabled: PropTypes.bool,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     dataTest: PropTypes.string,
 };

--- a/src/components/core/RadioGroup.js
+++ b/src/components/core/RadioGroup.js
@@ -1,0 +1,48 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { FieldGroup } from '@dhis2/ui';
+import styles from './styles/RadioGroup.module.css';
+
+export const RadioContext = React.createContext();
+
+const RadioGroup = ({
+    value,
+    label,
+    helpText,
+    onChange,
+    children,
+    dataTest,
+}) => {
+    const [radio, setRadio] = useState(value);
+
+    useEffect(() => {
+        if (value !== radio) {
+            setRadio(value);
+        }
+    }, [value, radio]);
+
+    return (
+        <RadioContext.Provider value={{ radio, onChange }}>
+            <div className={styles.radioGroup}>
+                <FieldGroup
+                    label={label}
+                    helpText={helpText}
+                    dataTest={dataTest}
+                >
+                    {children}
+                </FieldGroup>
+            </div>
+        </RadioContext.Provider>
+    );
+};
+
+RadioGroup.propTypes = {
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    label: PropTypes.string,
+    helpText: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    children: PropTypes.arrayOf(PropTypes.node),
+    dataTest: PropTypes.string,
+};
+
+export default RadioGroup;

--- a/src/components/core/RadioGroup.js
+++ b/src/components/core/RadioGroup.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { FieldGroup } from '@dhis2/ui';
+import cx from 'classnames';
 import styles from './styles/RadioGroup.module.css';
 
 export const RadioContext = React.createContext();
@@ -9,6 +10,7 @@ const RadioGroup = ({
     value,
     label,
     helpText,
+    display,
     onChange,
     children,
     dataTest,
@@ -23,7 +25,11 @@ const RadioGroup = ({
 
     return (
         <RadioContext.Provider value={{ radio, onChange }}>
-            <div className={styles.radioGroup}>
+            <div
+                className={cx(styles.radioGroup, {
+                    [styles.row]: display === 'row',
+                })}
+            >
                 <FieldGroup
                     label={label}
                     helpText={helpText}
@@ -40,6 +46,7 @@ RadioGroup.propTypes = {
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     label: PropTypes.string,
     helpText: PropTypes.string,
+    display: PropTypes.string,
     onChange: PropTypes.func.isRequired,
     children: PropTypes.arrayOf(PropTypes.node),
     dataTest: PropTypes.string,

--- a/src/components/core/styles/RadioGroup.module.css
+++ b/src/components/core/styles/RadioGroup.module.css
@@ -9,3 +9,15 @@
 .radioGroup fieldset > div > div > label {
     height: 36px;
 }
+
+.row {
+    margin: var(--spacers-dp8) 0;
+}
+
+.row fieldset > div > div {
+    display: flex;
+}
+
+.row fieldset > div > div > label {
+    margin-right: var(--spacers-dp16);
+}

--- a/src/components/core/styles/RadioGroup.module.css
+++ b/src/components/core/styles/RadioGroup.module.css
@@ -1,0 +1,11 @@
+.radioGroup {
+    margin-bottom: var(--spacers-dp12);
+}
+
+.radioGroup fieldset > div > label {
+    margin-top: var(--spacers-dp12);
+}
+
+.radioGroup fieldset > div > div > label {
+    height: 36px;
+}

--- a/src/components/dataElement/TotalsDetailsSelect.js
+++ b/src/components/dataElement/TotalsDetailsSelect.js
@@ -1,36 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
-import { withStyles } from '@material-ui/core/styles';
+import RadioGroup from '../core/RadioGroup';
 import Radio from '../core/Radio';
-import { RadioGroup } from '@material-ui/core';
 
-const styles = {
-    radioGroup: {
-        display: 'inline-block',
-        marginTop: 8,
-    },
-};
-
-const TotalsDetailsSelect = ({ operand, onChange, className, classes }) => (
-    <div style={className}>
-        <RadioGroup
-            name="operand"
-            value={operand === true ? 'details' : 'totals'}
-            onChange={(event, value) => onChange(value === 'details')}
-            className={classes.radioGroup}
-        >
-            <Radio value="totals" label={i18n.t('Totals')} />
-            <Radio value="details" label={i18n.t('Details')} />
-        </RadioGroup>
-    </div>
+const TotalsDetailsSelect = ({ operand, onChange }) => (
+    <RadioGroup
+        name="operand"
+        value={operand === true ? 'details' : 'totals'}
+        onChange={value => onChange(value === 'details')}
+    >
+        <Radio value="totals" label={i18n.t('Totals')} />
+        <Radio value="details" label={i18n.t('Details')} />
+    </RadioGroup>
 );
 
 TotalsDetailsSelect.propTypes = {
     operand: PropTypes.bool, // true = 'details'
     onChange: PropTypes.func.isRequired,
     className: PropTypes.string,
-    classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(TotalsDetailsSelect);
+export default TotalsDetailsSelect;

--- a/src/components/dataElement/TotalsDetailsSelect.js
+++ b/src/components/dataElement/TotalsDetailsSelect.js
@@ -9,6 +9,7 @@ const TotalsDetailsSelect = ({ operand, onChange }) => (
         name="operand"
         value={operand === true ? 'details' : 'totals'}
         onChange={value => onChange(value === 'details')}
+        display="row"
     >
         <Radio value="totals" label={i18n.t('Totals')} />
         <Radio value="details" label={i18n.t('Details')} />

--- a/src/components/edit/thematic/ThematicMapTypeSelect.js
+++ b/src/components/edit/thematic/ThematicMapTypeSelect.js
@@ -1,38 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
+import RadioGroup from '../../core/RadioGroup';
 import Radio from '../../core/Radio';
-import { RadioGroup } from '@material-ui/core';
 import { setThematicMapType } from '../../../actions/layerEdit';
 import {
     THEMATIC_CHOROPLETH,
     getThematicMapTypes,
 } from '../../../constants/layers';
 
-const styles = {
-    radioGroup: {
-        paddingBottom: 20,
-    },
-    radio: {
-        height: 36,
-    },
-};
-
 // Select between choropleth and bubble map for thematic layers
 export const ThematicMapTypeSelect = ({
     type = THEMATIC_CHOROPLETH,
     setThematicMapType,
-    classes,
 }) => (
-    <RadioGroup
-        name="type"
-        value={type}
-        onChange={(event, type) => setThematicMapType(type)}
-        className={classes.radioGroup}
-    >
+    <RadioGroup name="type" value={type} onChange={setThematicMapType}>
         {getThematicMapTypes().map(({ id, name }) => (
-            <Radio key={id} value={id} label={name} className={classes.radio} />
+            <Radio key={id} value={id} label={name} />
         ))}
     </RadioGroup>
 );
@@ -40,9 +24,6 @@ export const ThematicMapTypeSelect = ({
 ThematicMapTypeSelect.propTypes = {
     type: PropTypes.string,
     setThematicMapType: PropTypes.func.isRequired,
-    classes: PropTypes.object.isRequired,
 };
 
-export default connect(null, { setThematicMapType })(
-    withStyles(styles)(ThematicMapTypeSelect)
-);
+export default connect(null, { setThematicMapType })(ThematicMapTypeSelect);

--- a/src/components/edit/trackedEntity/PeriodTypeSelect.js
+++ b/src/components/edit/trackedEntity/PeriodTypeSelect.js
@@ -1,24 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
 import i18n from '@dhis2/d2-i18n';
+import RadioGroup from '../../core/RadioGroup';
 import Radio from '../../core/Radio';
-import { RadioGroup } from '@material-ui/core';
 import { setPeriodType } from '../../../actions/layerEdit';
-
-const styles = {
-    radioGroup: {
-        paddingBottom: 20,
-    },
-    radio: {
-        height: 50,
-    },
-    label: {
-        margin: '12px 0',
-        fontSize: 14,
-    },
-};
 
 export const PeriodTypeSelect = ({
     program,
@@ -34,20 +20,14 @@ export const PeriodTypeSelect = ({
         <RadioGroup
             name="type"
             value={periodType}
-            onChange={(event, type) => setPeriodType({ id: type })}
-            className={classes.radioGroup}
+            onChange={type => setPeriodType({ id: type })}
         >
-            <Radio
-                value="lastUpdated"
-                label={label}
-                className={classes.radio}
-            />
+            <Radio value="lastUpdated" label={label} />
             <Radio
                 value="program"
                 label={`${i18n.t('Program/Enrollment date')}: ${i18n.t(
                     'the date a tracked entity was registered or enrolled in a program'
                 )}`}
-                className={classes.radio}
             />
         </RadioGroup>
     ) : (
@@ -68,4 +48,4 @@ export default connect(
         periodType: layerEdit.periodType,
     }),
     { setPeriodType }
-)(withStyles(styles)(PeriodTypeSelect));
+)(PeriodTypeSelect);

--- a/src/components/periods/RenderingStrategy.js
+++ b/src/components/periods/RenderingStrategy.js
@@ -2,13 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withStyles } from '@material-ui/core/styles';
-import {
-    FormControl,
-    FormLabel,
-    FormControlLabel,
-    RadioGroup,
-    Radio,
-} from '@material-ui/core';
+import RadioGroup from '../core/RadioGroup';
+import Radio from '../core/Radio';
 import i18n from '@dhis2/d2-i18n';
 import {
     RENDERING_STRATEGY_SINGLE,
@@ -70,67 +65,49 @@ class RenderingStrategy extends Component {
         }
     }
 
-    onChange = (evt, value) => this.props.onChange(value);
-
     render() {
         const {
             value,
             period,
             hasOtherLayers,
             hasOtherTimelineLayers,
-            classes,
+            onChange,
         } = this.props;
 
         if (singleMapPeriods.includes(period.id)) {
             return null;
         }
 
-        return (
-            <FormControl component="fieldset" className={classes.control}>
-                <FormLabel component="legend" className={classes.label}>
-                    {i18n.t('Display periods')}
-                </FormLabel>
-                <RadioGroup
-                    aria-label="Period display"
-                    name="period-display"
-                    value={value}
-                    onChange={this.onChange}
-                >
-                    <FormControlLabel
-                        value="SINGLE"
-                        control={<Radio className={classes.radio} />}
-                        label={i18n.t('Single (aggregate)')}
-                    />
-                    <FormControlLabel
-                        value="TIMELINE"
-                        control={<Radio className={classes.radio} />}
-                        label={i18n.t('Timeline')}
-                        disabled={hasOtherTimelineLayers}
-                    />
-                    <FormControlLabel
-                        value="SPLIT_BY_PERIOD"
-                        control={<Radio className={classes.radio} />}
-                        label={i18n.t('Split map views')}
-                        disabled={
-                            hasOtherLayers ||
-                            invalidSplitViewPeriods.includes(period.id)
-                        }
-                    />
-                </RadioGroup>
+        let helpText;
 
-                <div className={classes.message}>
-                    {hasOtherTimelineLayers && (
-                        <div>{i18n.t('Only one timeline is allowed.')}</div>
-                    )}
-                    {hasOtherLayers && (
-                        <div>
-                            {i18n.t(
-                                'Remove other layers to enable split map views.'
-                            )}
-                        </div>
-                    )}
-                </div>
-            </FormControl>
+        if (hasOtherTimelineLayers) {
+            helpText = i18n.t('Only one timeline is allowed.');
+        } else if (hasOtherLayers) {
+            helpText = i18n.t('Remove other layers to enable split map views.');
+        }
+
+        return (
+            <RadioGroup
+                label={i18n.t('Display periods')}
+                value={value}
+                onChange={onChange}
+                helpText={helpText}
+            >
+                <Radio value="SINGLE" label={i18n.t('Single (aggregate)')} />
+                <Radio
+                    value="TIMELINE"
+                    label={i18n.t('Timeline')}
+                    disabled={hasOtherTimelineLayers}
+                />
+                <Radio
+                    value="SPLIT_BY_PERIOD"
+                    label={i18n.t('Split map views')}
+                    disabled={
+                        hasOtherLayers ||
+                        invalidSplitViewPeriods.includes(period.id)
+                    }
+                />
+            </RadioGroup>
         );
     }
 }


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-9699

This PR switches from MUI Radio and RadioGroup to @dhis2/ui Radio and FieldGroup.

There is no @dhis2/ui RadioGroup, so I created a wrapper around FieldGroup with onChange prop, so we don't need to add it for each radio. This is similar to what I did for Tab/TabGroup in #1147 

After this PR: 

<img width="321" alt="Screenshot 2020-10-29 at 14 42 22" src="https://user-images.githubusercontent.com/548708/97582116-ad4b3080-19f5-11eb-8d53-795c0d4b0a24.png">

---

<img width="356" alt="Screenshot 2020-10-29 at 14 45 15" src="https://user-images.githubusercontent.com/548708/97582119-ae7c5d80-19f5-11eb-9c9f-4c6536f86282.png">

---

<img width="346" alt="Screenshot 2020-10-29 at 14 46 33" src="https://user-images.githubusercontent.com/548708/97582122-af14f400-19f5-11eb-9469-affaef4f80a8.png">

---

<img width="588" alt="Screenshot 2020-10-29 at 14 47 00" src="https://user-images.githubusercontent.com/548708/97582125-af14f400-19f5-11eb-98a8-b5e8d5865adb.png">
 

