### PR TITLE
fix: allow map scroll zoom in app

### DIFF
--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -86,6 +86,7 @@ class Map extends Component {
             latitude,
             longitude,
             zoom,
+            isPlugin,
             isFullscreen,
         } = this.props;
         const { map } = this;
@@ -94,7 +95,6 @@ class Map extends Component {
         this.node.appendChild(map.getContainer());
 
         map.resize();
-        this.onFullScreenChange({ isFullscreen });
 
         // Add map controls
         if (controls) {
@@ -114,16 +114,20 @@ class Map extends Component {
         } else {
             map.fitWorld();
         }
+
+        if (isPlugin) {
+            this.onFullScreenChange({ isFullscreen });
+        }
     }
 
     componentDidUpdate(prevProps) {
-        const { resizeCount, isFullscreen } = this.props;
+        const { resizeCount, isFullscreen, isPlugin } = this.props;
 
         if (resizeCount !== prevProps.resizeCount) {
             this.map.resize();
         }
 
-        if (isFullscreen !== prevProps.isFullscreen) {
+        if (isPlugin && isFullscreen !== prevProps.isFullscreen) {
             this.onFullScreenChange({ isFullscreen });
         }
     }

--- a/src/components/map/MapItem.js
+++ b/src/components/map/MapItem.js
@@ -55,13 +55,13 @@ class MapItem extends PureComponent {
     }
 
     componentDidUpdate(prevProps) {
-        const { count, isFullscreen } = this.props;
+        const { count, isFullscreen, isPlugin } = this.props;
 
         if (count !== prevProps.count) {
             this.fitLayerBounds();
         }
 
-        if (isFullscreen !== prevProps.isFullscreen) {
+        if (isPlugin && isFullscreen !== prevProps.isFullscreen) {
             this.map.toggleScrollZoom(isFullscreen);
         }
 


### PR DESCRIPTION
Fixes an issue caused by previous PR: https://github.com/dhis2/maps-app/pull/1420

The map scroll zoom should always be available in the app, only in fullscreen for the plugin. 