### PR TITLE
feat: legend support for external layers (DHIS2-3201)

### DIFF
--- a/src/components/edit/LayerEdit.js
+++ b/src/components/edit/LayerEdit.js
@@ -51,7 +51,9 @@ class LayerEdit extends Component {
     };
 
     componentDidUpdate() {
-        this.loadLayer();
+        if (this.props.layer) {
+            this.loadLayer();
+        }
     }
 
     closeDialog() {

--- a/src/components/edit/LayerEdit.js
+++ b/src/components/edit/LayerEdit.js
@@ -50,12 +50,6 @@ class LayerEdit extends Component {
         validateLayer: false,
     };
 
-    componentDidUpdate() {
-        if (this.props.layer) {
-            this.loadLayer();
-        }
-    }
-
     closeDialog() {
         this.props.cancelLayer();
     }

--- a/src/components/edit/LayerEdit.js
+++ b/src/components/edit/LayerEdit.js
@@ -51,12 +51,7 @@ class LayerEdit extends Component {
     };
 
     componentDidUpdate() {
-        const { layer } = this.props;
-
-        if (layer && layer.layer === 'external') {
-            // External layers has no edit widget
-            this.loadLayer();
-        }
+        this.loadLayer();
     }
 
     closeDialog() {

--- a/src/components/layers/overlays/AddLayerPopover.js
+++ b/src/components/layers/overlays/AddLayerPopover.js
@@ -16,9 +16,7 @@ const AddLayerPopover = ({
 }) => {
     const onLayerSelect = layer => {
         const config = { ...layer };
-
         layer.layer === 'external' ? loadLayer(config) : editLayer(config);
-
         onClose();
     };
 

--- a/src/components/layers/overlays/AddLayerPopover.js
+++ b/src/components/layers/overlays/AddLayerPopover.js
@@ -15,9 +15,9 @@ const AddLayerPopover = ({
     onClose,
 }) => {
     const onLayerSelect = layer => {
-        layer.layer === 'external'
-            ? loadLayer({ ...layer, isLoaded: true })
-            : editLayer({ ...layer });
+        const config = { ...layer };
+
+        layer.layer === 'external' ? loadLayer(config) : editLayer(config);
 
         onClose();
     };

--- a/src/components/layers/overlays/AddLayerPopover.js
+++ b/src/components/layers/overlays/AddLayerPopover.js
@@ -4,19 +4,19 @@ import { connect } from 'react-redux';
 import { Popover } from '@dhis2/ui';
 import LayerList from './LayerList';
 import { isSplitViewMap } from '../../../util/helpers';
-import { addLayer, editLayer } from '../../../actions/layers';
+import { loadLayer, editLayer } from '../../../actions/layers';
 
 const AddLayerPopover = ({
     anchorEl,
     layers = [],
     isSplitView,
-    addLayer,
+    loadLayer,
     editLayer,
     onClose,
 }) => {
     const onLayerSelect = layer => {
         layer.layer === 'external'
-            ? addLayer({ ...layer, isLoaded: true })
+            ? loadLayer({ ...layer, isLoaded: true })
             : editLayer({ ...layer });
 
         onClose();
@@ -44,7 +44,7 @@ AddLayerPopover.propTypes = {
     anchorEl: PropTypes.object,
     layers: PropTypes.array,
     isSplitView: PropTypes.bool,
-    addLayer: PropTypes.func.isRequired,
+    loadLayer: PropTypes.func.isRequired,
     editLayer: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
 };
@@ -54,5 +54,5 @@ export default connect(
         layers,
         isSplitView: isSplitViewMap(map.mapViews),
     }),
-    { addLayer, editLayer }
+    { loadLayer, editLayer }
 )(AddLayerPopover);

--- a/src/components/legend/Legend.js
+++ b/src/components/legend/Legend.js
@@ -13,6 +13,7 @@ const Legend = ({
     items,
     bubbles,
     explanation,
+    url,
     source,
     sourceUrl,
 }) => (
@@ -32,6 +33,7 @@ const Legend = ({
                 </table>
             )
         )}
+        {url && <img className={styles.legendImage} src={url} />}
         {Array.isArray(filters) && (
             <div className={styles.filters}>
                 <div>{i18n.t('Filters')}:</div>
@@ -70,6 +72,7 @@ Legend.propTypes = {
         radiusHigh: PropTypes.number.isRequired,
         color: PropTypes.string,
     }),
+    url: PropTypes.string,
     explanation: PropTypes.array,
     source: PropTypes.string,
     sourceUrl: PropTypes.string,

--- a/src/components/legend/styles/Legend.module.css
+++ b/src/components/legend/styles/Legend.module.css
@@ -17,7 +17,7 @@
 }
 
 .legendImage {
-    max-width: 240px;
+    max-width: 100%;
 }
 
 .filters {

--- a/src/components/legend/styles/Legend.module.css
+++ b/src/components/legend/styles/Legend.module.css
@@ -16,6 +16,10 @@
     padding-bottom: var(--spacers-dp12);
 }
 
+.legendImage {
+    max-width: 240px;
+}
+
 .filters {
     padding-top: var(--spacers-dp16);
     font-size: 12px;

--- a/src/components/plugin/Legend.js
+++ b/src/components/plugin/Legend.js
@@ -6,7 +6,8 @@ import './styles/Legend.css';
 
 // Renders a legend for all map layers
 const Legend = ({ layers }) => {
-    const [isOpen, toggleOpen] = useState(false);
+    // const [isOpen, toggleOpen] = useState(false);
+    const [isOpen, toggleOpen] = useState(true);
 
     const legendLayers = layers
         .filter(layer => layer.legend || layer.alerts)
@@ -17,7 +18,8 @@ const Legend = ({ layers }) => {
             {isOpen ? (
                 <div
                     className="dhis2-map-legend-content"
-                    onMouseLeave={() => toggleOpen(false)}
+                    // onMouseLeave={() => toggleOpen(false)}
+                    onMouseLeave={() => toggleOpen(true)}
                 >
                     {legendLayers.map(layer => (
                         <LegendLayer key={layer.id} {...layer} />

--- a/src/components/plugin/Legend.js
+++ b/src/components/plugin/Legend.js
@@ -6,8 +6,7 @@ import './styles/Legend.css';
 
 // Renders a legend for all map layers
 const Legend = ({ layers }) => {
-    // const [isOpen, toggleOpen] = useState(false);
-    const [isOpen, toggleOpen] = useState(true);
+    const [isOpen, toggleOpen] = useState(false);
 
     const legendLayers = layers
         .filter(layer => layer.legend || layer.alerts)
@@ -18,8 +17,7 @@ const Legend = ({ layers }) => {
             {isOpen ? (
                 <div
                     className="dhis2-map-legend-content"
-                    // onMouseLeave={() => toggleOpen(false)}
-                    onMouseLeave={() => toggleOpen(true)}
+                    onMouseLeave={() => toggleOpen(false)}
                 >
                     {legendLayers.map(layer => (
                         <LegendLayer key={layer.id} {...layer} />

--- a/src/components/plugin/LegendLayer.js
+++ b/src/components/plugin/LegendLayer.js
@@ -3,35 +3,26 @@ import PropTypes from 'prop-types';
 import LayerLegend from '../legend/Legend';
 
 // Renders a legend with alerts for one map layer
-const LegendLayer = props => {
-    const { id, layer, legend, serverCluster, data, alerts = [] } = props;
-
-    const hasData =
-        (Array.isArray(data) && data.length > 0) ||
-        serverCluster ||
-        layer === 'earthEngine';
-
-    return (
-        <div key={id}>
-            {legend && (
-                <Fragment>
-                    <h2 className="dhis2-map-legend-title">
-                        {legend.title}
-                        <span className="dhis2-map-legend-period">
-                            {legend.period}
-                        </span>
-                    </h2>
-                    {hasData && <LayerLegend {...legend} />}
-                </Fragment>
-            )}
-            {alerts.map(alert => (
-                <div key={alert.id} className="dhis2-map-legend-alert">
-                    {alert.message}
-                </div>
-            ))}
-        </div>
-    );
-};
+const LegendLayer = ({ id, legend, alerts = [] }) => (
+    <div key={id}>
+        {legend && (
+            <Fragment>
+                <h2 className="dhis2-map-legend-title">
+                    {legend.title}
+                    <span className="dhis2-map-legend-period">
+                        {legend.period}
+                    </span>
+                </h2>
+                <LayerLegend {...legend} />
+            </Fragment>
+        )}
+        {alerts.map(alert => (
+            <div key={alert.id} className="dhis2-map-legend-alert">
+                {alert.message}
+            </div>
+        ))}
+    </div>
+);
 
 LegendLayer.propTypes = {
     id: PropTypes.string.isRequired,

--- a/src/epics/externalLayers.js
+++ b/src/epics/externalLayers.js
@@ -50,34 +50,46 @@ const loadExternalMapLayers = () =>
 
 // Create external layer config object
 const createLayerConfig = () => layer => {
+    const {
+        id,
+        name,
+        attribution,
+        mapService,
+        url,
+        layers,
+        imageFormat,
+        legendSet,
+        legendSetUrl,
+    } = layer;
+
     const config = {
         type: 'tileLayer',
-        url: layer.url,
-        attribution: layer.attribution,
-        name: layer.name,
+        url,
+        attribution,
+        name,
     };
 
-    if (layer.mapService === 'TMS') {
+    if (mapService === 'TMS') {
         config.tms = true;
     }
 
-    if (layer.mapService === 'WMS') {
+    if (mapService === 'WMS') {
         config.type = 'wmsLayer';
-        config.layers = layer.layers;
+        config.layers = layers;
 
-        if (layer.imageFormat === 'JPG') {
+        if (imageFormat === 'JPG') {
             // PNG is default
             config.format = 'image/jpeg';
         }
     }
 
     return {
-        id: layer.id,
+        id,
         layer: 'external',
-        name: layer.name,
-        // subtitle: subTitle, // layer.mapLayerPosition === 'BASEMAP' ? 'External basemap' : 'External layer', // TODO: i18n
-        // img: layer.img, // TODO: Get from Web API
+        name,
         opacity: 1,
+        legendSet,
+        legendSetUrl,
         config,
     };
 };

--- a/src/epics/externalLayers.js
+++ b/src/epics/externalLayers.js
@@ -10,7 +10,7 @@ import * as types from '../constants/actionTypes';
 import { addBasemap } from '../actions/basemap';
 import { addExternalLayer } from '../actions/externalLayers';
 import { errorActionCreator } from '../actions/helpers';
-import { getExternalLayerConfig } from '../util/external';
+import { createExternalLayer } from '../util/external';
 
 // Load external layers from Web API
 export const loadExternalLayers = action$ =>
@@ -19,12 +19,12 @@ export const loadExternalLayers = action$ =>
             .mergeMap(collection => {
                 const externalBaseMapLayers = collection
                     .filter(isBaseMap)
-                    .map(createLayerConfig)
+                    .map(createExternalLayer)
                     .map(addBasemap);
 
                 const externalOverlayLayers = collection
                     .filter(isOverlay)
-                    .map(createLayerConfig)
+                    .map(createExternalLayer)
                     .map(addExternalLayer);
                 return [...externalBaseMapLayers, ...externalOverlayLayers];
             })
@@ -48,13 +48,5 @@ const loadExternalMapLayers = () =>
         .then(externalMapLayersCollection =>
             externalMapLayersCollection.toArray()
         );
-
-const createLayerConfig = layer => ({
-    layer: 'external',
-    id: layer.id,
-    name: layer.name,
-    opacity: 1,
-    config: getExternalLayerConfig(layer),
-});
 
 export default combineEpics(loadExternalLayers);

--- a/src/epics/externalLayers.js
+++ b/src/epics/externalLayers.js
@@ -10,11 +10,7 @@ import * as types from '../constants/actionTypes';
 import { addBasemap } from '../actions/basemap';
 import { addExternalLayer } from '../actions/externalLayers';
 import { errorActionCreator } from '../actions/helpers';
-
-export const loadExternalLayer = async id => {
-    const d2 = await getD2();
-    return d2.models.externalMapLayers.get(id);
-};
+import { getExternalLayerConfig } from '../util/external';
 
 // Load external layers from Web API
 export const loadExternalLayers = action$ =>
@@ -23,12 +19,12 @@ export const loadExternalLayers = action$ =>
             .mergeMap(collection => {
                 const externalBaseMapLayers = collection
                     .filter(isBaseMap)
-                    .map(createLayerConfig('External basemap'))
+                    .map(createLayerConfig)
                     .map(addBasemap);
 
                 const externalOverlayLayers = collection
                     .filter(isOverlay)
-                    .map(createLayerConfig('External layer'))
+                    .map(createLayerConfig)
                     .map(addExternalLayer);
                 return [...externalBaseMapLayers, ...externalOverlayLayers];
             })
@@ -53,52 +49,12 @@ const loadExternalMapLayers = () =>
             externalMapLayersCollection.toArray()
         );
 
-// Create external layer config object
-const createLayerConfig = () => layer => {
-    const {
-        id,
-        name,
-        attribution,
-        mapService,
-        url,
-        layers,
-        imageFormat,
-        legendSet,
-        legendSetUrl,
-    } = layer;
-
-    // console.log('createLayerConfig', id, name);
-
-    const config = {
-        type: 'tileLayer',
-        url,
-        attribution,
-        name,
-        legendSetUrl,
-    };
-
-    if (mapService === 'TMS') {
-        config.tms = true;
-    }
-
-    if (mapService === 'WMS') {
-        config.type = 'wmsLayer';
-        config.layers = layers;
-
-        if (imageFormat === 'JPG') {
-            // PNG is default
-            config.format = 'image/jpeg';
-        }
-    }
-
-    return {
-        id,
-        layer: 'external',
-        name,
-        opacity: 1,
-        legendSet,
-        config,
-    };
-};
+const createLayerConfig = layer => ({
+    layer: 'external',
+    id: layer.id,
+    name: layer.name,
+    opacity: 1,
+    config: getExternalLayerConfig(layer),
+});
 
 export default combineEpics(loadExternalLayers);

--- a/src/epics/externalLayers.js
+++ b/src/epics/externalLayers.js
@@ -11,6 +11,11 @@ import { addBasemap } from '../actions/basemap';
 import { addExternalLayer } from '../actions/externalLayers';
 import { errorActionCreator } from '../actions/helpers';
 
+export const loadExternalLayer = async id => {
+    const d2 = await getD2();
+    return d2.models.externalMapLayers.get(id);
+};
+
 // Load external layers from Web API
 export const loadExternalLayers = action$ =>
     action$.ofType(types.EXTERNAL_LAYERS_LOAD).mergeMap(() => {
@@ -62,11 +67,14 @@ const createLayerConfig = () => layer => {
         legendSetUrl,
     } = layer;
 
+    // console.log('createLayerConfig', id, name);
+
     const config = {
         type: 'tileLayer',
         url,
         attribution,
         name,
+        legendSetUrl,
     };
 
     if (mapService === 'TMS') {
@@ -89,7 +97,6 @@ const createLayerConfig = () => layer => {
         name,
         opacity: 1,
         legendSet,
-        legendSetUrl,
         config,
     };
 };

--- a/src/loaders/externalLoader.js
+++ b/src/loaders/externalLoader.js
@@ -1,5 +1,5 @@
 import { isString } from 'lodash/fp';
-// import { loadExternalLayer } from '../epics/externalLayers';
+// import { loadExternalLayer } from '../util/externalLayers';
 import { loadLegendSet, getPredefinedLegendItems } from '../util/legend';
 
 const externalLoader = async config => {

--- a/src/loaders/externalLoader.js
+++ b/src/loaders/externalLoader.js
@@ -6,16 +6,14 @@ const externalLoader = async layer => {
 
     if (typeof config === 'string') {
         // External layer is loaded in analytical object
-        config = (await parseLayerConfig(config)) || {};
+        config = await parseLayerConfig(config);
     } else {
         delete layer.id;
     }
 
     const { name, legendSet, legendSetUrl } = config;
 
-    const legend = {
-        title: config.name,
-    };
+    const legend = { title: name };
 
     if (legendSet) {
         const legendItems = await loadLegendSet(legendSet);

--- a/src/loaders/externalLoader.js
+++ b/src/loaders/externalLoader.js
@@ -1,8 +1,12 @@
-import { isString } from 'lodash/fp';
+// import { isString } from 'lodash/fp';
 // import { loadExternalLayer } from '../util/externalLayers';
 import { loadLegendSet, getPredefinedLegendItems } from '../util/legend';
 
-const externalLoader = async config => {
+const externalLoader = async layer => {
+    const { config } = layer;
+
+    // console.log('externalLoader', layer, config);
+
     // const { id } = config;
     // const layer = await loadExternalLayer(id);
 
@@ -10,12 +14,14 @@ const externalLoader = async config => {
 
     // console.log('externalLoader', id, layer);
 
+    // From database as favorite
+    /*
     if (isString(config.config)) {
-        // From database as favorite
         config.config = JSON.parse(config.config);
         config.name = config.config.name;
         config.legendSetUrl = config.config.legendSetUrl;
     }
+    */
 
     let { legendSet, legendSetUrl } = config;
 
@@ -32,10 +38,10 @@ const externalLoader = async config => {
         legend.url = config.legendSetUrl;
     }
 
-    delete config.id;
+    delete layer.id;
 
     return {
-        ...config,
+        ...layer,
         layer: 'external',
         legend,
         isLoaded: true,

--- a/src/loaders/externalLoader.js
+++ b/src/loaders/externalLoader.js
@@ -1,17 +1,43 @@
 import { isString } from 'lodash/fp';
+// import { loadExternalLayer } from '../epics/externalLayers';
+import { loadLegendSet, getPredefinedLegendItems } from '../util/legend';
 
 const externalLoader = async config => {
-    // Returns a promise
+    // const { id } = config;
+    // const layer = await loadExternalLayer(id);
+
+    // id,displayName~rename(name),service,url,attribution,mapService,layers,imageFormat,mapLayerPosition,legendSet,legendSetUrl'
+
+    // console.log('externalLoader', id, layer);
+
     if (isString(config.config)) {
         // From database as favorite
         config.config = JSON.parse(config.config);
         config.name = config.config.name;
+        config.legendSetUrl = config.config.legendSetUrl;
     }
+
+    let { legendSet, legendSetUrl } = config;
+
+    const legend = {
+        title: config.name,
+    };
+
+    if (legendSet) {
+        legendSet = await loadLegendSet(legendSet);
+        legend.items = getPredefinedLegendItems(legendSet);
+    }
+
+    if (legendSetUrl) {
+        legend.url = config.legendSetUrl;
+    }
+
+    delete config.id;
 
     return {
         ...config,
         layer: 'external',
-        name: config.name,
+        legend,
         isLoaded: true,
         isExpanded: true,
         isVisible: true,

--- a/src/loaders/externalLoader.js
+++ b/src/loaders/externalLoader.js
@@ -1,41 +1,27 @@
-// import { isString } from 'lodash/fp';
-// import { loadExternalLayer } from '../util/externalLayers';
+import { parseLayerConfig } from '../util/external';
 import { loadLegendSet, getPredefinedLegendItems } from '../util/legend';
 
 const externalLoader = async layer => {
-    const { config } = layer;
+    let { config } = layer;
 
-    // console.log('externalLoader', layer, config);
-
-    // const { id } = config;
-    // const layer = await loadExternalLayer(id);
-
-    // id,displayName~rename(name),service,url,attribution,mapService,layers,imageFormat,mapLayerPosition,legendSet,legendSetUrl'
-
-    // console.log('externalLoader', id, layer);
-
-    // From database as favorite
-    /*
-    if (isString(config.config)) {
-        config.config = JSON.parse(config.config);
-        config.name = config.config.name;
-        config.legendSetUrl = config.config.legendSetUrl;
+    if (typeof config === 'string') {
+        // External layer is loaded in analytical object
+        config = parseLayerConfig(config);
     }
-    */
 
-    let { legendSet, legendSetUrl } = config;
+    const { name, legendSet, legendSetUrl } = config;
 
     const legend = {
         title: config.name,
     };
 
     if (legendSet) {
-        legendSet = await loadLegendSet(legendSet);
-        legend.items = getPredefinedLegendItems(legendSet);
+        const legendItems = await loadLegendSet(legendSet);
+        legend.items = getPredefinedLegendItems(legendItems);
     }
 
     if (legendSetUrl) {
-        legend.url = config.legendSetUrl;
+        legend.url = legendSetUrl;
     }
 
     delete layer.id;
@@ -43,7 +29,9 @@ const externalLoader = async layer => {
     return {
         ...layer,
         layer: 'external',
+        name,
         legend,
+        config,
         isLoaded: true,
         isExpanded: true,
         isVisible: true,

--- a/src/loaders/externalLoader.js
+++ b/src/loaders/externalLoader.js
@@ -6,7 +6,9 @@ const externalLoader = async layer => {
 
     if (typeof config === 'string') {
         // External layer is loaded in analytical object
-        config = parseLayerConfig(config);
+        config = (await parseLayerConfig(config)) || {};
+    } else {
+        delete layer.id;
     }
 
     const { name, legendSet, legendSetUrl } = config;
@@ -23,8 +25,6 @@ const externalLoader = async layer => {
     if (legendSetUrl) {
         legend.url = legendSetUrl;
     }
-
-    delete layer.id;
 
     return {
         ...layer,

--- a/src/util/external.js
+++ b/src/util/external.js
@@ -43,3 +43,8 @@ export const createExternalLayerConfig = layer => {
         legendSetUrl,
     };
 };
+
+export const parseLayerConfig = config => {
+    // console.log('parseLayerConfig', config);
+    return JSON.parse(config);
+};

--- a/src/util/external.js
+++ b/src/util/external.js
@@ -22,6 +22,8 @@ export const createExternalLayerConfig = layer => {
         url,
         layers,
         imageFormat,
+        legendSet,
+        legendSetUrl,
     } = layer;
 
     const type = mapService === 'WMS' ? 'wmsLayer' : 'tileLayer';
@@ -37,5 +39,7 @@ export const createExternalLayerConfig = layer => {
         layers,
         tms,
         format,
+        legendSet,
+        legendSetUrl,
     };
 };

--- a/src/util/external.js
+++ b/src/util/external.js
@@ -1,0 +1,41 @@
+import { getInstance as getD2 } from 'd2';
+
+export const loadExternalLayer = async id => {
+    const d2 = await getD2();
+    return d2.models.externalMapLayers.get(id);
+};
+
+export const createExternalLayer = layer => ({
+    layer: 'external',
+    id: layer.id,
+    name: layer.name,
+    opacity: 1,
+    config: createExternalLayerConfig(layer),
+});
+
+export const createExternalLayerConfig = layer => {
+    const {
+        id,
+        name,
+        attribution,
+        mapService,
+        url,
+        layers,
+        imageFormat,
+    } = layer;
+
+    const type = mapService === 'WMS' ? 'wmsLayer' : 'tileLayer';
+    const format = imageFormat === 'JPG' ? 'image/jpeg' : 'image/png';
+    const tms = mapService === 'TMS';
+
+    return {
+        id,
+        type,
+        url,
+        attribution,
+        name,
+        layers,
+        tms,
+        format,
+    };
+};


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-3201

This PR adds legend support for external layers. The legend can be a predefined in DHIS2, or a url to a legend image. 

This was already supported for external layers in the maintenance app:

<img width="572" alt="Screenshot 2020-12-02 at 12 49 17" src="https://user-images.githubusercontent.com/548708/100869100-d64f5d00-349c-11eb-8272-e8ae624059d9.png">

Showing a predefined legend and a legend image in the maps app: 

<img width="903" alt="Screenshot 2020-12-02 at 12 44 37" src="https://user-images.githubusercontent.com/548708/100868835-76f14d00-349c-11eb-90e4-18f9c4f0acbe.png">

We don't control the design of an external layer image - the max-width is adjusted to the container. 

The same legends shown for a plugin map (dashboard): 

<img width="451" alt="Screenshot 2020-12-02 at 12 45 21" src="https://user-images.githubusercontent.com/548708/100868858-7bb60100-349c-11eb-8269-66f58ca2a5a2.png">

The logic for saving external layers is changed: Before we save the full layer config so we can recreate the layer from the analytical object alone. This is not sufficient when we now start to add additional capabilities to external layers. If the legend is updated this should be reflected on all saved maps using the layer. After this PR we will store the id of the external layer, and then fetch the latest layer config when the map is loading.  