### PR TITLE
chore: refactor context menu to use @dhis2/ui (DHIS2-9699)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-10-19T07:59:10.931Z\n"
-"PO-Revision-Date: 2020-10-19T07:59:10.931Z\n"
+"POT-Creation-Date: 2020-11-02T16:50:47.063Z\n"
+"PO-Revision-Date: 2020-11-02T16:50:47.063Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -759,6 +759,12 @@ msgstr ""
 msgid "Start/end dates"
 msgstr ""
 
+msgid "Only one timeline is allowed."
+msgstr ""
+
+msgid "Remove other layers to enable split map views."
+msgstr ""
+
 msgid "Display periods"
 msgstr ""
 
@@ -769,12 +775,6 @@ msgid "Timeline"
 msgstr ""
 
 msgid "Split map views"
-msgstr ""
-
-msgid "Only one timeline is allowed."
-msgstr ""
-
-msgid "Remove other layers to enable split map views."
 msgstr ""
 
 msgid "Start date"

--- a/public/index.html
+++ b/public/index.html
@@ -14,8 +14,6 @@
 
     <body>
         <div id="app"></div>
-        <div id="context-menu"></div>
-
         <%= htmlWebpackPlugin.options.vendorScripts %>
     </body>
 </html>

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -14,6 +14,8 @@ import MapContainer from '../map/MapContainer';
 import BottomPanel from '../datatable/BottomPanel';
 import LayerEdit from '../edit/LayerEdit';
 import ContextMenu from '../map/ContextMenu';
+import OrgUnitDialog from '../orgunits/OrgUnitDialog';
+import RelocateDialog from '../orgunits/RelocateDialog';
 import AlertSnackbar from '../alerts/AlertSnackbar';
 import Message from '../message/Message';
 import InterpretationsPanel from '../interpretations/InterpretationsPanel';
@@ -66,6 +68,8 @@ export class App extends Component {
                         <Message />
                         <DataDownloadDialog />
                         <OpenAsMapDialog />
+                        <OrgUnitDialog />
+                        <RelocateDialog />
                     </MuiThemeProvider>
                 </FatalErrorBoundary>
             </Provider>

--- a/src/components/map/ContextMenu.js
+++ b/src/components/map/ContextMenu.js
@@ -1,9 +1,8 @@
-import React from 'react';
+import React, { Fragment, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
-import { withStyles } from '@material-ui/core/styles';
-import { Menu, MenuItem, ListItemIcon, ListItemText } from '@material-ui/core';
+import { Popover, Menu, MenuItem } from '@dhis2/ui';
 import UpIcon from '@material-ui/icons/ArrowUpward';
 import DownIcon from '@material-ui/icons/ArrowDownward';
 import InfoIcon from '@material-ui/icons/InfoOutlined';
@@ -21,26 +20,10 @@ import {
     startRelocateOrgUnit,
     changeOrgUnitCoordinate,
 } from '../../actions/orgUnits';
+import styles from './styles/ContextMenu.module.css';
 
 // https://github.com/callemall/material-ui/issues/2866
 const anchorEl = document.getElementById('context-menu');
-
-const styles = {
-    menuItem: {
-        padding: '0 8px',
-    },
-    icon: {
-        margin: '0 3px 0 1px',
-        left: 6,
-        width: 20,
-        height: 18,
-        minWidth: 0,
-    },
-    text: {
-        fontSize: 12,
-        padding: '0 8px',
-    },
-};
 
 const polygonTypes = ['Polygon', 'MultiPolygon'];
 
@@ -60,24 +43,19 @@ const ContextMenu = (props, context) => {
         onSwapCoordinate,
         onRelocateStart,
         showEarthEngineValue,
-        classes,
-        theme,
     } = props;
 
+    if (!position) {
+        return null;
+    }
+
+    const anchorRef = useRef();
     const isAdmin = context.d2.currentUser.authorities.has('F_GIS_ADMIN');
-    const iconColor = theme.colors.greyBlack;
-    const iconDisabledColor = theme.colors.greyLight;
+    const left = offset[0] + position[0];
+    const top = offset[1] + position[1];
+
     let isPoint;
     let attr = {};
-
-    if (position) {
-        const [left, top] = offset;
-        const [x, y] = position;
-
-        anchorEl.style.position = 'fixed';
-        anchorEl.style.left = `${left + x}px`;
-        anchorEl.style.top = `${top + y}px`;
-    }
 
     if (feature) {
         const { geometry, properties } = feature;
@@ -89,165 +67,112 @@ const ContextMenu = (props, context) => {
             geometry.type === 'Point' && !polygonTypes.includes(attr.type);
     }
 
-    return [
-        <Menu
-            key="menu"
-            open={position ? true : false}
-            anchorEl={anchorEl}
-            onClose={onClose}
-        >
-            {layerType !== 'facility' && feature && (
-                <MenuItem
-                    disabled={!attr.hasCoordinatesUp}
-                    onClick={() =>
-                        onDrill(
-                            layerId,
-                            attr.grandParentId,
-                            attr.grandParentParentGraph,
-                            parseInt(attr.level) - 1
-                        )
-                    }
-                    className={classes.menuItem}
-                >
-                    <ListItemIcon className={classes.icon}>
-                        <UpIcon
-                            htmlColor={
-                                attr.hasCoordinatesUp
-                                    ? iconColor
-                                    : iconDisabledColor
-                            }
-                            style={styles.icon}
-                        />
-                    </ListItemIcon>
-                    <ListItemText
-                        primary={i18n.t('Drill up one level')}
-                        className={classes.text}
-                        disableTypography={true}
-                    />
-                </MenuItem>
-            )}
+    return (
+        <Fragment>
+            <div
+                ref={anchorRef}
+                className={styles.anchor}
+                style={{ left, top }}
+            />
+            <Popover
+                reference={anchorRef}
+                arrow={false}
+                placement="right"
+                onClickOutside={onClose}
+            >
+                <div className={styles.menu}>
+                    <Menu dense anchorEl={anchorEl}>
+                        {layerType !== 'facility' && feature && (
+                            <MenuItem
+                                label={i18n.t('Drill up one level')}
+                                icon={<UpIcon />}
+                                disabled={!attr.hasCoordinatesUp}
+                                onClick={() =>
+                                    onDrill(
+                                        layerId,
+                                        attr.grandParentId,
+                                        attr.grandParentParentGraph,
+                                        parseInt(attr.level) - 1
+                                    )
+                                }
+                            />
+                        )}
 
-            {layerType !== 'facility' && feature && (
-                <MenuItem
-                    disabled={!attr.hasCoordinatesDown}
-                    onClick={() =>
-                        onDrill(
-                            layerId,
-                            attr.id,
-                            attr.parentGraph,
-                            parseInt(attr.level) + 1
-                        )
-                    }
-                    className={classes.menuItem}
-                >
-                    <ListItemIcon className={classes.icon}>
-                        <DownIcon
-                            htmlColor={
-                                attr.hasCoordinatesDown
-                                    ? iconColor
-                                    : iconDisabledColor
-                            }
-                            style={styles.icon}
-                        />
-                    </ListItemIcon>
-                    <ListItemText
-                        primary={i18n.t('Drill down one level')}
-                        className={classes.text}
-                        disableTypography={true}
-                    />
-                </MenuItem>
-            )}
+                        {layerType !== 'facility' && feature && (
+                            <MenuItem
+                                label={i18n.t('Drill down one level')}
+                                icon={<DownIcon />}
+                                disabled={!attr.hasCoordinatesDown}
+                                onClick={() =>
+                                    onDrill(
+                                        layerId,
+                                        attr.id,
+                                        attr.parentGraph,
+                                        parseInt(attr.level) + 1
+                                    )
+                                }
+                            />
+                        )}
 
-            {feature && (
-                <MenuItem
-                    onClick={() => onShowInformation(attr)}
-                    className={classes.menuItem}
-                >
-                    <ListItemIcon className={classes.icon}>
-                        <InfoIcon style={styles.icon} />
-                    </ListItemIcon>
-                    <ListItemText
-                        primary={i18n.t('Show information')}
-                        className={classes.text}
-                        disableTypography={true}
-                    />
-                </MenuItem>
-            )}
+                        {feature && (
+                            <MenuItem
+                                label={i18n.t('Show information')}
+                                icon={<InfoIcon />}
+                                onClick={() => onShowInformation(attr)}
+                            />
+                        )}
 
-            {coordinates && (
-                <MenuItem
-                    onClick={() => showCoordinate(coordinates)}
-                    className={classes.menuItem}
-                >
-                    <ListItemIcon className={classes.icon}>
-                        <PositionIcon style={styles.icon} />
-                    </ListItemIcon>
-                    <ListItemText
-                        primary={i18n.t('Show longitude/latitude')}
-                        className={classes.text}
-                        disableTypography={true}
-                    />
-                </MenuItem>
-            )}
+                        {coordinates && (
+                            <MenuItem
+                                label={i18n.t('Show longitude/latitude')}
+                                icon={<PositionIcon />}
+                                onClick={() => showCoordinate(coordinates)}
+                            />
+                        )}
 
-            {isAdmin && isPoint && (
-                <MenuItem
-                    onClick={() =>
-                        onSwapCoordinate(
-                            layerId,
-                            feature.id,
-                            feature.geometry.coordinates.slice(0).reverse()
-                        )
-                    }
-                    className={classes.menuItem}
-                >
-                    <ListItemIcon className={classes.icon}>
-                        <PositionIcon style={styles.icon} />
-                    </ListItemIcon>
-                    <ListItemText
-                        primary={i18n.t('Swap longitude/latitude')}
-                        className={classes.text}
-                        disableTypography={true}
-                    />
-                </MenuItem>
-            )}
+                        {isAdmin && isPoint && (
+                            <MenuItem
+                                label={i18n.t('Swap longitude/latitude')}
+                                icon={<PositionIcon />}
+                                onClick={() =>
+                                    onSwapCoordinate(
+                                        layerId,
+                                        feature.id,
+                                        feature.geometry.coordinates
+                                            .slice(0)
+                                            .reverse()
+                                    )
+                                }
+                            />
+                        )}
 
-            {isAdmin && isPoint && (
-                <MenuItem
-                    onClick={() => onRelocateStart(layerId, feature)}
-                    className={classes.menuItem}
-                >
-                    <ListItemIcon className={classes.icon}>
-                        <PositionIcon style={styles.icon} />
-                    </ListItemIcon>
-                    <ListItemText
-                        primary={i18n.t('Relocate')}
-                        className={classes.text}
-                        disableTypography={true}
-                    />
-                </MenuItem>
-            )}
+                        {isAdmin && isPoint && (
+                            <MenuItem
+                                label={i18n.t('Relocate')}
+                                icon={<PositionIcon />}
+                                onClick={() =>
+                                    onRelocateStart(layerId, feature)
+                                }
+                            />
+                        )}
 
-            {earthEngineLayers.map(layer => (
-                <MenuItem
-                    key={layer.id}
-                    onClick={() => showEarthEngineValue(layer.id, coordinates)}
-                    className={classes.menuItem}
-                >
-                    <ListItemIcon className={classes.icon}>
-                        <PositionIcon style={styles.icon} />
-                    </ListItemIcon>
-                    <ListItemText
-                        primary={i18n.t(layer.name)}
-                        className={classes.text}
-                        disableTypography={true}
-                    />
-                </MenuItem>
-            ))}
-        </Menu>,
-        <OrgUnitDialog key="orgunit" />,
-        <RelocateDialog key="relocate" />,
-    ];
+                        {earthEngineLayers.map(layer => (
+                            <MenuItem
+                                key={layer.id}
+                                label={i18n.t(layer.name)}
+                                icon={<PositionIcon />}
+                                onClick={() =>
+                                    showEarthEngineValue(layer.id, coordinates)
+                                }
+                            />
+                        ))}
+                    </Menu>
+                </div>
+            </Popover>
+            <OrgUnitDialog key="orgunit" />
+            <RelocateDialog key="relocate" />
+        </Fragment>
+    );
 };
 
 ContextMenu.contextTypes = {
@@ -257,8 +182,10 @@ ContextMenu.contextTypes = {
 ContextMenu.propTypes = {
     feature: PropTypes.object,
     layerType: PropTypes.string,
-    coordinate: PropTypes.array,
+    layerId: PropTypes.string,
+    coordinates: PropTypes.array,
     position: PropTypes.array,
+    offset: PropTypes.array,
     earthEngineLayers: PropTypes.array,
     onClose: PropTypes.func.isRequired,
     onDrill: PropTypes.func.isRequired,
@@ -267,7 +194,6 @@ ContextMenu.propTypes = {
     onRelocateStart: PropTypes.func.isRequired,
     onSwapCoordinate: PropTypes.func.isRequired,
     showEarthEngineValue: PropTypes.func.isRequired,
-    classes: PropTypes.object.isRequired,
 };
 
 const mapStateToProps = state => ({
@@ -303,11 +229,4 @@ const mapDispatchToProps = dispatch => ({
     },
 });
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps
-)(
-    withStyles(styles, {
-        withTheme: true,
-    })(ContextMenu)
-);
+export default connect(mapStateToProps, mapDispatchToProps)(ContextMenu);

--- a/src/components/map/ContextMenu.js
+++ b/src/components/map/ContextMenu.js
@@ -7,8 +7,6 @@ import UpIcon from '@material-ui/icons/ArrowUpward';
 import DownIcon from '@material-ui/icons/ArrowDownward';
 import InfoIcon from '@material-ui/icons/InfoOutlined';
 import PositionIcon from '@material-ui/icons/Room';
-import OrgUnitDialog from '../orgunits/OrgUnitDialog';
-import RelocateDialog from '../orgunits/RelocateDialog';
 import {
     closeContextMenu,
     openCoordinatePopup,
@@ -21,9 +19,6 @@ import {
     changeOrgUnitCoordinate,
 } from '../../actions/orgUnits';
 import styles from './styles/ContextMenu.module.css';
-
-// https://github.com/callemall/material-ui/issues/2866
-const anchorEl = document.getElementById('context-menu');
 
 const polygonTypes = ['Polygon', 'MultiPolygon'];
 
@@ -81,7 +76,7 @@ const ContextMenu = (props, context) => {
                 onClickOutside={onClose}
             >
                 <div className={styles.menu}>
-                    <Menu dense anchorEl={anchorEl}>
+                    <Menu dense>
                         {layerType !== 'facility' && feature && (
                             <MenuItem
                                 label={i18n.t('Drill up one level')}
@@ -169,8 +164,6 @@ const ContextMenu = (props, context) => {
                     </Menu>
                 </div>
             </Popover>
-            <OrgUnitDialog key="orgunit" />
-            <RelocateDialog key="relocate" />
         </Fragment>
     );
 };

--- a/src/components/map/styles/ContextMenu.module.css
+++ b/src/components/map/styles/ContextMenu.module.css
@@ -1,0 +1,7 @@
+.anchor {
+    position: fixed;
+}
+
+.menu {
+    padding: var(--spacers-dp8) 0;
+}


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-9699

This PR switches from MUI to @dhis2/ui for the context menu, including an overhaul of the code. 

After this PR:

<img width="239" alt="Screenshot 2020-11-03 at 10 01 02" src="https://user-images.githubusercontent.com/548708/97966815-9d986700-1dbc-11eb-9207-e6ad8c232361.png">

Vertical placement of the context menu is not correct, same issue as before - will hopefully be fixed when we get rid of all MUI styles. We're not merging to master before the popover placement issues are fixed. 

There are no changes in translation file, just a reordering. 