### PR TITLE
 chore: refactor circular loaders to use @dhis2/ui (DHIS2-9699)

### DIFF
--- a/src/components/edit/trackedEntity/TrackedEntityRelationshipTypeSelect.js
+++ b/src/components/edit/trackedEntity/TrackedEntityRelationshipTypeSelect.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
-import CircularProgress from '@material-ui/core/CircularProgress';
+import { CircularLoader } from '@dhis2/ui';
 import SelectField from '../../core/SelectField';
 import memoize from 'lodash/memoize';
 import { apiFetch } from '../../../util/api';
@@ -43,7 +43,7 @@ class TrackedEntityRelationshipTypeSelect extends Component {
 
     render() {
         if (!this.state.allTypes) {
-            return <CircularProgress />;
+            return <CircularLoader small />;
         } else if (this.state.error) {
             return <span>{this.state.error}</span>;
         }

--- a/src/components/map/MapLoadingMask.js
+++ b/src/components/map/MapLoadingMask.js
@@ -1,33 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
-import { CircularProgress } from '@material-ui/core';
+import { ComponentCover, CenteredContent, CircularLoader } from '@dhis2/ui';
 
-const styles = () => ({
-    mask: {
-        zIndex: 990,
-        backgroundColor: 'rgba(255,255,255,0.8)',
-        position: 'absolute',
-        top: 0,
-        bottom: 0,
-        left: 0,
-        right: 0,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-    },
-});
+const MapLoadingMask = () => (
+    <ComponentCover translucent>
+        <CenteredContent>
+            <CircularLoader />
+        </CenteredContent>
+    </ComponentCover>
+);
 
-const MapLoadingMask = ({ classes }) => {
-    return (
-        <div className={classes.mask}>
-            <CircularProgress size={32} />
-        </div>
-    );
-};
-
-MapLoadingMask.propTypes = {
-    classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(MapLoadingMask);
+export default MapLoadingMask;

--- a/src/components/optionSet/OptionSetStyle.js
+++ b/src/components/optionSet/OptionSetStyle.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { CircularProgress } from '@material-ui/core';
+import { CircularLoader } from '@dhis2/ui';
 import OptionStyle from './OptionStyle';
 import { loadOptionSet } from '../../actions/optionSets';
 import { setOptionStyle } from '../../actions/layerEdit';
@@ -79,7 +79,7 @@ class OptionSetStyle extends Component {
                         />
                     ))
                 ) : (
-                    <CircularProgress size={48} />
+                    <CircularLoader small />
                 )}
             </div>
         );


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-9699

This small PR is replacing MUI CircularProgress with CircularLoader to @dhis2/ui. ComponentCover and CenteredContent is also used to add a mask and to center the circular loader on the map. 

After this PR: 

![Screenshot 2020-11-11 at 11 20 43](https://user-images.githubusercontent.com/548708/98802226-407f5f80-2413-11eb-90ac-a9e3dfdfc4e0.png)
