### PR TITLE
fix: allow the right click context menu to be closed (DHIS2-10071, 2.35 backport)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "35.0.12",
+    "version": "35.0.13",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {
@@ -53,7 +53,7 @@
         "@dhis2/d2-ui-interpretations": "^7.0.8",
         "@dhis2/d2-ui-org-unit-dialog": "^7.0.8",
         "@dhis2/d2-ui-org-unit-tree": "^7.0.8",
-        "@dhis2/maps-gl": "^1.3.3",
+        "@dhis2/maps-gl": "^1.3.5",
         "@dhis2/ui-core": "^4.1.1",
         "@dhis2/ui-widgets": "^2.1.0",
         "@material-ui/core": "^4.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -383,10 +383,10 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@^1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.3.3.tgz#6fb8744002d7dbe6857c7ac2ecdb35c64d64b1e0"
-  integrity sha512-FW9C5D9mCN+2akxPdMQFznOtB0gnhNQayrFFRzYeGuMO5d4SgrPLjtypbTnd1gMDhC2Jez12+8PZKMg9Vc3Xhw==
+"@dhis2/maps-gl@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.3.5.tgz#1df0555bfa1019c671acf852733b5d8da3091bf4"
+  integrity sha512-sogjIR2JLGisDf6cIY2wAYx2nGNwS690RpkmGvzrGPIUGN3BK2sIag+CFe6OmonDX+kEdfY3HUnnK7168W0MkA==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.0.1"


### PR DESCRIPTION
2.35 backport of: https://jira.dhis2.org/browse/DHIS2-10071

This PR allows the right click context menu to be closed by clicking the map on dashboard maps.