### PR TITLE
fix: allow mouse scroll in fullscreen (DHIS2-10252)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@dhis2/d2-ui-interpretations": "^7.1.3",
         "@dhis2/d2-ui-org-unit-dialog": "^7.1.3",
         "@dhis2/d2-ui-org-unit-tree": "^7.1.3",
-        "@dhis2/maps-gl": "^1.3.5",
+        "@dhis2/maps-gl": "^1.3.6",
         "@dhis2/ui": "^5.7.8",
         "@material-ui/icons": "^4.9.1",
         "abortcontroller-polyfill": "^1.5.0",

--- a/public/plugin.html
+++ b/public/plugin.html
@@ -62,12 +62,6 @@
             });
             picker.style.display = 'none';
             mapContainer.style.display = 'block';
-
-
-            setTimeout(function() { 
-                console.log('scrollable?');
-                mapPlugin.resize('map', true);
-             }, 6000);
         }
 
         function onReloadBtnPress(e) {

--- a/public/plugin.html
+++ b/public/plugin.html
@@ -62,6 +62,12 @@
             });
             picker.style.display = 'none';
             mapContainer.style.display = 'block';
+
+
+            setTimeout(function() { 
+                console.log('scrollable?');
+                mapPlugin.resize('map', true);
+             }, 6000);
         }
 
         function onReloadBtnPress(e) {

--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -27,6 +27,7 @@ const layerType = {
 class Map extends Component {
     static propTypes = {
         isPlugin: PropTypes.bool,
+        isFullscreen: PropTypes.bool,
         basemap: PropTypes.object,
         layers: PropTypes.array,
         controls: PropTypes.array,
@@ -43,6 +44,7 @@ class Map extends Component {
 
     static defaultProps = {
         isPlugin: false,
+        isFullscreen: false,
     };
 
     static childContextTypes = {
@@ -78,13 +80,21 @@ class Map extends Component {
     }
 
     componentDidMount() {
-        const { controls, bounds, latitude, longitude, zoom } = this.props;
+        const {
+            controls,
+            bounds,
+            latitude,
+            longitude,
+            zoom,
+            isFullscreen,
+        } = this.props;
         const { map } = this;
 
         // Append map container to DOM
         this.node.appendChild(map.getContainer());
 
         map.resize();
+        this.onFullScreenChange({ isFullscreen });
 
         // Add map controls
         if (controls) {
@@ -107,8 +117,14 @@ class Map extends Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (this.props.resizeCount !== prevProps.resizeCount) {
+        const { resizeCount, isFullscreen } = this.props;
+
+        if (resizeCount !== prevProps.resizeCount) {
             this.map.resize();
+        }
+
+        if (isFullscreen !== prevProps.isFullscreen) {
+            this.onFullScreenChange({ isFullscreen });
         }
     }
 

--- a/src/components/map/MapView.js
+++ b/src/components/map/MapView.js
@@ -9,6 +9,7 @@ import { getMapControls } from '../../util/mapControls';
 const MapView = props => {
     const {
         isPlugin,
+        isFullscreen,
         basemap,
         layers,
         controls,
@@ -29,6 +30,7 @@ const MapView = props => {
             {isSplitView ? (
                 <SplitView
                     isPlugin={isPlugin}
+                    isFullscreen={isFullscreen}
                     basemap={basemap}
                     layer={splitViewLayer}
                     controls={mapControls}
@@ -38,6 +40,7 @@ const MapView = props => {
             ) : (
                 <Map
                     isPlugin={isPlugin}
+                    isFullscreen={isFullscreen}
                     basemap={basemap}
                     layers={[...layers].reverse()}
                     bounds={bounds}
@@ -55,6 +58,7 @@ const MapView = props => {
 
 MapView.propTypes = {
     isPlugin: PropTypes.bool,
+    isFullscreen: PropTypes.bool,
     basemap: PropTypes.object,
     layers: PropTypes.array,
     controls: PropTypes.array,

--- a/src/components/map/PeriodName.js
+++ b/src/components/map/PeriodName.js
@@ -7,7 +7,7 @@ const PeriodName = ({ period, isTimeline }) => (
         className={`dhis2-map-period ${styles.periodName}`}
         style={isTimeline ? { bottom: 86 } : null}
     >
-        <div className={styles.periodName}>{period}</div>
+        <div className={styles.period}>{period}</div>
     </div>
 );
 

--- a/src/components/map/SplitView.js
+++ b/src/components/map/SplitView.js
@@ -10,14 +10,15 @@ import styles from './styles/SplitView.module.css';
 class SplitView extends PureComponent {
     static propTypes = {
         isPlugin: PropTypes.bool,
+        isFullscreen: PropTypes.bool,
         layer: PropTypes.object.isRequired,
         basemap: PropTypes.object,
         controls: PropTypes.array,
         openContextMenu: PropTypes.func.isRequired,
     };
 
-    // TODO: Remove
     static defaultProps = {
+        isFullscreen: false,
         openContextMenu: () => {},
     };
 
@@ -28,18 +29,22 @@ class SplitView extends PureComponent {
 
     // Add map controls to split view container
     componentDidUpdate(prevProps, prevState) {
-        const { state, node } = this;
+        const { isFullscreen } = this.props;
+        const { controls } = this.state;
 
-        if (state.controls !== prevState.controls) {
-            Object.values(state.controls).forEach(control =>
-                node.append(control)
+        if (isFullscreen !== prevProps.isFullscreen) {
+            this.onFullScreenChange({ isFullscreen });
+        }
+
+        if (controls !== prevState.controls) {
+            Object.values(controls).forEach(control =>
+                this.node.append(control)
             );
         }
     }
 
     render() {
         const { isPlugin, basemap, layer, openContextMenu } = this.props;
-
         const { isFullscreen } = this.state;
 
         const { id, periods = [] } = layer;

--- a/src/components/plugin/Plugin.js
+++ b/src/components/plugin/Plugin.js
@@ -46,6 +46,7 @@ class Plugin extends Component {
             mapViews,
             resizeCount,
             isSplitView,
+            isFullscreen,
             container,
         } = this.state;
 
@@ -56,6 +57,7 @@ class Plugin extends Component {
                 {!hideTitle && <MapName name={name} />}
                 <MapView
                     isPlugin={true}
+                    isFullscreen={isFullscreen}
                     basemap={basemap}
                     layers={mapViews}
                     controls={controls}
@@ -78,9 +80,12 @@ class Plugin extends Component {
     }
 
     // Call this method when plugin container is resized
-    resize() {
+    resize(isFullscreen = false) {
         // Will trigger a redraw of the MapView component
-        this.setState(state => ({ resizeCount: state.resizeCount + 1 }));
+        this.setState(state => ({
+            resizeCount: state.resizeCount + 1,
+            isFullscreen,
+        }));
     }
 
     onOpenContextMenu = state => this.setState(state);

--- a/src/map.js
+++ b/src/map.js
@@ -217,7 +217,7 @@ const PluginContainer = () => {
     }
 
     // Should be called if the map container is resized
-    function resize(el, isFullscreen) {
+    function resize(el, isFullscreen = false) {
         const mapComponent = _components[el];
 
         if (mapComponent && mapComponent.current) {

--- a/src/map.js
+++ b/src/map.js
@@ -166,7 +166,7 @@ const PluginContainer = () => {
             if (domEl) {
                 const ref = createRef();
 
-                render(<Plugin innerRef={ref} {...config} />, domEl);
+                render(<Plugin ref={ref} {...config} />, domEl);
 
                 if (config.onReady) {
                     config.onReady();
@@ -217,11 +217,11 @@ const PluginContainer = () => {
     }
 
     // Should be called if the map container is resized
-    function resize(el) {
+    function resize(el, isFullscreen) {
         const mapComponent = _components[el];
 
         if (mapComponent && mapComponent.current) {
-            mapComponent.current.resize();
+            mapComponent.current.resize(isFullscreen);
             return true;
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,10 +388,10 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@^1.3.5":
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.3.5.tgz#1df0555bfa1019c671acf852733b5d8da3091bf4"
-  integrity sha512-sogjIR2JLGisDf6cIY2wAYx2nGNwS690RpkmGvzrGPIUGN3BK2sIag+CFe6OmonDX+kEdfY3HUnnK7168W0MkA==
+"@dhis2/maps-gl@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.3.6.tgz#7442bc96cb361d110ecdd6c8812cbcdd8fc8bcc7"
+  integrity sha512-7+DmkxCpztfvG38/BA4FZI5bSlIcA85m21BL/9BT1Eso2Id1hCq8gi3p8XloxJc1a/2gmIkpumYVrA1Dam5e/Q==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.0.1"
@@ -403,6 +403,7 @@
     fetch-jsonp "^1.1.3"
     lodash.throttle "^4.1.1"
     mapbox-gl "^1.11.0"
+    mapbox-gl-multitouch "^1.0.3"
     mapboxgl-spiderifier "^1.0.9"
     polylabel "^1.1.0"
     suggestions "^1.7.0"
@@ -9184,6 +9185,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+mapbox-gl-multitouch@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/mapbox-gl-multitouch/-/mapbox-gl-multitouch-1.0.3.tgz#db8bbe86a15d8398e3315d97305c9edde3f0f0d7"
+  integrity sha512-lpTFL2Sp7hK867mkMOZe2DvdS5eEHxWfMc7aSWCRDMgSq9IjPubsiix3FPs+IqcbkYmR+IUrzvH9RWBOXVs2cg==
 
 mapbox-gl@^1.11.0:
   version "1.12.0"


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10252

This PR fixes: 

1. Switch to multitouch for map panning to avoid "scroll trap" on touch screens. This was fixed in maps-gl: https://github.com/dhis2/maps-gl/pull/236
2. Allow map to be resized outside the plugin component. The plugin resize method now has an additional argument: isFullscreen - mapPlugin.resize(el, **isFullscreen**) - if true mouse scroll zoom will be enabled. This is disabled by default to avoid "scroll trap" when scrolling a long dashboard. The old fullscreen handling code is kept to also support the built-in fullscreen control. 
3. Fixed a styling issue for the period labels in split view maps (occured in the MUI-UI transition):

Before:
<img width="1300" alt="Screenshot 2021-01-19 at 11 49 35" src="https://user-images.githubusercontent.com/548708/105025823-220a9580-5a4e-11eb-8e03-2a16fbf1f3ad.png">
  
After: 
<img width="1300" alt="Screenshot 2021-01-19 at 11 50 38" src="https://user-images.githubusercontent.com/548708/105025850-2cc52a80-5a4e-11eb-8d66-14e6bed8647e.png">

I've tested that this worked locally - can be tested fully when this fix is included in the maps plugin on the dashboard. 