### PR TITLE
fix: various style fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@dhis2/d2-ui-interpretations": "^7.1.4",
         "@dhis2/d2-ui-org-unit-dialog": "^7.1.4",
         "@dhis2/d2-ui-org-unit-tree": "^7.1.4",
-        "@dhis2/maps-gl": "^1.7.0",
+        "@dhis2/maps-gl": "^1.7.1",
         "@dhis2/ui": "^6.4.0",
         "abortcontroller-polyfill": "^1.5.0",
         "array-move": "^3.0.1",

--- a/src/components/edit/styles/LayerDialog.module.css
+++ b/src/components/edit/styles/LayerDialog.module.css
@@ -1,6 +1,6 @@
 .select {
     width: auto;
-    max-width: 300px;
+    max-width: 340px;
 }
 
 .tabContent {

--- a/src/components/edit/thematic/styles/NoDataColor.module.css
+++ b/src/components/edit/thematic/styles/NoDataColor.module.css
@@ -1,4 +1,5 @@
 .checkbox {
+    min-width: 160px;
     margin-right: 40px;
     height: 60px;
 }

--- a/src/components/map/layers/earthEngine/EarthEnginePopup.js
+++ b/src/components/map/layers/earthEngine/EarthEnginePopup.js
@@ -53,7 +53,8 @@ const EarthEnginePopup = props => {
         } else {
             header = (
                 <caption>
-                    {title} {period}
+                    {title}
+                    {period && <div>{period}</div>}
                     {groups && (
                         <div className={styles.group}>
                             {groups.length > 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,10 +391,10 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.7.0.tgz#2e680c2f31bab258b663cf107fe01ee45583205f"
-  integrity sha512-LG3RzJTIBZt9WR7D8A5BHbqsCCnh80c4wtlagcsq0P17vmOUfmZsFerYQfBOqmfW1Oy3AoWbzI617HUOKnbAWw==
+"@dhis2/maps-gl@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.7.1.tgz#7998eae27bf29261a449a5565cb9668f0202c30e"
+  integrity sha512-KybOFQQnm8SfrpvxN9is4KMCmocITUsKqKXIJtQLSTg/HhxUaRRPs4D28ToKIu3Tgcp1ySSabswq5La1WzI5bg==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.3.0"


### PR DESCRIPTION
This PR contains the following style fixes:
- Wider select fields in layer dialogs.
- Wider checkbox field for no data selection
- Show period in popup on separate line
- Remove focus outline for search popups

After: 
<img width="445" alt="Screenshot 2021-02-25 at 11 30 49" src="https://user-images.githubusercontent.com/548708/109140872-5bc17100-775d-11eb-8d9d-9144ec61557b.png">

Before: 
<img width="410" alt="Screenshot 2021-02-25 at 11 28 20" src="https://user-images.githubusercontent.com/548708/109140897-624fe880-775d-11eb-81cf-e346c9f38b12.png">

After: 
<img width="308" alt="Screenshot 2021-02-25 at 11 42 04" src="https://user-images.githubusercontent.com/548708/109142188-d8a11a80-775e-11eb-8278-fd25a5e33e11.png">

Before: 
<img width="303" alt="Screenshot 2021-02-25 at 11 38 48" src="https://user-images.githubusercontent.com/548708/109142199-ddfe6500-775e-11eb-894e-b191528c2ebf.png">

After: 
<img width="224" alt="Screenshot 2021-02-25 at 12 56 12" src="https://user-images.githubusercontent.com/548708/109150463-3470a100-7769-11eb-935f-dc65e223f1b4.png">

Before: 
<img width="295" alt="Screenshot 2021-02-25 at 12 48 50" src="https://user-images.githubusercontent.com/548708/109150484-3c304580-7769-11eb-9abd-8d485bcd28bd.png">

After: 
<img width="291" alt="Screenshot 2021-02-25 at 13 25 57" src="https://user-images.githubusercontent.com/548708/109153368-1f960c80-776d-11eb-8bac-4d932f58c003.png">

Before: 
<img width="304" alt="Screenshot 2021-02-25 at 13 03 33" src="https://user-images.githubusercontent.com/548708/109153392-24f35700-776d-11eb-8345-644acd7ad167.png">

