### PR TITLE
fix: unify translations of analytical objects 

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -104,7 +104,7 @@ const PluginContainer = () => {
                 })
             );
         } else {
-            loadLayers(translateConfig(config));
+            translateConfig(config).then(loadLayers);
         }
     }
 

--- a/src/util/analyticalObject.js
+++ b/src/util/analyticalObject.js
@@ -78,6 +78,7 @@ export const getThematicLayerFromAnalyticalObject = async (
         aggregationType,
         legendSet,
         isVisible,
+        opacity: 0.9,
     };
 };
 

--- a/src/util/favorites.js
+++ b/src/util/favorites.js
@@ -2,6 +2,7 @@ import i18n from '@dhis2/d2-i18n';
 import { isNil, omitBy, pick, isObject, omit } from 'lodash/fp';
 import { generateUid } from 'd2/uid';
 import { upgradeGisAppLayers } from './requests';
+import { getThematicLayerFromAnalyticalObject } from './analyticalObject';
 
 // TODO: get latitude, longitude, zoom from map + basemap: 'none'
 const validMapProperties = [
@@ -213,21 +214,23 @@ const setExternalBasemap = config => {
 };
 
 // Translate from chart/pivot config to map config, or from the old GIS app format
-export const translateConfig = config => {
+export const translateConfig = async config => {
     // If chart/pivot config
     if (!config.mapViews) {
         const { el, name } = config;
-        const dimensions = [
-            ...(config.columns || []),
-            ...(config.rows || []),
-            ...(config.filters || []),
-        ];
-        const columns = [dimensions.find(dim => dim.dimension === 'dx')]; // Data item
-        const rows = [dimensions.find(dim => dim.dimension === 'ou')]; // Org units
-        const filters = [dimensions.find(dim => dim.dimension === 'pe')]; // Period
 
-        if (!columns.length || !rows.length || !filters.length) {
-            return {
+        return getThematicLayerFromAnalyticalObject(config)
+            .then(mapView => ({
+                el,
+                name,
+                mapViews: [
+                    {
+                        id: generateUid(),
+                        ...mapView,
+                    },
+                ],
+            }))
+            .catch(() => ({
                 el,
                 name,
                 alerts: [
@@ -238,23 +241,7 @@ export const translateConfig = config => {
                         )}`,
                     },
                 ],
-            };
-        }
-
-        return {
-            el,
-            name,
-            mapViews: [
-                {
-                    layer: 'thematic',
-                    id: generateUid(),
-                    name,
-                    columns,
-                    rows,
-                    filters,
-                },
-            ],
-        };
+            }));
     }
 
     const newConfig = setExternalBasemap(config);

--- a/src/util/favorites.js
+++ b/src/util/favorites.js
@@ -1,4 +1,3 @@
-import i18n from '@dhis2/d2-i18n';
 import { isNil, omitBy, pick, isObject, omit } from 'lodash/fp';
 import { generateUid } from 'd2/uid';
 import { upgradeGisAppLayers } from './requests';
@@ -219,29 +218,16 @@ export const translateConfig = async config => {
     if (!config.mapViews) {
         const { el, name } = config;
 
-        return getThematicLayerFromAnalyticalObject(config)
-            .then(mapView => ({
-                el,
-                name,
-                mapViews: [
-                    {
-                        id: generateUid(),
-                        ...mapView,
-                    },
-                ],
-            }))
-            .catch(() => ({
-                el,
-                name,
-                alerts: [
-                    {
-                        critical: true,
-                        message: `${name}: ${i18n.t(
-                            'There was a problem creating a map from the imported data.'
-                        )}`,
-                    },
-                ],
-            }));
+        return getThematicLayerFromAnalyticalObject(config).then(mapView => ({
+            el,
+            name,
+            mapViews: [
+                {
+                    id: generateUid(),
+                    ...mapView,
+                },
+            ],
+        }));
     }
 
     const newConfig = setExternalBasemap(config);


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-9602

The maps app had two different ways of translating analytical objects (ao) on the dashboard, and when switching from DV to Maps. This PR will unify the way the ao is translated, and use a predefined legend set if associated with the indicator/data element. 

The PR also sets a default layer opacity for the thematic layer created.

Before this PR the dashboard map had an automatic legend while the same ao gets a predefined legend in the app: 

<img width="946" alt="Screenshot 2021-01-29 at 13 21 00" src="https://user-images.githubusercontent.com/548708/106285487-d96c8c80-6244-11eb-9ee6-3ed57e6757b1.png">
<img width="1105" alt="Screenshot 2021-01-29 at 13 24 09" src="https://user-images.githubusercontent.com/548708/106285492-dbcee680-6244-11eb-8df3-60128e28db20.png">

After this PR the plugin/dashboard map will also have predefined legend: 

<img width="508" alt="Screenshot 2021-01-29 at 14 56 56" src="https://user-images.githubusercontent.com/548708/106285534-e7baa880-6244-11eb-9a49-afb00453a0df.png">

