### PR TITLE
feat: configurable map controls (DHIS2-10125)

### DIFF
--- a/public/plugin.html
+++ b/public/plugin.html
@@ -58,7 +58,7 @@
         if (mapId) {
             mapPlugin.load({
                 id: mapId,
-                el: 'map',
+                el: 'map'
             });
             picker.style.display = 'none';
             mapContainer.style.display = 'block';

--- a/public/plugin.html
+++ b/public/plugin.html
@@ -59,10 +59,6 @@
             mapPlugin.load({
                 id: mapId,
                 el: 'map',
-                // controls: [{
-                //     type: 'scale',
-                //     imperial: false,
-                // }],
             });
             picker.style.display = 'none';
             mapContainer.style.display = 'block';

--- a/public/plugin.html
+++ b/public/plugin.html
@@ -58,7 +58,11 @@
         if (mapId) {
             mapPlugin.load({
                 id: mapId,
-                el: 'map'
+                el: 'map',
+                // controls: [{
+                //     type: 'scale',
+                //     imperial: false,
+                // }],
             });
             picker.style.display = 'none';
             mapContainer.style.display = 'block';

--- a/src/components/map/MapView.js
+++ b/src/components/map/MapView.js
@@ -3,11 +3,7 @@ import PropTypes from 'prop-types';
 import Map from './Map';
 import SplitView from './SplitView';
 import { getSplitViewLayer } from '../../util/helpers';
-import {
-    mapControls,
-    splitViewControls,
-    pluginControls,
-} from '../../constants/mapControls';
+import { getMapControls } from '../../util/mapControls';
 
 // Shared component between app and plugin
 const MapView = props => {
@@ -15,6 +11,7 @@ const MapView = props => {
         isPlugin,
         basemap,
         layers,
+        controls,
         bounds,
         coordinatePopup,
         closeCoordinatePopup,
@@ -24,22 +21,17 @@ const MapView = props => {
     } = props;
 
     const splitViewLayer = getSplitViewLayer(layers);
+    const isSplitView = !!splitViewLayer;
+    const mapControls = getMapControls(isPlugin, isSplitView, controls);
 
     return (
         <Fragment>
-            {splitViewLayer ? (
+            {isSplitView ? (
                 <SplitView
                     isPlugin={isPlugin}
                     basemap={basemap}
                     layer={splitViewLayer}
-                    controls={
-                        isPlugin
-                            ? pluginControls.map(c => ({
-                                  ...c,
-                                  isSplitView: true,
-                              }))
-                            : splitViewControls
-                    }
+                    controls={mapControls}
                     openContextMenu={openContextMenu}
                     resizeCount={resizeCount}
                 />
@@ -49,7 +41,7 @@ const MapView = props => {
                     basemap={basemap}
                     layers={[...layers].reverse()}
                     bounds={bounds}
-                    controls={isPlugin ? pluginControls : mapControls}
+                    controls={mapControls}
                     coordinatePopup={coordinatePopup}
                     closeCoordinatePopup={closeCoordinatePopup}
                     openContextMenu={openContextMenu}
@@ -65,6 +57,7 @@ MapView.propTypes = {
     isPlugin: PropTypes.bool,
     basemap: PropTypes.object,
     layers: PropTypes.array,
+    controls: PropTypes.array,
     bounds: PropTypes.array,
     coordinatePopup: PropTypes.array,
     closeCoordinatePopup: PropTypes.func,

--- a/src/components/plugin/Plugin.js
+++ b/src/components/plugin/Plugin.js
@@ -20,6 +20,7 @@ class Plugin extends Component {
         name: PropTypes.string,
         basemap: PropTypes.object,
         mapViews: PropTypes.array,
+        controls: PropTypes.array,
     };
 
     static defaultProps = {
@@ -37,7 +38,7 @@ class Plugin extends Component {
     }
 
     render() {
-        const { name, basemap, hideTitle } = this.props;
+        const { name, basemap, hideTitle, controls } = this.props;
         const {
             position,
             offset,
@@ -57,6 +58,7 @@ class Plugin extends Component {
                     isPlugin={true}
                     basemap={basemap}
                     layers={mapViews}
+                    controls={controls}
                     bounds={defaultBounds}
                     openContextMenu={this.onOpenContextMenu}
                     onCloseContextMenu={this.onCloseContextMenu}

--- a/src/components/plugin/styles/MapName.module.css
+++ b/src/components/plugin/styles/MapName.module.css
@@ -6,7 +6,7 @@
     top: var(--spacers-dp8);
     left: 50px;
     right: 50px;
-    z-index: 998px;
+    z-index: 998;
 }
 
 .name {

--- a/src/components/plugin/styles/Plugin.module.css
+++ b/src/components/plugin/styles/Plugin.module.css
@@ -11,3 +11,15 @@
     right: auto;
     max-height: calc(100% - 20px);
 }
+
+/* Scrollbar width */
+::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+}
+
+/* Scrollbar handle */
+::-webkit-scrollbar-thumb {
+    background: #cbcdcf;
+    border-radius: 3px;
+}

--- a/src/components/plugin/styles/Plugin.module.css
+++ b/src/components/plugin/styles/Plugin.module.css
@@ -4,3 +4,9 @@
     width: 100%;
     font-family: Roboto, Helvetica, Arial, sans-serif;
 }
+
+.plugin :global(.dhis2-map-legend) {
+    top: 10px;
+    left: 10px;
+    right: auto;
+}

--- a/src/components/plugin/styles/Plugin.module.css
+++ b/src/components/plugin/styles/Plugin.module.css
@@ -9,4 +9,5 @@
     top: 10px;
     left: 10px;
     right: auto;
+    max-height: calc(100% - 20px);
 }

--- a/src/constants/mapControls.js
+++ b/src/constants/mapControls.js
@@ -1,38 +1,18 @@
 export const mapControls = [
-    {
-        type: 'zoom',
-    },
-    {
-        type: 'fullscreen',
-    },
-    {
-        type: 'fitBounds',
-    },
-    {
-        type: 'scale',
-        imperial: false,
-    },
-    {
-        type: 'search',
-    },
-    {
-        type: 'measure',
-    },
+    { type: 'zoom' },
+    { type: 'fullscreen' },
+    { type: 'fitBounds' },
+    { type: 'scale', imperial: false },
+    { type: 'search' },
+    { type: 'measure' },
 ];
 
 export const splitViewControls = [
     { type: 'zoom' },
-    { type: 'fullscreen', isSplitView: true },
+    { type: 'fullscreen' },
     { type: 'fitBounds' },
     { type: 'search' },
     { type: 'attribution', prefix: false },
 ];
 
-export const pluginControls = [
-    {
-        type: 'zoom',
-    },
-    {
-        type: 'fullscreen',
-    },
-];
+export const pluginControls = [{ type: 'zoom' }];

--- a/src/util/mapControls.js
+++ b/src/util/mapControls.js
@@ -1,0 +1,23 @@
+import {
+    mapControls,
+    splitViewControls,
+    pluginControls,
+} from '../constants/mapControls';
+
+// Returns the map controls shown on a map
+export const getMapControls = (isPlugin, isSplitView, controls) => {
+    let ctrls;
+
+    if (isPlugin) {
+        ctrls = controls || pluginControls;
+    } else {
+        ctrls = controls || isSplitView ? splitViewControls : mapControls;
+    }
+
+    return isSplitView
+        ? ctrls.map(c => ({
+              ...c,
+              isSplitView,
+          }))
+        : ctrls;
+};


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10125

This PR makes the map plugin controls configureable. The default is to only show the zoom control:

![Screenshot 2020-12-10 at 14 20 38](https://user-images.githubusercontent.com/548708/101777560-edbcc480-3af2-11eb-9bbe-d68ea8f45a96.png)

The fullscreen control is removed from plugin maps by default. For dashboard maps fullscreen will be handled outside the plugin: https://jira.dhis2.org/browse/DHIS2-9879

For other uses of the plugin, the user can now add the map controls as they like: 

![Screenshot 2020-12-10 at 14 12 04](https://user-images.githubusercontent.com/548708/101777810-49874d80-3af3-11eb-9f94-a93c465eb3f5.png)

All map controls can be added, not only the fullscreen control. 

Code example:

```
mapPlugin.load({
  id: mapId,
  el: 'map',
  controls: [
    { type: 'zoom' },
    { type: 'fullscreen' },
    { type: 'fitBounds' },
    { type: 'scale', imperial: false },
    { type: 'search' },
    { type: 'measure' },
  ],
});
```

The legend control is moved to the left side as the number of controls on the right side is no longer constant: 

![Screenshot 2020-12-10 at 14 02 42](https://user-images.githubusercontent.com/548708/101777953-7a678280-3af3-11eb-82cb-2510f69dcc6b.png)

This also gives more space for the legend when opened: 

![Screenshot 2020-12-10 at 14 06 00](https://user-images.githubusercontent.com/548708/101778055-a08d2280-3af3-11eb-9450-d52d892288d5.png)

Before this PR: 

![Screenshot 2020-12-10 at 13 54 42](https://user-images.githubusercontent.com/548708/101778075-a84cc700-3af3-11eb-8a79-b9dcd91d304c.png)
