### PR TITLE
fix: allow the right click context menu to be closed (DHIS2-10071)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@dhis2/d2-ui-interpretations": "^7.0.8",
         "@dhis2/d2-ui-org-unit-dialog": "^7.0.8",
         "@dhis2/d2-ui-org-unit-tree": "^7.0.8",
-        "@dhis2/maps-gl": "^1.3.3",
+        "@dhis2/maps-gl": "^1.3.5",
         "@dhis2/ui": "^5.7.8",
         "@material-ui/icons": "^4.9.1",
         "abortcontroller-polyfill": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -357,10 +357,10 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@^1.3.3":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.3.4.tgz#a5264ab3222ae1165d24e409b2715919c79a64e0"
-  integrity sha512-oKbNtEFdnYUvxbfZqom+IhZjbSW4lF5sK9eUUUIZHQsN5rUhVNFTzzKoFCrq7Covv2KOgNuXR8gXNFE/zHlv7g==
+"@dhis2/maps-gl@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.3.5.tgz#1df0555bfa1019c671acf852733b5d8da3091bf4"
+  integrity sha512-sogjIR2JLGisDf6cIY2wAYx2nGNwS690RpkmGvzrGPIUGN3BK2sIag+CFe6OmonDX+kEdfY3HUnnK7168W0MkA==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.0.1"


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10071

This PR allows the right click context menu to be closed by clicking the map on dashboard maps. 