### PR TITLE
chore: refactor layer toolbar to use @dhis2/ui and css modules (DHIS2-9699)

### DIFF
--- a/src/components/core/FontStyle.js
+++ b/src/components/core/FontStyle.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
-import { IconButton } from '@material-ui/core';
 import BoldIcon from '@material-ui/icons/FormatBold';
 import ItalicIcon from '@material-ui/icons/FormatItalic';
 import cx from 'classnames';
@@ -34,28 +33,26 @@ const FontStyle = ({
             />
         )}
         {onWeightChange && (
-            <IconButton
+            <div
                 onClick={() =>
                     onWeightChange(weight === 'bold' ? 'normal' : 'bold')
                 }
                 className={styles.button}
-                disableTouchRipple={true}
             >
                 <BoldIcon htmlColor={weight === 'bold' ? '#333' : '#aaa'} />
-            </IconButton>
+            </div>
         )}
         {onStyleChange && (
-            <IconButton
+            <div
                 onClick={() =>
                     onStyleChange(fontStyle === 'italic' ? 'normal' : 'italic')
                 }
                 className={styles.button}
-                disableTouchRipple={true}
             >
                 <ItalicIcon
                     htmlColor={fontStyle === 'italic' ? '#333' : '#aaa'}
                 />
-            </IconButton>
+            </div>
         )}
         {onColorChange && (
             <ColorPicker

--- a/src/components/core/styles/FontStyle.module.css
+++ b/src/components/core/styles/FontStyle.module.css
@@ -4,11 +4,10 @@
     max-width: 74px;
 }
 
-/* !important will be removed when we switch to ui-icons */
 .button {
     background: #fafafa;
-    margin: 0 var(--spacers-dp8) var(--spacers-dp8) 0 !important;
-    border-radius: 0 !important;
+    margin: 0 var(--spacers-dp8) var(--spacers-dp8) 0;
+    padding: var(--spacers-dp8);
     width: 40px;
     height: 40px;
 }

--- a/src/components/layers/LayersToggle.js
+++ b/src/components/layers/LayersToggle.js
@@ -1,30 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withStyles } from '@material-ui/core/styles';
-import { IconButton } from '@material-ui/core';
 import LeftIcon from '@material-ui/icons/ChevronLeft';
 import RightIcon from '@material-ui/icons/ChevronRight';
 import { openLayersPanel, closeLayersPanel } from '../../actions/ui';
-import { HEADER_HEIGHT, LAYERS_PANEL_WIDTH } from '../../constants/layout';
-
-const styles = theme => ({
-    button: {
-        position: 'absolute',
-        top: HEADER_HEIGHT + 15,
-        left: LAYERS_PANEL_WIDTH,
-        width: 24,
-        height: 40,
-        padding: 0,
-        background: theme.palette.background.paper,
-        borderRadius: 0,
-        boxShadow: '3px 1px 5px -1px rgba(0, 0, 0, 0.2)',
-        zIndex: 1100,
-        '&:hover': {
-            backgroundColor: theme.palette.background.hover,
-        },
-    },
-});
+import styles from './styles/LayersToggle.module.css';
 
 // This expand/collapse toggle is separate from LayersPanel to avoid overflow issue
 const LayersToggle = ({
@@ -32,17 +12,15 @@ const LayersToggle = ({
     isDownload,
     openLayersPanel,
     closeLayersPanel,
-    classes,
 }) =>
     !isDownload && (
-        <IconButton
+        <div
             onClick={isOpen ? closeLayersPanel : openLayersPanel}
-            className={classes.button}
-            disableTouchRipple={true}
+            className={styles.layersToggle}
             style={isOpen ? {} : { left: 0 }}
         >
             {isOpen ? <LeftIcon /> : <RightIcon />}
-        </IconButton>
+        </div>
     );
 
 LayersToggle.propTypes = {
@@ -50,7 +28,6 @@ LayersToggle.propTypes = {
     isDownload: PropTypes.bool.isRequired,
     openLayersPanel: PropTypes.func.isRequired,
     closeLayersPanel: PropTypes.func.isRequired,
-    classes: PropTypes.object.isRequired,
 };
 
 export default connect(
@@ -59,4 +36,4 @@ export default connect(
         isDownload: state.download.showDialog,
     }),
     { openLayersPanel, closeLayersPanel }
-)(withStyles(styles)(LayersToggle));
+)(LayersToggle);

--- a/src/components/layers/styles/LayersToggle.module.css
+++ b/src/components/layers/styles/LayersToggle.module.css
@@ -1,0 +1,16 @@
+.layersToggle {
+    position: absolute;
+    top: 104px;
+    left: 300px;
+    width: 24px;
+    height: 40px;
+    padding: var(--spacers-dp8) 0;
+    background-color: var(--colors-white);
+    box-shadow: 3px 1px 5px -1px rgba(0, 0, 0, 0.2);
+    z-index: 1100;
+    cursor: pointer;
+}
+
+.layersToggle:hover {
+    background-color: var(--colors-grey300);
+}

--- a/src/components/layers/toolbar/LayerToolbar.js
+++ b/src/components/layers/toolbar/LayerToolbar.js
@@ -1,107 +1,66 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
-import { withStyles } from '@material-ui/core/styles';
-import { Toolbar, IconButton, Tooltip } from '@material-ui/core';
+import { Tooltip } from '@dhis2/ui';
 import CreateIcon from '@material-ui/icons/Create';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
 import OpacitySlider from './OpacitySlider';
 import LayerToolbarMoreMenu from './LayerToolbarMoreMenu';
-
-const styles = theme => ({
-    toolbar: {
-        position: 'relative',
-        height: 32,
-        minHeight: 32,
-        padding: `0 ${theme.spacing(1)}px`,
-        backgroundColor: theme.palette.background.paper,
-        borderTop: `1px solid ${theme.palette.divider}`,
-    },
-    spacer: {
-        marginRight: theme.spacing(2),
-    },
-    button: {
-        float: 'left',
-        padding: 4,
-        width: 32,
-        height: 32,
-    },
-    moreMenuButton: {
-        width: 32,
-        height: 32,
-        padding: 4,
-        position: 'absolute',
-        right: theme.spacing(0.5),
-        top: 0,
-    },
-    sliderContainer: {
-        marginLeft: theme.spacing(0.5),
-    },
-    sliderRoot: {
-        paddingLeft: 0,
-        paddingTop: 8,
-        paddingBottom: 8,
-    },
-});
+import styles from './styles/LayerToolbar.module.css';
 
 export const LayerToolbar = ({
-    opacity,
+    opacity = 1,
     isVisible,
     onOpacityChange,
     toggleLayerVisibility,
-    classes,
     ...expansionMenuProps
 }) => {
     const onEdit = expansionMenuProps.onEdit;
 
     return (
-        <Toolbar className={classes.toolbar} data-test="layertoolbar">
+        <div className={styles.toolbar} data-test="layertoolbar">
             {onEdit && (
                 <Fragment>
-                    <Tooltip key="edit" title={i18n.t('Edit')}>
-                        <IconButton className={classes.button} onClick={onEdit}>
+                    <Tooltip content={i18n.t('Edit')}>
+                        <div
+                            className={styles.button}
+                            onClick={onEdit}
+                            data-test="editbutton"
+                        >
                             <CreateIcon data-icon="CreateIcon" />
-                        </IconButton>
+                        </div>
                     </Tooltip>
-                    <span className={classes.spacer} />
+                    <span className={styles.spacer} />
                 </Fragment>
             )}
-            <Tooltip title={i18n.t('Toggle visibility')}>
-                <IconButton
-                    className={classes.button}
+            <Tooltip content={i18n.t('Toggle visibility')}>
+                <div
+                    className={styles.button}
                     onClick={toggleLayerVisibility}
+                    data-test="visibilitybutton"
                 >
                     {isVisible ? (
                         <VisibilityIcon data-icon="VisibilityIcon" />
                     ) : (
                         <VisibilityOffIcon data-icon="VisibilityOffIcon" />
                     )}
-                </IconButton>
+                </div>
             </Tooltip>
-            <div className={classes.sliderContainer}>
-                <Tooltip title={i18n.t('Set layer opacity')}>
-                    <div>
-                        <OpacitySlider
-                            classes={{
-                                root: classes.sliderRoot,
-                            }}
-                            opacity={opacity}
-                            onChange={onOpacityChange}
-                        />
-                    </div>
+            <div className={styles.sliderContainer}>
+                <Tooltip content={i18n.t('Set layer opacity')}>
+                    <OpacitySlider
+                        opacity={opacity}
+                        onChange={onOpacityChange}
+                    />
                 </Tooltip>
             </div>
-            <LayerToolbarMoreMenu
-                classes={{ button: classes.moreMenuButton }}
-                {...expansionMenuProps}
-            />
-        </Toolbar>
+            <LayerToolbarMoreMenu {...expansionMenuProps} />
+        </div>
     );
 };
 
 LayerToolbar.propTypes = {
-    classes: PropTypes.object.isRequired,
     opacity: PropTypes.number.isRequired,
     isVisible: PropTypes.bool,
     toggleLayerVisibility: PropTypes.func.isRequired,
@@ -109,8 +68,4 @@ LayerToolbar.propTypes = {
     onEdit: PropTypes.func,
 };
 
-LayerToolbar.defaultProps = {
-    opacity: 1,
-};
-
-export default withStyles(styles)(LayerToolbar);
+export default LayerToolbar;

--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -1,190 +1,119 @@
-import React, { Component, Fragment } from 'react';
+import React, { Fragment, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
-import { withStyles } from '@material-ui/core/styles';
-import {
-    Menu,
-    MenuItem,
-    Tooltip,
-    IconButton,
-    ListItemIcon,
-    ListItemText,
-    Divider,
-} from '@material-ui/core';
+import { Popover, Menu, MenuItem, Tooltip, Divider } from '@dhis2/ui';
 import MoreIcon from '@material-ui/icons/MoreHoriz';
 import EditIcon from '@material-ui/icons/Create';
 import TableIcon from '@material-ui/icons/ViewList';
 import DeleteIcon from '@material-ui/icons/Delete';
 import SaveIcon from '@material-ui/icons/SaveAlt';
 import ChartIcon from '@material-ui/icons/BarChart';
+import styles from './styles/LayerToolbarMore.module.css';
 
-const styles = theme => ({
-    button: {
-        float: 'left',
-        padding: 4,
-        width: 32,
-        height: 32,
-    },
-    menuItem: {
-        padding: '4px 16px',
-    },
-    divider: {
-        margin: `${theme.spacing(1)}px 0`,
-    },
-});
+export const LayerToolbarMoreMenu = ({
+    onEdit,
+    onRemove,
+    toggleDataTable,
+    openAs,
+    downloadData,
+}) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const anchorRef = useRef();
 
-export class LayerToolbarMoreMenu extends Component {
-    state = {
-        open: false,
-        anchorEl: null,
-    };
+    const somethingAboveDivider = toggleDataTable || downloadData,
+        somethingBelowDivider = onRemove || onEdit,
+        showDivider = somethingAboveDivider && somethingBelowDivider;
 
-    static propTypes = {
-        classes: PropTypes.object.isRequired,
-        onEdit: PropTypes.func,
-        onRemove: PropTypes.func,
-        toggleDataTable: PropTypes.func,
-        openAs: PropTypes.func,
-        downloadData: PropTypes.func,
-    };
-
-    handleBtnClick = e => {
-        this.setState({
-            anchorEl: e.currentTarget,
-            open: true,
-        });
-    };
-
-    closeMenu = () => {
-        this.setState({
-            anchorEl: null,
-            open: false,
-        });
-    };
-
-    handleEditBtnClick = () => {
-        this.closeMenu();
-        this.props.onEdit();
-    };
-
-    handleDataTableBtnClick = () => {
-        this.closeMenu();
-        this.props.toggleDataTable();
-    };
-
-    handleOpenAsChartBtnClick = () => {
-        this.closeMenu();
-        this.props.openAs('CHART');
-    };
-
-    handleRemoveBtnClick = () => {
-        this.closeMenu();
-        this.props.onRemove();
-    };
-
-    handleDownloadBtnClick = () => {
-        this.closeMenu();
-        this.props.downloadData();
-    };
-
-    render() {
-        const {
-            classes,
-            onEdit,
-            onRemove,
-            toggleDataTable,
-            openAs,
-            downloadData,
-        } = this.props;
-
-        const somethingAboveDivider = toggleDataTable || downloadData,
-            somethingBelowDivider = onRemove || onEdit,
-            showDivider = somethingAboveDivider && somethingBelowDivider;
-
-        if (!somethingAboveDivider && !somethingBelowDivider) {
-            return null;
-        }
-
-        return (
-            <Fragment>
-                <Tooltip title={i18n.t('More actions')}>
-                    <IconButton
-                        className={classes.button}
-                        onClick={this.handleBtnClick}
-                    >
-                        <MoreIcon />
-                    </IconButton>
-                </Tooltip>
-                <Menu
-                    anchorEl={this.state.anchorEl}
-                    getContentAnchorEl={null}
-                    anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-                    open={this.state.open}
-                    onClose={this.closeMenu}
-                    disableRestoreFocus={true} // Don't re-focus on the Tooltip after the dialog is closed
-                >
-                    {toggleDataTable && (
-                        <MenuItem
-                            onClick={this.handleDataTableBtnClick}
-                            className={classes.menuItem}
-                        >
-                            <ListItemIcon>
-                                <TableIcon />
-                            </ListItemIcon>
-                            <ListItemText primary={i18n.t('Data table')} />
-                        </MenuItem>
-                    )}
-                    {openAs && (
-                        <MenuItem
-                            onClick={this.handleOpenAsChartBtnClick}
-                            className={classes.menuItem}
-                        >
-                            <ListItemIcon>
-                                <ChartIcon />
-                            </ListItemIcon>
-                            <ListItemText primary={i18n.t('Open as chart')} />
-                        </MenuItem>
-                    )}
-                    {downloadData && (
-                        <MenuItem
-                            onClick={this.handleDownloadBtnClick}
-                            className={classes.menuItem}
-                        >
-                            <ListItemIcon>
-                                <SaveIcon />
-                            </ListItemIcon>
-                            <ListItemText primary={i18n.t('Download data')} />
-                        </MenuItem>
-                    )}
-                    {showDivider && (
-                        <Divider className={classes.divider} light />
-                    )}
-                    {onEdit && (
-                        <MenuItem
-                            onClick={this.handleEditBtnClick}
-                            className={classes.menuItem}
-                        >
-                            <ListItemIcon>
-                                <EditIcon />
-                            </ListItemIcon>
-                            <ListItemText primary={i18n.t('Edit layer')} />
-                        </MenuItem>
-                    )}
-                    {onRemove && (
-                        <MenuItem
-                            onClick={this.handleRemoveBtnClick}
-                            className={classes.menuItem}
-                        >
-                            <ListItemIcon>
-                                <DeleteIcon />
-                            </ListItemIcon>
-                            <ListItemText primary={i18n.t('Remove layer')} />
-                        </MenuItem>
-                    )}
-                </Menu>
-            </Fragment>
-        );
+    if (!somethingAboveDivider && !somethingBelowDivider) {
+        return null;
     }
-}
 
-export default withStyles(styles)(LayerToolbarMoreMenu);
+    return (
+        <Fragment>
+            <Tooltip content={i18n.t('More actions')}>
+                <div
+                    ref={anchorRef}
+                    className={styles.moreMenuButton}
+                    onClick={() => setIsOpen(!isOpen)}
+                    data-test="moremenubutton"
+                >
+                    <MoreIcon />
+                </div>
+            </Tooltip>
+            {isOpen && (
+                <Popover
+                    reference={anchorRef}
+                    arrow={false}
+                    placement="right"
+                    onClickOutside={() => setIsOpen(false)}
+                >
+                    <div className={styles.menu}>
+                        <Menu dense>
+                            {toggleDataTable && (
+                                <MenuItem
+                                    label={i18n.t('Data table')}
+                                    icon={<TableIcon />}
+                                    onClick={() => {
+                                        setIsOpen(false);
+                                        toggleDataTable();
+                                    }}
+                                />
+                            )}
+                            {openAs && (
+                                <MenuItem
+                                    label={i18n.t('Open as chart')}
+                                    icon={<ChartIcon />}
+                                    onClick={() => {
+                                        setIsOpen(false);
+                                        openAs('CHART');
+                                    }}
+                                />
+                            )}
+                            {downloadData && (
+                                <MenuItem
+                                    label={i18n.t('Download data')}
+                                    icon={<SaveIcon />}
+                                    onClick={() => {
+                                        setIsOpen(false);
+                                        downloadData();
+                                    }}
+                                />
+                            )}
+                            {showDivider && <Divider />}
+                            {onEdit && (
+                                <MenuItem
+                                    label={i18n.t('Edit layer')}
+                                    icon={<EditIcon />}
+                                    onClick={() => {
+                                        setIsOpen(false);
+                                        onEdit();
+                                    }}
+                                />
+                            )}
+                            {onRemove && (
+                                <MenuItem
+                                    label={i18n.t('Remove layer')}
+                                    icon={<DeleteIcon />}
+                                    onClick={() => {
+                                        setIsOpen(false);
+                                        onRemove();
+                                    }}
+                                />
+                            )}
+                        </Menu>
+                    </div>
+                </Popover>
+            )}
+        </Fragment>
+    );
+};
+
+LayerToolbarMoreMenu.propTypes = {
+    onEdit: PropTypes.func,
+    onRemove: PropTypes.func,
+    toggleDataTable: PropTypes.func,
+    openAs: PropTypes.func,
+    downloadData: PropTypes.func,
+};
+
+export default LayerToolbarMoreMenu;

--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -51,7 +51,7 @@ export const LayerToolbarMoreMenu = ({
                         <Menu dense>
                             {toggleDataTable && (
                                 <MenuItem
-                                    label={i18n.t('Data table')}
+                                    label={i18n.t('Show data table')}
                                     icon={<TableIcon />}
                                     onClick={() => {
                                         setIsOpen(false);

--- a/src/components/layers/toolbar/OpacitySlider.js
+++ b/src/components/layers/toolbar/OpacitySlider.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import { Slider } from '@material-ui/core';
+import styles from './styles/OpacitySlider.module.css';
 
+/*
 const styles = theme => ({
     root: {
         width: 100,
-        marginTop: 4,
+        background: 'yellow',
     },
     track: {
         backgroundColor: theme.palette.action.active,
@@ -15,22 +16,24 @@ const styles = theme => ({
         backgroundColor: theme.palette.action.active,
     },
 });
+*/
 
-const OpacitySlider = ({ opacity, onChange, classes }) => (
-    <Slider
-        value={opacity}
-        min={0}
-        max={1}
-        step={0.01}
-        onChange={(evt, opacity) => onChange(opacity)}
-        classes={classes}
-    />
+const OpacitySlider = ({ opacity, onChange }) => (
+    <div className={styles.slider}>
+        <Slider
+            value={opacity}
+            min={0}
+            max={1}
+            step={0.01}
+            onChange={(evt, opacity) => onChange(opacity)}
+            // classes={classes}
+        />
+    </div>
 );
 
 OpacitySlider.propTypes = {
     opacity: PropTypes.number.isRequired,
     onChange: PropTypes.func.isRequired,
-    classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(OpacitySlider);
+export default OpacitySlider;

--- a/src/components/layers/toolbar/OpacitySlider.js
+++ b/src/components/layers/toolbar/OpacitySlider.js
@@ -3,21 +3,6 @@ import PropTypes from 'prop-types';
 import { Slider } from '@material-ui/core';
 import styles from './styles/OpacitySlider.module.css';
 
-/*
-const styles = theme => ({
-    root: {
-        width: 100,
-        background: 'yellow',
-    },
-    track: {
-        backgroundColor: theme.palette.action.active,
-    },
-    thumb: {
-        backgroundColor: theme.palette.action.active,
-    },
-});
-*/
-
 const OpacitySlider = ({ opacity, onChange }) => (
     <div className={styles.slider}>
         <Slider
@@ -26,7 +11,6 @@ const OpacitySlider = ({ opacity, onChange }) => (
             max={1}
             step={0.01}
             onChange={(evt, opacity) => onChange(opacity)}
-            // classes={classes}
         />
     </div>
 );

--- a/src/components/layers/toolbar/__tests__/LayerToolbar.spec.js
+++ b/src/components/layers/toolbar/__tests__/LayerToolbar.spec.js
@@ -6,7 +6,6 @@ describe('LayerToolbar', () => {
     const shallowRenderLayerToolbar = props =>
         shallow(
             <LayerToolbar
-                classes={{}}
                 opacity={0}
                 isVisible={true}
                 toggleLayerVisibility={() => null}
@@ -16,11 +15,9 @@ describe('LayerToolbar', () => {
         );
     it('Should render only a visibility toggle and opacity slider', () => {
         const wrapper = shallowRenderLayerToolbar();
-        expect(wrapper.find('WithStyles(ForwardRef(IconButton))').length).toBe(
-            1
-        ); // Visibility toggle
-        expect(wrapper.find('WithStyles(OpacitySlider)').length).toBe(1);
-        expect(wrapper.find('WithStyles(LayerToolbarMoreMenu)').length).toBe(1);
+        expect(wrapper.find('[data-test="visibilitybutton"]').length).toBe(1); // Visibility toggle
+        expect(wrapper.find('OpacitySlider').length).toBe(1);
+        expect(wrapper.find('LayerToolbarMoreMenu').length).toBe(1);
     });
 
     it('Should show VisibilityIcon when visible', () => {
@@ -48,7 +45,7 @@ describe('LayerToolbar', () => {
         const wrapper = shallowRenderLayerToolbar({
             toggleLayerVisibility: toggleVisibleFn,
         });
-        wrapper.find('WithStyles(ForwardRef(IconButton))').simulate('click');
+        wrapper.find('[data-test="visibilitybutton"]').simulate('click');
         expect(toggleVisibleFn).toHaveBeenCalled();
     });
 
@@ -61,11 +58,9 @@ describe('LayerToolbar', () => {
         const wrapper = shallowRenderLayerToolbar({
             onEdit: () => null,
         });
-        expect(wrapper.find('WithStyles(ForwardRef(IconButton))').length).toBe(
-            2
-        ); // Visibility toggle and Edit
-        expect(wrapper.find('WithStyles(OpacitySlider)').length).toBe(1);
-        expect(wrapper.find('WithStyles(LayerToolbarMoreMenu)').length).toBe(1);
+        expect(wrapper.find('[data-test="visibilitybutton"]').length).toBe(1);
+        expect(wrapper.find('OpacitySlider').length).toBe(1);
+        expect(wrapper.find('LayerToolbarMoreMenu').length).toBe(1);
     });
 
     it('Should match toolbar snapshot WITH Edit button', () => {
@@ -84,19 +79,11 @@ describe('LayerToolbar', () => {
             onEdit: editFn,
         });
 
-        // First button should be Edit
-        wrapper
-            .find('WithStyles(ForwardRef(IconButton))')
-            .first()
-            .simulate('click');
+        wrapper.find('[data-test="editbutton"]').simulate('click');
         expect(editFn).toHaveBeenCalled();
         expect(toggleVisibleFn).not.toHaveBeenCalled();
 
-        // Second button should be Visibility Toggle
-        wrapper
-            .find('WithStyles(ForwardRef(IconButton))')
-            .at(1)
-            .simulate('click');
+        wrapper.find('[data-test="visibilitybutton"]').simulate('click');
         expect(toggleVisibleFn).toHaveBeenCalled();
         expect(editFn).toHaveBeenCalledTimes(1);
     });

--- a/src/components/layers/toolbar/__tests__/LayerToolbarMoreMenu.spec.js
+++ b/src/components/layers/toolbar/__tests__/LayerToolbarMoreMenu.spec.js
@@ -4,106 +4,83 @@ import { LayerToolbarMoreMenu } from '../LayerToolbarMoreMenu';
 
 describe('LayerToolbarMoreMenu', () => {
     it('Should render nothing when no props passed', () => {
-        const wrapper = shallow(<LayerToolbarMoreMenu classes={{}} />);
+        const wrapper = shallow(<LayerToolbarMoreMenu />);
         expect(wrapper.equals(null)).toBe(true);
     });
 
     it('Should open menu on click', () => {
-        const wrapper = shallow(
-            <LayerToolbarMoreMenu classes={{}} onRemove={() => null} />
-        );
+        const wrapper = shallow(<LayerToolbarMoreMenu onRemove={() => null} />);
 
-        expect(wrapper.state('open')).toBe(false);
-        expect(wrapper.state('anchorEl')).toBe(null);
-        wrapper
-            .find('WithStyles(ForwardRef(IconButton))')
-            .simulate('click', { currentTarget: 42 });
-        expect(wrapper.state('open')).toBe(true);
-        expect(wrapper.state('anchorEl')).toBe(42);
+        expect(wrapper.find('Menu').length).toBe(0);
+
+        wrapper.find('[data-test="moremenubutton"]').simulate('click');
+
+        expect(wrapper.find('Menu').length).toBe(1);
     });
 
     it('Should render a single MenuItem with no divider if the only prop is onRemove', () => {
-        const wrapper = shallow(
-            <LayerToolbarMoreMenu classes={{}} onRemove={() => null} />
-        );
+        const wrapper = shallow(<LayerToolbarMoreMenu onRemove={() => null} />);
 
-        expect(wrapper.find('WithStyles(ForwardRef(IconButton))').length).toBe(
-            1
-        );
+        wrapper.find('[data-test="moremenubutton"]').simulate('click');
 
-        expect(wrapper.find('WithStyles(ForwardRef(MenuItem))').length).toBe(1);
-        expect(wrapper.find('WithStyles(ForwardRef(Divider))').length).toBe(0);
+        expect(wrapper.find('MenuItem').length).toBe(1);
+        expect(wrapper.find('Divider').length).toBe(0);
     });
 
     it('Should render two MenuItems with no divider if only passed onEdit and onRemove', () => {
         const wrapper = shallow(
-            <LayerToolbarMoreMenu
-                classes={{}}
-                onEdit={() => null}
-                onRemove={() => null}
-            />
+            <LayerToolbarMoreMenu onEdit={() => null} onRemove={() => null} />
         );
 
-        expect(wrapper.find('WithStyles(ForwardRef(IconButton))').length).toBe(
-            1
-        );
+        wrapper.find('[data-test="moremenubutton"]').simulate('click');
 
-        expect(wrapper.find('WithStyles(ForwardRef(MenuItem))').length).toBe(2);
-        expect(wrapper.find('WithStyles(ForwardRef(Divider))').length).toBe(0);
+        expect(wrapper.find('MenuItem').length).toBe(2);
+        expect(wrapper.find('Divider').length).toBe(0);
     });
 
     it('Should render two MenuItems with no divider if only passed toggleDataTable', () => {
         const wrapper = shallow(
-            <LayerToolbarMoreMenu classes={{}} toggleDataTable={() => null} />
+            <LayerToolbarMoreMenu toggleDataTable={() => null} />
         );
 
-        expect(wrapper.find('WithStyles(ForwardRef(IconButton))').length).toBe(
-            1
-        );
+        wrapper.find('[data-test="moremenubutton"]').simulate('click');
 
-        expect(wrapper.find('WithStyles(ForwardRef(MenuItem))').length).toBe(1);
-        expect(wrapper.find('WithStyles(ForwardRef(Divider))').length).toBe(0);
+        expect(wrapper.find('MenuItem').length).toBe(1);
+        expect(wrapper.find('Divider').length).toBe(0);
     });
 
     it('Should render two MenuItems with no divider if only passed toggleDataTable and downloadData', () => {
         const wrapper = shallow(
             <LayerToolbarMoreMenu
-                classes={{}}
                 toggleDataTable={() => null}
                 downloadData={() => null}
             />
         );
 
-        expect(wrapper.find('WithStyles(ForwardRef(IconButton))').length).toBe(
-            1
-        );
+        wrapper.find('[data-test="moremenubutton"]').simulate('click');
 
-        expect(wrapper.find('WithStyles(ForwardRef(MenuItem))').length).toBe(2);
-        expect(wrapper.find('WithStyles(ForwardRef(Divider))').length).toBe(0);
+        expect(wrapper.find('MenuItem').length).toBe(2);
+        expect(wrapper.find('Divider').length).toBe(0);
     });
 
     it('Should render three MenuItems WITH divider if passed toggleDataTable, onEdit, and onRemove', () => {
         const wrapper = shallow(
             <LayerToolbarMoreMenu
-                classes={{}}
                 onEdit={() => null}
                 onRemove={() => null}
                 toggleDataTable={() => null}
             />
         );
 
-        expect(wrapper.find('WithStyles(ForwardRef(IconButton))').length).toBe(
-            1
-        );
+        wrapper.find('[data-test="moremenubutton"]').simulate('click');
 
-        expect(wrapper.find('WithStyles(ForwardRef(MenuItem))').length).toBe(3);
-        expect(wrapper.find('WithStyles(ForwardRef(Divider))').length).toBe(1);
+        expect(wrapper.find('MenuItem').length).toBe(3);
+        expect(wrapper.find('Divider').length).toBe(1);
     });
 
     it('Should render four MenuItems WITH divider if passed toggleDataTable, downloadData, onEdit, and onRemove', () => {
         const wrapper = shallow(
             <LayerToolbarMoreMenu
-                classes={{}}
                 onEdit={() => null}
                 onRemove={() => null}
                 downloadData={() => null}
@@ -111,24 +88,23 @@ describe('LayerToolbarMoreMenu', () => {
             />
         );
 
-        expect(wrapper.find('WithStyles(ForwardRef(IconButton))').length).toBe(
-            1
-        );
+        wrapper.find('[data-test="moremenubutton"]').simulate('click');
 
-        expect(wrapper.find('WithStyles(ForwardRef(MenuItem))').length).toBe(4);
-        expect(wrapper.find('WithStyles(ForwardRef(Divider))').length).toBe(1);
+        expect(wrapper.find('MenuItem').length).toBe(4);
+        expect(wrapper.find('Divider').length).toBe(1);
     });
 
     it('Should match snapshot', () => {
         const wrapper = shallow(
             <LayerToolbarMoreMenu
-                classes={{}}
                 onEdit={() => null}
                 onRemove={() => null}
                 downloadData={() => null}
                 toggleDataTable={() => null}
             />
         );
+
+        wrapper.find('[data-test="moremenubutton"]').simulate('click');
 
         expect(wrapper).toMatchSnapshot();
     });
@@ -141,7 +117,6 @@ describe('LayerToolbarMoreMenu', () => {
 
         const wrapper = shallow(
             <LayerToolbarMoreMenu
-                classes={{}}
                 onEdit={onEdit}
                 onRemove={onRemove}
                 downloadData={downloadData}
@@ -149,37 +124,29 @@ describe('LayerToolbarMoreMenu', () => {
             />
         );
 
-        wrapper
-            .find('WithStyles(ForwardRef(MenuItem))')
-            .at(0)
-            .simulate('click');
+        wrapper.find('[data-test="moremenubutton"]').simulate('click');
+
+        const menuItems = wrapper.find('MenuItem');
+
+        menuItems.at(0).simulate('click');
         expect(toggleDataTable).toHaveBeenCalledTimes(1);
         expect(downloadData).toHaveBeenCalledTimes(0);
         expect(onEdit).toHaveBeenCalledTimes(0);
         expect(onRemove).toHaveBeenCalledTimes(0);
 
-        wrapper
-            .find('WithStyles(ForwardRef(MenuItem))')
-            .at(1)
-            .simulate('click');
+        menuItems.at(1).simulate('click');
         expect(toggleDataTable).toHaveBeenCalledTimes(1);
         expect(downloadData).toHaveBeenCalledTimes(1);
         expect(onEdit).toHaveBeenCalledTimes(0);
         expect(onRemove).toHaveBeenCalledTimes(0);
 
-        wrapper
-            .find('WithStyles(ForwardRef(MenuItem))')
-            .at(2)
-            .simulate('click');
+        menuItems.at(2).simulate('click');
         expect(toggleDataTable).toHaveBeenCalledTimes(1);
         expect(downloadData).toHaveBeenCalledTimes(1);
         expect(onEdit).toHaveBeenCalledTimes(1);
         expect(onRemove).toHaveBeenCalledTimes(0);
 
-        wrapper
-            .find('WithStyles(ForwardRef(MenuItem))')
-            .at(3)
-            .simulate('click');
+        menuItems.at(3).simulate('click');
         expect(toggleDataTable).toHaveBeenCalledTimes(1);
         expect(downloadData).toHaveBeenCalledTimes(1);
         expect(onEdit).toHaveBeenCalledTimes(1);

--- a/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbar.spec.js.snap
+++ b/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbar.spec.js.snap
@@ -1,99 +1,107 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LayerToolbar Should match toolbar snapshot WITH Edit button 1`] = `
-<WithStyles(ForwardRef(Toolbar))
+<div
+  className="toolbar"
   data-test="layertoolbar"
 >
-  <WithStyles(ForwardRef(Tooltip))
-    key="edit"
-    title="Edit"
+  <Tooltip
+    content="Edit"
+    dataTest="dhis2-uicore-tooltip"
+    maxWidth={300}
+    placement="top"
+    tag="span"
   >
-    <WithStyles(ForwardRef(IconButton))
+    <div
+      className="button"
+      data-test="editbutton"
       onClick={[Function]}
     >
       <CreateIcon
         data-icon="CreateIcon"
       />
-    </WithStyles(ForwardRef(IconButton))>
-  </WithStyles(ForwardRef(Tooltip))>
-  <span />
-  <WithStyles(ForwardRef(Tooltip))
-    title="Toggle visibility"
+    </div>
+  </Tooltip>
+  <span
+    className="spacer"
+  />
+  <Tooltip
+    content="Toggle visibility"
+    dataTest="dhis2-uicore-tooltip"
+    maxWidth={300}
+    placement="top"
+    tag="span"
   >
-    <WithStyles(ForwardRef(IconButton))
+    <div
+      className="button"
+      data-test="visibilitybutton"
       onClick={[Function]}
     >
       <VisibilityIcon
         data-icon="VisibilityIcon"
       />
-    </WithStyles(ForwardRef(IconButton))>
-  </WithStyles(ForwardRef(Tooltip))>
-  <div>
-    <WithStyles(ForwardRef(Tooltip))
-      title="Set layer opacity"
+    </div>
+  </Tooltip>
+  <div
+    className="sliderContainer"
+  >
+    <Tooltip
+      content="Set layer opacity"
+      dataTest="dhis2-uicore-tooltip"
+      maxWidth={300}
+      placement="top"
+      tag="span"
     >
-      <div>
-        <WithStyles(OpacitySlider)
-          classes={
-            Object {
-              "root": undefined,
-            }
-          }
-          onChange={[Function]}
-          opacity={0}
-        />
-      </div>
-    </WithStyles(ForwardRef(Tooltip))>
+      <OpacitySlider
+        onChange={[Function]}
+        opacity={0}
+      />
+    </Tooltip>
   </div>
-  <WithStyles(LayerToolbarMoreMenu)
-    classes={
-      Object {
-        "button": undefined,
-      }
-    }
+  <LayerToolbarMoreMenu
     onEdit={[Function]}
   />
-</WithStyles(ForwardRef(Toolbar))>
+</div>
 `;
 
 exports[`LayerToolbar Should match toolbar snapshot without Edit button 1`] = `
-<WithStyles(ForwardRef(Toolbar))
+<div
+  className="toolbar"
   data-test="layertoolbar"
 >
-  <WithStyles(ForwardRef(Tooltip))
-    title="Toggle visibility"
+  <Tooltip
+    content="Toggle visibility"
+    dataTest="dhis2-uicore-tooltip"
+    maxWidth={300}
+    placement="top"
+    tag="span"
   >
-    <WithStyles(ForwardRef(IconButton))
+    <div
+      className="button"
+      data-test="visibilitybutton"
       onClick={[Function]}
     >
       <VisibilityIcon
         data-icon="VisibilityIcon"
       />
-    </WithStyles(ForwardRef(IconButton))>
-  </WithStyles(ForwardRef(Tooltip))>
-  <div>
-    <WithStyles(ForwardRef(Tooltip))
-      title="Set layer opacity"
+    </div>
+  </Tooltip>
+  <div
+    className="sliderContainer"
+  >
+    <Tooltip
+      content="Set layer opacity"
+      dataTest="dhis2-uicore-tooltip"
+      maxWidth={300}
+      placement="top"
+      tag="span"
     >
-      <div>
-        <WithStyles(OpacitySlider)
-          classes={
-            Object {
-              "root": undefined,
-            }
-          }
-          onChange={[Function]}
-          opacity={0}
-        />
-      </div>
-    </WithStyles(ForwardRef(Tooltip))>
+      <OpacitySlider
+        onChange={[Function]}
+        opacity={0}
+      />
+    </Tooltip>
   </div>
-  <WithStyles(LayerToolbarMoreMenu)
-    classes={
-      Object {
-        "button": undefined,
-      }
-    }
-  />
-</WithStyles(ForwardRef(Toolbar))>
+  <LayerToolbarMoreMenu />
+</div>
 `;

--- a/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbarMoreMenu.spec.js.snap
+++ b/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbarMoreMenu.spec.js.snap
@@ -2,71 +2,71 @@
 
 exports[`LayerToolbarMoreMenu Should match snapshot 1`] = `
 <Fragment>
-  <WithStyles(ForwardRef(Tooltip))
-    title="More actions"
+  <Tooltip
+    content="More actions"
+    dataTest="dhis2-uicore-tooltip"
+    maxWidth={300}
+    placement="top"
+    tag="span"
   >
-    <WithStyles(ForwardRef(IconButton))
+    <div
+      className="moreMenuButton"
+      data-test="moremenubutton"
       onClick={[Function]}
     >
       <MoreHorizIcon />
-    </WithStyles(ForwardRef(IconButton))>
-  </WithStyles(ForwardRef(Tooltip))>
-  <WithStyles(ForwardRef(Menu))
-    anchorEl={null}
-    anchorOrigin={
+    </div>
+  </Tooltip>
+  <Popover
+    arrow={false}
+    dataTest="dhis2-uicore-popover"
+    elevation="0 0 1px 0 rgba(64,75,90,0.29), 0 3px 8px -2px rgba(64,75,90,0.30)"
+    maxWidth={360}
+    onClickOutside={[Function]}
+    placement="right"
+    reference={
       Object {
-        "horizontal": "left",
-        "vertical": "bottom",
+        "current": undefined,
       }
     }
-    disableRestoreFocus={true}
-    getContentAnchorEl={null}
-    onClose={[Function]}
-    open={false}
   >
-    <WithStyles(ForwardRef(MenuItem))
-      onClick={[Function]}
+    <div
+      className="menu"
     >
-      <WithStyles(ForwardRef(ListItemIcon))>
-        <ViewListIcon />
-      </WithStyles(ForwardRef(ListItemIcon))>
-      <WithStyles(ForwardRef(ListItemText))
-        primary="Data table"
-      />
-    </WithStyles(ForwardRef(MenuItem))>
-    <WithStyles(ForwardRef(MenuItem))
-      onClick={[Function]}
-    >
-      <WithStyles(ForwardRef(ListItemIcon))>
-        <SaveAltIcon />
-      </WithStyles(ForwardRef(ListItemIcon))>
-      <WithStyles(ForwardRef(ListItemText))
-        primary="Download data"
-      />
-    </WithStyles(ForwardRef(MenuItem))>
-    <WithStyles(ForwardRef(Divider))
-      light={true}
-    />
-    <WithStyles(ForwardRef(MenuItem))
-      onClick={[Function]}
-    >
-      <WithStyles(ForwardRef(ListItemIcon))>
-        <CreateIcon />
-      </WithStyles(ForwardRef(ListItemIcon))>
-      <WithStyles(ForwardRef(ListItemText))
-        primary="Edit layer"
-      />
-    </WithStyles(ForwardRef(MenuItem))>
-    <WithStyles(ForwardRef(MenuItem))
-      onClick={[Function]}
-    >
-      <WithStyles(ForwardRef(ListItemIcon))>
-        <DeleteIcon />
-      </WithStyles(ForwardRef(ListItemIcon))>
-      <WithStyles(ForwardRef(ListItemText))
-        primary="Remove layer"
-      />
-    </WithStyles(ForwardRef(MenuItem))>
-  </WithStyles(ForwardRef(Menu))>
+      <Menu
+        dataTest="dhis2-uicore-menulist"
+        dense={true}
+      >
+        <MenuItem
+          dataTest="dhis2-uicore-menuitem"
+          icon={<UNDEFINED />}
+          label="Data table"
+          onClick={[Function]}
+        />
+        <MenuItem
+          dataTest="dhis2-uicore-menuitem"
+          icon={<UNDEFINED />}
+          label="Download data"
+          onClick={[Function]}
+        />
+        <Divider
+          dataTest="dhis2-uicore-divider"
+          margin="8px 0"
+        />
+        <MenuItem
+          dataTest="dhis2-uicore-menuitem"
+          icon={<UNDEFINED />}
+          label="Edit layer"
+          onClick={[Function]}
+        />
+        <MenuItem
+          dataTest="dhis2-uicore-menuitem"
+          icon={<UNDEFINED />}
+          label="Remove layer"
+          onClick={[Function]}
+        />
+      </Menu>
+    </div>
+  </Popover>
 </Fragment>
 `;

--- a/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbarMoreMenu.spec.js.snap
+++ b/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbarMoreMenu.spec.js.snap
@@ -40,7 +40,7 @@ exports[`LayerToolbarMoreMenu Should match snapshot 1`] = `
         <MenuItem
           dataTest="dhis2-uicore-menuitem"
           icon={<UNDEFINED />}
-          label="Data table"
+          label="Show data table"
           onClick={[Function]}
         />
         <MenuItem

--- a/src/components/layers/toolbar/styles/LayerToolbar.module.css
+++ b/src/components/layers/toolbar/styles/LayerToolbar.module.css
@@ -1,0 +1,27 @@
+.toolbar {
+    position: relative;
+    height: var(--spacers-dp32);
+    min-height: var(--spacers-dp32);
+    padding: 0 var(--spacers-dp8);
+    border-top: 1px solid var(--colors-grey300);
+    color: var(--colors-grey800);
+}
+
+.spacer {
+    float: left;
+    height: var(--spacers-dp32);
+    width: var(--spacers-dp16);
+}
+
+.button {
+    float: left;
+    padding: var(--spacers-dp4);
+    width: var(--spacers-dp32);
+    height: var(--spacers-dp32);
+    cursor: pointer;
+}
+
+.sliderContainer {
+    float: left;
+    margin-left: var(--spacers-dp16);
+}

--- a/src/components/layers/toolbar/styles/LayerToolbarMore.module.css
+++ b/src/components/layers/toolbar/styles/LayerToolbarMore.module.css
@@ -1,0 +1,13 @@
+.moreMenuButton {
+    width: var(--spacers-dp32);
+    height: var(--spacers-dp32);
+    padding: var(--spacers-dp4);
+    position: absolute;
+    right: var(--spacers-dp4);
+    top: 0;
+    cursor: pointer;
+}
+
+.menu {
+    padding: var(--spacers-dp8) 0;
+}

--- a/src/components/layers/toolbar/styles/OpacitySlider.module.css
+++ b/src/components/layers/toolbar/styles/OpacitySlider.module.css
@@ -1,0 +1,9 @@
+.slider {
+    width: 100px;
+    height: var(--spacers-dp32);
+    padding-top: 2px;
+}
+
+.slider > span {
+    color: var(--colors-grey800);
+}


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-9699

This PR refactors the layer toolbar and places where MUI IconButton was used. The main changes are: 
- Switch from MUI to @dhis2/ui (Tooltip, Popover, Menu, MenuItem, Divider)
- There is no Toolbar or IconButton (without an outline) in @dhis2/ui, so they are replaced by styled divs. 
- Inline styles are moved to css modules
- Class components are translated to functional components

The opacity slider still uses MUI, will be fixed in a separate PR. 

There are still issues with the placements of @dhis2/ui components (tooltip and popover menu). Will be fixed in a separate PR after all MUI styles are gone. 

After this PR: 

<img width="463" alt="Screenshot 2020-11-10 at 18 55 48" src="https://user-images.githubusercontent.com/548708/98712260-5dba1c80-2386-11eb-9845-fa694ca9cdff.png">

