### PR TITLE
fix: keep palette and support decimals for EE layers (DHIS2-10582)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-02-22T16:51:45.512Z\n"
-"PO-Revision-Date: 2021-02-22T16:51:45.512Z\n"
+"POT-Creation-Date: 2021-03-01T10:00:46.533Z\n"
+"PO-Revision-Date: 2021-03-01T10:00:46.533Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -227,6 +227,9 @@ msgid "Available periods are set by the source data"
 msgstr ""
 
 msgid "Loading periods"
+msgstr ""
+
+msgid "Unit: {{unit}}"
 msgstr ""
 
 msgid "Min"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-03-01T10:00:46.533Z\n"
-"PO-Revision-Date: 2021-03-01T10:00:46.533Z\n"
+"POT-Creation-Date: 2021-03-01T10:04:26.422Z\n"
+"PO-Revision-Date: 2021-03-01T10:04:26.422Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -227,9 +227,6 @@ msgid "Available periods are set by the source data"
 msgstr ""
 
 msgid "Loading periods"
-msgstr ""
-
-msgid "Unit: {{unit}}"
 msgstr ""
 
 msgid "Min"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-03-04T08:35:18.741Z\n"
-"PO-Revision-Date: 2021-03-04T08:35:18.741Z\n"
+"POT-Creation-Date: 2021-03-04T09:19:28.040Z\n"
+"PO-Revision-Date: 2021-03-04T09:19:28.040Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -235,7 +235,7 @@ msgstr ""
 msgid "Max value is required"
 msgstr ""
 
-msgid "Max should be higher than min"
+msgid "Max should be greater than min"
 msgstr ""
 
 msgid "Valid steps are {{minSteps}} to {{maxSteps}}"
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Elevation"
 msgstr ""
 
-msgid "metres"
+msgid "meters"
 msgstr ""
 
 msgid "Elevation above sea-level."

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-03-01T10:04:26.422Z\n"
-"PO-Revision-Date: 2021-03-01T10:04:26.422Z\n"
+"POT-Creation-Date: 2021-03-04T08:35:18.741Z\n"
+"PO-Revision-Date: 2021-03-04T08:35:18.741Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -227,6 +227,18 @@ msgid "Available periods are set by the source data"
 msgstr ""
 
 msgid "Loading periods"
+msgstr ""
+
+msgid "Min value is required"
+msgstr ""
+
+msgid "Max value is required"
+msgstr ""
+
+msgid "Max should be higher than min"
+msgstr ""
+
+msgid "Valid steps are {{minSteps}} to {{maxSteps}}"
 msgstr ""
 
 msgid "Min"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "@dhis2/d2-ui-org-unit-dialog": "^7.1.4",
         "@dhis2/d2-ui-org-unit-tree": "^7.1.4",
         "@dhis2/maps-gl": "^1.7.1",
-        "@dhis2/ui": "^6.4.0",
+        "@dhis2/ui": "^6.5.0",
         "abortcontroller-polyfill": "^1.5.0",
         "array-move": "^3.0.1",
         "babel-preset-stage-0": "^6.24.1",

--- a/src/actions/layerEdit.js
+++ b/src/actions/layerEdit.js
@@ -243,11 +243,9 @@ export const setOrgUnitMode = mode => ({
 });
 
 // Set layer params (EE)
-export const setParams = (min, max, palette) => ({
+export const setParams = params => ({
     type: types.LAYER_EDIT_PARAMS_SET,
-    min,
-    max,
-    palette,
+    payload: params,
 });
 
 // Set collection filter (EE)

--- a/src/components/core/NumberField.js
+++ b/src/components/core/NumberField.js
@@ -4,7 +4,6 @@ import { InputField } from '@dhis2/ui';
 import cx from 'classnames';
 import styles from './styles/InputField.module.css';
 
-// Adds support for min/max values for @dhis2/ui InputField
 const NumberField = ({
     label,
     value,
@@ -24,7 +23,7 @@ const NumberField = ({
             max={String(max)}
             step={String(step)}
             label={label}
-            value={String(value)}
+            value={Number.isNaN(value) ? '' : String(value)}
             disabled={disabled}
             onChange={({ value }) => onChange(value)}
         />

--- a/src/components/core/NumberField.js
+++ b/src/components/core/NumberField.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { InputField } from '@dhis2/ui';
 import cx from 'classnames';
@@ -10,42 +10,33 @@ const NumberField = ({
     value,
     min,
     max,
+    step = 1,
     dense = true,
     disabled,
     onChange,
     className,
-}) => {
-    const onNumberChange = useCallback(
-        ({ value }) => {
-            if (
-                (min === undefined || value >= min) &&
-                (max === undefined || value <= max)
-            ) {
-                onChange(value);
-            }
-        },
-        [min, max]
-    );
-
-    return (
-        <div className={cx(styles.inputField, className)}>
-            <InputField
-                dense={dense}
-                type="number"
-                label={label}
-                value={String(value)}
-                disabled={disabled}
-                onChange={onNumberChange}
-            />
-        </div>
-    );
-};
+}) => (
+    <div className={cx(styles.inputField, className)}>
+        <InputField
+            dense={dense}
+            type="number"
+            min={String(min)}
+            max={String(max)}
+            step={String(step)}
+            label={label}
+            value={String(value)}
+            disabled={disabled}
+            onChange={({ value }) => onChange(value)}
+        />
+    </div>
+);
 
 NumberField.propTypes = {
     label: PropTypes.string.isRequired,
     value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     min: PropTypes.number,
     max: PropTypes.number,
+    step: PropTypes.number,
     dense: PropTypes.bool,
     disabled: PropTypes.bool,
     onChange: PropTypes.func.isRequired,

--- a/src/components/edit/earthEngine/StyleSelect.js
+++ b/src/components/edit/earthEngine/StyleSelect.js
@@ -48,7 +48,9 @@ const StyleSelect = ({ unit, params, setParams }) => {
     return (
         <div className={styles.flexColumnFlow}>
             <div className={styles.flexColumn}>
-                <p>{i18n.t('Unit: {{ unit }}', { unit })}</p>
+                <p>
+                    {i18n.t('Unit')}: {unit}
+                </p>
                 <div key="minmax" className={styles.flexInnerColumnFlow}>
                     <NumberField
                         label={i18n.t('Min')}

--- a/src/components/edit/earthEngine/StyleSelect.js
+++ b/src/components/edit/earthEngine/StyleSelect.js
@@ -14,13 +14,13 @@ import styles from '../styles/LayerDialog.module.css';
 const minSteps = 3;
 const maxSteps = 9;
 
-const isValidParams = ({ min, max }) =>
+const paramsAreValid = ({ min, max }) =>
     !Number.isNaN(min) && !Number.isNaN(max) && max > min;
 
 const StyleSelect = ({ unit, params, setParams }) => {
     const { min, max, palette } = params;
     const [steps, setSteps] = useState(palette.split(',').length);
-    const legend = isValidParams(params) && createLegend(params);
+    const legend = paramsAreValid(params) && createLegend(params);
 
     const onStepsChange = useCallback(
         steps => {
@@ -45,7 +45,7 @@ const StyleSelect = ({ unit, params, setParams }) => {
     } else if (Number.isNaN(max)) {
         warningText = i18n.t('Max value is required');
     } else if (max <= min) {
-        warningText = i18n.t('Max should be higher than min');
+        warningText = i18n.t('Max should be greater than min');
     } else if (steps < minSteps || steps > maxSteps) {
         warningText = i18n.t('Valid steps are {{minSteps}} to {{maxSteps}}', {
             minSteps,

--- a/src/components/edit/earthEngine/StyleSelect.js
+++ b/src/components/edit/earthEngine/StyleSelect.js
@@ -38,16 +38,16 @@ const StyleSelect = ({ unit, params, setParams }) => {
         [palette, setParams]
     );
 
-    let help;
+    let warningText;
 
     if (Number.isNaN(min)) {
-        help = i18n.t('Min value is required');
+        warningText = i18n.t('Min value is required');
     } else if (Number.isNaN(max)) {
-        help = i18n.t('Max value is required');
+        warningText = i18n.t('Max value is required');
     } else if (max <= min) {
-        help = i18n.t('Max should be higher than min');
+        warningText = i18n.t('Max should be higher than min');
     } else if (steps < minSteps || steps > maxSteps) {
-        help = i18n.t('Valid steps are {{minSteps}} to {{maxSteps}}', {
+        warningText = i18n.t('Valid steps are {{minSteps}} to {{maxSteps}}', {
             minSteps,
             maxSteps,
         });
@@ -78,7 +78,9 @@ const StyleSelect = ({ unit, params, setParams }) => {
                         onChange={onStepsChange}
                         className={styles.flexInnerColumn}
                     />
-                    {help && <div className={styles.eeError}>{help}</div>}
+                    {warningText && (
+                        <div className={styles.eeError}>{warningText}</div>
+                    )}
                     <div className={styles.scale}>
                         <ColorScaleSelect
                             palette={params.palette}

--- a/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbar.spec.js.snap
+++ b/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbar.spec.js.snap
@@ -28,9 +28,11 @@ exports[`LayerToolbar Should match toolbar snapshot WITH Edit button 1`] = `
     className="sliderContainer"
   >
     <Tooltip
+      closeDelay={400}
       content="Set layer opacity"
       dataTest="dhis2-uicore-tooltip"
       maxWidth={300}
+      openDelay={200}
       placement="top"
       tag="span"
     >
@@ -64,9 +66,11 @@ exports[`LayerToolbar Should match toolbar snapshot without Edit button 1`] = `
     className="sliderContainer"
   >
     <Tooltip
+      closeDelay={400}
       content="Set layer opacity"
       dataTest="dhis2-uicore-tooltip"
       maxWidth={300}
+      openDelay={200}
       placement="top"
       tag="span"
     >

--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -212,7 +212,7 @@ export const earthEngineLayers = () => [
         layer: EARTH_ENGINE_LAYER,
         datasetId: 'USGS/SRTMGL1_003',
         name: i18n.t('Elevation'),
-        unit: i18n.t('metres'),
+        unit: i18n.t('meters'),
         description: i18n.t('Elevation above sea-level.'),
         source: 'NASA / USGS / JPL-Caltech / Google Earth Engine',
         sourceUrl:

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -1,8 +1,10 @@
 import { getInstance as getD2 } from 'd2';
+import { precisionRound } from 'd3-format';
 import { getEarthEngineLayer } from '../constants/earthEngine';
 import { getPeriodFromFilter } from '../util/earthEngine';
 import { getOrgUnitsFromRows } from '../util/analytics';
 import { getDisplayProperty } from '../util/helpers';
+import { numberPrecision } from '../util/numbers';
 import { toGeoJson } from '../util/map';
 
 // Returns a promise
@@ -106,6 +108,8 @@ const earthEngineLoader = async config => {
 export const createLegend = ({ min, max, palette }) => {
     const colors = palette.split(',');
     const step = (max - min) / (colors.length - (min > 0 ? 2 : 1));
+    const precision = precisionRound(step, max);
+    const valueFormat = numberPrecision(precision);
 
     let from = min;
     let to = Math.round(min + step);
@@ -130,7 +134,7 @@ export const createLegend = ({ min, max, palette }) => {
         }
 
         from = to;
-        to = Math.round(min + step * (index + (min > 0 ? 1 : 2)));
+        to = valueFormat(min + step * (index + (min > 0 ? 1 : 2)));
 
         return item;
     });

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -112,7 +112,7 @@ export const createLegend = ({ min, max, palette }) => {
     const valueFormat = numberPrecision(precision);
 
     let from = min;
-    let to = Math.round(min + step);
+    let to = valueFormat(min + step);
 
     return colors.map((color, index) => {
         const item = { color };

--- a/src/reducers/layerEdit.js
+++ b/src/reducers/layerEdit.js
@@ -435,9 +435,8 @@ const layerEdit = (state = null, action) => {
             return {
                 ...state,
                 params: {
-                    min: action.min,
-                    max: action.max,
-                    palette: action.palette,
+                    ...state.params,
+                    ...action.payload,
                 },
             };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,17 +418,17 @@
   dependencies:
     prop-types "^15"
 
-"@dhis2/ui-constants@6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-6.4.0.tgz#45a8201dcab8b65318e59e42933346a0ce39edad"
-  integrity sha512-BbYp68eqiuYsmidvC/oovSXpmiIbM5iGhsT+s23dwk1vjvbyRecLqPMPjEUqr+mDO0UkFgRIN/9K4+lvBiWqEw==
+"@dhis2/ui-constants@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-constants/-/ui-constants-6.5.0.tgz#1066710d565417378248ee2d4e3a1e611088a7c3"
+  integrity sha512-9vvIABl3vSucPCWopObdOKRk4uYOsclnEMR2ZXHJVjUJ24CW3S0WV4sgqoIsSJRDPJbCfvYvYHa/scaELfP2Kg==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
 
-"@dhis2/ui-core@6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-6.4.0.tgz#f6c58301d0548429e55dc7577e254fb3f83b114e"
-  integrity sha512-4DPcMYFx3BebmCFuVhpI+Jr51QG8Or5sosaZg9pN+k1QiUp1uLlfCKwQ9FvNkhl+0gWY5T3/o9DWS3IROGA/cQ==
+"@dhis2/ui-core@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-6.5.0.tgz#ee4cd043c86a5823558b2ecc860062fbc14126b6"
+  integrity sha512-6tz+LncBLwV3/Oye87mP3Ady8GRsNBrJ+dcNVsSItmoG9rA1UEU51vYyU/W5Nb5C82kp+16y9g36jUl2qAI/eg==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
     "@popperjs/core" "^2.6.0"
@@ -436,41 +436,41 @@
     react-popper "^2.2.3"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2/ui-forms@6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-6.4.0.tgz#4fdb54614a7eaf30d74ea9df58b74cb8ee6dceb3"
-  integrity sha512-r/weFAdTERVQ+Qw7aXd/IIDw++OGxKc4FMSn4tMiMud0upu1f6mqWzMAjB9XMiv147CGbfyUc7kD6MKYxWnd6Q==
+"@dhis2/ui-forms@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-forms/-/ui-forms-6.5.0.tgz#c1f104a0209797ba4c315c1b6dbaa7df901b92d7"
+  integrity sha512-qvL/WV+WTYSfc6QKPyVAmc593J4PY/HI13wLDcmn5e6q65ON/D8VH7/pr0ByY03Hhv7Dk3KBizhCBb/8VC+zfg==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
     final-form "^4.20.1"
     react-final-form "^6.5.1"
 
-"@dhis2/ui-icons@6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-6.4.0.tgz#da406952d9cb7e137d6941963dd5fb8af8f69f42"
-  integrity sha512-7AetepD5oWjVBV3gH9Jgp93eFcTxHRAwq+yBoyhIakvfYDUtVctIAX/0WOy30um4KT43ntXBbk+ynzDSx+wd1A==
+"@dhis2/ui-icons@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-6.5.0.tgz#e75b64d1ae7ac717d792f64c3d1a0681bac7b04c"
+  integrity sha512-4/pOH6a2el9M2y8GWnXd9faQB9zpln+nHEcCWahY/O+gRSdaQpe3pLH18aKapGJygJt/Jp9lrCDjOop4klCXNw==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
 
-"@dhis2/ui-widgets@6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-6.4.0.tgz#5b7121802ebc1dea769920024d3b9b6300eaf357"
-  integrity sha512-P1HcaceTCbX9oIOUn8aJl1w4nkWVoZhIvbv1nEMfcrqImO4veDm7TwciZhr+ADcg+grcGMu+mIdN/kWTaT4M+g==
+"@dhis2/ui-widgets@6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-widgets/-/ui-widgets-6.5.0.tgz#c54cdc79df69acdada79fccd13cf7dc564312ec5"
+  integrity sha512-rQqANZsGi2ZpuEemRlQ2ksHJp+AGejiEu8c6TtsyktDC5razQkq6r3Laul7ftUPPqgk9STotpPf1wQAyhy8Svw==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
 
-"@dhis2/ui@^6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-6.4.0.tgz#6b565a07cfbc4c705ad9aa93758d5c9e07f94576"
-  integrity sha512-EjBfhzm7XApN9Q/0iedkAJBnQC+VySfKDR8RO/hQLwr1ksnoBhLClL531mWShNz4aXi7XNWJtbg7whIps3NgvA==
+"@dhis2/ui@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-6.5.0.tgz#8972d1c42f6445976965b6653571070d8e588726"
+  integrity sha512-zW6jl3qMDe6D29WuZtqd4p43mDsKTo49rYEgccbCx7S/ZEfs8KNi/aQsvhkphjjrtp6QqncBmp853WAvGxfdvw==
   dependencies:
-    "@dhis2/ui-constants" "6.4.0"
-    "@dhis2/ui-core" "6.4.0"
-    "@dhis2/ui-forms" "6.4.0"
-    "@dhis2/ui-icons" "6.4.0"
-    "@dhis2/ui-widgets" "6.4.0"
+    "@dhis2/ui-constants" "6.5.0"
+    "@dhis2/ui-core" "6.5.0"
+    "@dhis2/ui-forms" "6.5.0"
+    "@dhis2/ui-icons" "6.5.0"
+    "@dhis2/ui-widgets" "6.5.0"
 
 "@emotion/babel-utils@^0.6.4":
   version "0.6.10"


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10582

From the monkey testing: 
- Only show legend preview when the values are valid
- Min, max and step should not reset each other
- Allow steps to be changed with the keyboard
- Number of steps align the the number of colors shown, not the number of steps between min and max

In addition: 
- Show help text when values are missing or not correct

This PR upgrades DHIS2 UI to latest version 6.5.0 - with support for min, max and step values for input fields. This update also solved an issue where the color palette where changed back to default when min, max and steps where changed. 

After this PR: 

![ezgif com-gif-maker](https://user-images.githubusercontent.com/548708/109813976-4e5d2880-7c2e-11eb-9775-754cff3af621.gif)

After this PR when number of steps is reduced the palette is kept: 

<img width="590" alt="Screenshot 2021-03-01 at 13 37 19" src="https://user-images.githubusercontent.com/548708/109498088-44eb8900-7a93-11eb-98c4-22ffe751b1cd.png">

Before this PR the palette was changed back to default: 

<img width="593" alt="Screenshot 2021-03-01 at 13 38 34" src="https://user-images.githubusercontent.com/548708/109498231-7bc19f00-7a93-11eb-9668-f1f02f942357.png">

The PR also allows for decimals precision in the classes/legend when the numbers are small: 

<img width="586" alt="Screenshot 2021-03-01 at 13 43 44" src="https://user-images.githubusercontent.com/548708/109498770-3651a180-7a94-11eb-98b9-1c5413905fb3.png">

Before this PR: 

<img width="591" alt="Screenshot 2021-03-01 at 13 43 51" src="https://user-images.githubusercontent.com/548708/109498780-3baeec00-7a94-11eb-843d-6c354bf31399.png">

I also changed in i18n translation as we got an error then the key was including a colon character. 
