### PR TITLE
fix: disable relocate options in context menu (DHIS2-9957)

### DIFF
--- a/src/components/map/ContextMenu.js
+++ b/src/components/map/ContextMenu.js
@@ -128,6 +128,7 @@ const ContextMenu = props => {
                     />
                 </MenuItem>
             )}
+
             {layerType !== 'facility' && feature && (
                 <MenuItem
                     disabled={!attr.hasCoordinatesDown}
@@ -158,6 +159,7 @@ const ContextMenu = props => {
                     />
                 </MenuItem>
             )}
+
             {feature && (
                 <MenuItem
                     onClick={() => onShowInformation(attr)}
@@ -173,6 +175,7 @@ const ContextMenu = props => {
                     />
                 </MenuItem>
             )}
+
             {coordinates && (
                 <MenuItem
                     onClick={() => showCoordinate(coordinates)}
@@ -188,6 +191,7 @@ const ContextMenu = props => {
                     />
                 </MenuItem>
             )}
+
             {isAdmin && isPoint && (
                 <MenuItem
                     onClick={() =>
@@ -209,6 +213,7 @@ const ContextMenu = props => {
                     />
                 </MenuItem>
             )}
+
             {isAdmin && isPoint && (
                 <MenuItem
                     onClick={() => onRelocateStart(layerId, feature)}
@@ -224,6 +229,7 @@ const ContextMenu = props => {
                     />
                 </MenuItem>
             )}
+
             {earthEngineLayers.map(layer => (
                 <MenuItem
                     key={layer.id}

--- a/src/components/map/ContextMenu.js
+++ b/src/components/map/ContextMenu.js
@@ -190,7 +190,7 @@ const ContextMenu = (props, context) => {
                 </MenuItem>
             )}
 
-            {isAdmin && isPoint && (
+            {/*isAdmin && isPoint && (
                 <MenuItem
                     onClick={() =>
                         onSwapCoordinate(
@@ -210,9 +210,9 @@ const ContextMenu = (props, context) => {
                         disableTypography={true}
                     />
                 </MenuItem>
-            )}
+            )*/}
 
-            {isAdmin && isPoint && (
+            {/*isAdmin && isPoint && (
                 <MenuItem
                     onClick={() => onRelocateStart(layerId, feature)}
                     className={classes.menuItem}
@@ -226,7 +226,7 @@ const ContextMenu = (props, context) => {
                         disableTypography={true}
                     />
                 </MenuItem>
-            )}
+            )*/}
 
             {earthEngineLayers.map(layer => (
                 <MenuItem

--- a/src/components/map/ContextMenu.js
+++ b/src/components/map/ContextMenu.js
@@ -44,7 +44,7 @@ const styles = {
 
 const polygonTypes = ['Polygon', 'MultiPolygon'];
 
-const ContextMenu = (props, context) => {
+const ContextMenu = props => {
     const {
         feature,
         layerId,
@@ -64,7 +64,9 @@ const ContextMenu = (props, context) => {
         theme,
     } = props;
 
-    const isAdmin = context.d2.currentUser.authorities.has('F_GIS_ADMIN');
+    // const isAdmin = context.d2.currentUser.authorities.has('F_GIS_ADMIN');
+    const isAdmin = false; // https://jira.dhis2.org/browse/TECH-482
+
     const iconColor = theme.colors.greyBlack;
     const iconDisabledColor = theme.colors.greyLight;
     let isPoint;
@@ -126,7 +128,6 @@ const ContextMenu = (props, context) => {
                     />
                 </MenuItem>
             )}
-
             {layerType !== 'facility' && feature && (
                 <MenuItem
                     disabled={!attr.hasCoordinatesDown}
@@ -157,7 +158,6 @@ const ContextMenu = (props, context) => {
                     />
                 </MenuItem>
             )}
-
             {feature && (
                 <MenuItem
                     onClick={() => onShowInformation(attr)}
@@ -173,7 +173,6 @@ const ContextMenu = (props, context) => {
                     />
                 </MenuItem>
             )}
-
             {coordinates && (
                 <MenuItem
                     onClick={() => showCoordinate(coordinates)}
@@ -189,8 +188,7 @@ const ContextMenu = (props, context) => {
                     />
                 </MenuItem>
             )}
-
-            {/*isAdmin && isPoint && (
+            {isAdmin && isPoint && (
                 <MenuItem
                     onClick={() =>
                         onSwapCoordinate(
@@ -210,9 +208,8 @@ const ContextMenu = (props, context) => {
                         disableTypography={true}
                     />
                 </MenuItem>
-            )*/}
-
-            {/*isAdmin && isPoint && (
+            )}
+            {isAdmin && isPoint && (
                 <MenuItem
                     onClick={() => onRelocateStart(layerId, feature)}
                     className={classes.menuItem}
@@ -226,8 +223,7 @@ const ContextMenu = (props, context) => {
                         disableTypography={true}
                     />
                 </MenuItem>
-            )*/}
-
+            )}
             {earthEngineLayers.map(layer => (
                 <MenuItem
                     key={layer.id}


### PR DESCRIPTION
This PR will remove the "Swap longitude/latitude" and "Relocate" options in the right-click context menu for point facilities. This is blocked by https://jira.dhis2.org/browse/TECH-482 and won't be fixed before 2.35.1 is released. 

The removal will be temporarily if the backend support is added again. 

JIRA: https://jira.dhis2.org/browse/DHIS2-9957

After this PR: 
<img width="309" alt="Screenshot 2020-12-03 at 10 55 06" src="https://user-images.githubusercontent.com/548708/100996666-9ef2b600-3559-11eb-98bd-2195fbcd20af.png">

Before this PR: 
<img width="267" alt="Screenshot 2020-12-03 at 10 56 15" src="https://user-images.githubusercontent.com/548708/100996646-98643e80-3559-11eb-84bb-cd01b2ef904d.png">
