### PR TITLE
chore: refactor color picker to use @dhis2/ui and css modules (DHIS2-9699)

### DIFF
--- a/src/components/core/ColorPicker.js
+++ b/src/components/core/ColorPicker.js
@@ -13,12 +13,12 @@ const ColorPicker = ({ color, label, width, height, onChange, className }) => {
 
     return (
         <Fragment>
-            <div className={styles.colorPicker}>
+            <div className={cx(styles.colorPicker, className)}>
                 {label && <div className={styles.label}>{label}</div>}
                 <div
                     ref={anchorRef}
                     onClick={() => setIsOpen(true)}
-                    className={cx(styles.button, className)}
+                    className={styles.button}
                     style={{
                         background: color,
                         width: width || '100%',

--- a/src/components/core/ColorPicker.js
+++ b/src/components/core/ColorPicker.js
@@ -27,7 +27,11 @@ const ColorPicker = ({ color, label, width, height, onChange, className }) => {
                 >
                     <span
                         className={styles.icon}
-                        style={{ color: hcl(color).l < 70 ? '#fff' : '#333' }}
+                        style={{
+                            color: `var(--colors-${
+                                hcl(color).l < 70 ? 'white' : 'grey900'
+                            })`,
+                        }}
                     >
                         <ArrowDropDownIcon />
                     </span>

--- a/src/components/core/ColorPicker.js
+++ b/src/components/core/ColorPicker.js
@@ -1,81 +1,62 @@
-import React, { Component } from 'react';
+import React, { Fragment, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { IconButton, Popover } from '@material-ui/core';
+import { Popover } from '@dhis2/ui';
 import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
 import ChromePicker from 'react-color/lib/components/chrome/Chrome';
 import { hcl } from 'd3-color';
 import cx from 'classnames';
 import styles from './styles/ColorPicker.module.css';
 
-export class ColorPicker extends Component {
-    static propTypes = {
-        color: PropTypes.string.isRequired,
-        label: PropTypes.string,
-        width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        onChange: PropTypes.func.isRequired,
-        className: PropTypes.string,
-    };
+const ColorPicker = ({ color, label, width, height, onChange, className }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const anchorRef = useRef();
 
-    constructor(...args) {
-        super(...args);
-
-        this.state = {
-            isOpen: false,
-            color: this.props.color,
-        };
-    }
-
-    handleOpen = event => {
-        this.setState({
-            isOpen: true,
-            anchorEl: event.currentTarget,
-        });
-    };
-
-    handleClose = () => {
-        this.setState({ isOpen: false });
-    };
-
-    handleChange = color => {
-        const hexColor = color.hex.toUpperCase();
-
-        this.setState({ color: hexColor });
-        this.props.onChange(hexColor);
-    };
-
-    render() {
-        const { label, width, height, className } = this.props;
-        const { color, isOpen, anchorEl } = this.state;
-
-        return (
-            <div className={cx(styles.colorPicker, className)}>
+    return (
+        <Fragment>
+            <div className={styles.colorPicker}>
                 {label && <div className={styles.label}>{label}</div>}
-                <IconButton
-                    onClick={this.handleOpen}
-                    className={styles.button}
+                <div
+                    ref={anchorRef}
+                    onClick={() => setIsOpen(true)}
+                    className={cx(styles.button, className)}
                     style={{
                         background: color,
                         width: width || '100%',
                         height: height || 40,
                     }}
-                    disableTouchRipple={true}
                 >
-                    <ArrowDropDownIcon
-                        htmlColor={hcl(color).l < 70 ? '#fff' : '#333'}
+                    <span
                         className={styles.icon}
-                    />
-                </IconButton>
-                <Popover
-                    open={isOpen}
-                    onClose={this.handleClose}
-                    anchorEl={anchorEl}
-                >
-                    <ChromePicker color={color} onChange={this.handleChange} />
-                </Popover>
+                        style={{ color: hcl(color).l < 70 ? '#fff' : '#333' }}
+                    >
+                        <ArrowDropDownIcon />
+                    </span>
+                </div>
             </div>
-        );
-    }
-}
+            {isOpen && (
+                <Popover
+                    reference={anchorRef}
+                    arrow={false}
+                    placement="right"
+                    onClickOutside={() => setIsOpen(false)}
+                >
+                    <ChromePicker
+                        color={color}
+                        onChange={color => onChange(color.hex.toUpperCase())}
+                    />
+                </Popover>
+            )}
+        </Fragment>
+    );
+};
+
+ColorPicker.propTypes = {
+    color: PropTypes.string.isRequired,
+    label: PropTypes.string,
+    width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    onChange: PropTypes.func.isRequired,
+    className: PropTypes.string,
+};
 
 export default ColorPicker;

--- a/src/components/core/styles/ColorPicker.module.css
+++ b/src/components/core/styles/ColorPicker.module.css
@@ -1,20 +1,25 @@
 .colorPicker {
-    /* margin: var(--spacers-dp12) 0; */
+    margin-bottom: var(--spacers-dp12);
+}
+
+.label {
+    font-size: 14px;
+    padding: var(--spacers-dp4) 0 var(--spacers-dp12);
 }
 
 .button {
-    padding: 0;
-    text-align: right;
-    border-radius: 0 !important;
+    position: relative;
+    border: 1px solid rgb(160, 173, 186);
+    border-radius: 3px;
+    box-shadow: rgba(48, 54, 60, 0.1) 0px 1px 2px 0px inset;
+    cursor: pointer;
 }
 
 .icon {
     position: absolute;
+    height: 24px;
     right: var(--spacers-dp4);
-}
-
-.label {
-    color: #000000;
-    font-size: 14px;
-    padding: var(--spacers-dp4) 0 var(--spacers-dp8);
+    top: 0;
+    bottom: 0;
+    margin: auto;
 }

--- a/src/components/core/styles/ColorPicker.module.css
+++ b/src/components/core/styles/ColorPicker.module.css
@@ -4,14 +4,14 @@
 
 .label {
     font-size: 14px;
-    padding: var(--spacers-dp4) 0 var(--spacers-dp12);
+    padding: var(--spacers-dp4) 0 var(--spacers-dp8);
 }
 
 .button {
     position: relative;
-    border: 1px solid rgb(160, 173, 186);
+    border: 1px solid var(--colors-grey500);
     border-radius: 3px;
-    box-shadow: rgba(48, 54, 60, 0.1) 0px 1px 2px 0px inset;
+    min-width: 40px;
     cursor: pointer;
 }
 

--- a/src/components/optionSet/OptionSetStyle.js
+++ b/src/components/optionSet/OptionSetStyle.js
@@ -6,10 +6,7 @@ import OptionStyle from './OptionStyle';
 import { loadOptionSet } from '../../actions/optionSets';
 import { setOptionStyle } from '../../actions/layerEdit';
 import { qualitativeColors } from '../../constants/colors';
-
-const style = {
-    marginTop: 8,
-};
+import styles from './styles/OptionSetStyle.module.css';
 
 class OptionSetStyle extends Component {
     static propTypes = {
@@ -71,7 +68,7 @@ class OptionSetStyle extends Component {
         const { options } = this.props;
 
         return (
-            <div style={style}>
+            <div className={styles.optionSetStyle}>
                 {options ? (
                     options.map(({ id, name, style }) => (
                         <OptionStyle

--- a/src/components/optionSet/styles/OptionSetStyle.module.css
+++ b/src/components/optionSet/styles/OptionSetStyle.module.css
@@ -1,0 +1,3 @@
+.optionSetStyle {
+    margin-top: var(--spacers-dp12);
+}

--- a/src/components/optionSet/styles/OptionStyle.module.css
+++ b/src/components/optionSet/styles/OptionStyle.module.css
@@ -4,15 +4,14 @@
 
 .color {
     display: inline-block;
-    width: var(--spacers-dp32);
-    height: var(--spacers-dp32);
+    width: var(--spacers-dp40);
+    height: var(--spacers-dp40);
     margin: 0 var(--spacers-dp8) 0 0;
 }
 
 .label {
     display: inline-block;
-    height: var(--spacers-dp24);
-    line-height: var(--spacers-dp32);
-    vertical-align: top;
+    height: 40px;
+    line-height: 40px;
     overflow: hidden;
 }


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-9699

This PR is a refactoring of the color picker to use popover from @dhis2/ui,  CSS modules and functional components. 
We don't have a color picker in @dhis2/ui, so we are still using the chrome picker from react-color: https://casesandberg.github.io/react-color/

After this PR:
<img width="611" alt="Screenshot 2020-11-04 at 16 15 43" src="https://user-images.githubusercontent.com/548708/98131016-2b5a7c00-1ebb-11eb-8891-8fed50f59e0c.png">

<img width="614" alt="Screenshot 2020-11-04 at 16 15 56" src="https://user-images.githubusercontent.com/548708/98130994-25fd3180-1ebb-11eb-92ff-83127bad7fa5.png">

Still a placement issue for the popover, - will fix the issue when all MUI styles are gone. 
