### PR TITLE
fix: context menu layer name and popup padding

### DIFF
--- a/src/components/map/ContextMenu.js
+++ b/src/components/map/ContextMenu.js
@@ -174,7 +174,9 @@ const ContextMenu = (props, context) => {
                         {earthEngineLayers.map(layer => (
                             <MenuItem
                                 key={layer.id}
-                                label={i18n.t(layer.name)}
+                                label={i18n.t('Show {{name}}', {
+                                    name: layer.name.toLowerCase(),
+                                })}
                                 icon={<PositionIcon />}
                                 onClick={() =>
                                     onClick('show_ee_value', layer.id)

--- a/src/components/map/Popup.css
+++ b/src/components/map/Popup.css
@@ -1,3 +1,7 @@
+.dhis2-map-popup .mapboxgl-popup-content {
+    padding-top: var(--spacers-dp16);
+}
+
 .dhis2-map-popup-event {
     overflow-x: auto;
 }


### PR DESCRIPTION
This PR includes "Show ..." before the earth engine layer name + adds some extra padding above the popup content. 

After this PR:

<img width="250" alt="Screenshot 2020-11-04 at 13 05 58" src="https://user-images.githubusercontent.com/548708/98110393-4cad6f00-1e9f-11eb-83f1-6c8d601fe7da.png">

<img width="241" alt="Screenshot 2020-11-04 at 13 06 09" src="https://user-images.githubusercontent.com/548708/98110395-4dde9c00-1e9f-11eb-8282-e27470f9deb5.png">
