### PR TITLE
fix: wider select fields in EE data tab

### DIFF
--- a/src/components/edit/earthEngine/AggregationSelect.js
+++ b/src/components/edit/earthEngine/AggregationSelect.js
@@ -9,7 +9,6 @@ import {
 } from '../../../constants/aggregationTypes';
 import { setAggregationType } from '../../../actions/layerEdit';
 import { hasClasses } from '../../../util/earthEngine';
-import styles from './styles/SelectField.module.css';
 
 const AggregationSelect = ({
     aggregationType,
@@ -29,15 +28,13 @@ const AggregationSelect = ({
     }, [aggregationType, defaultAggregation]);
 
     return (
-        <div className={styles.root}>
-            <SelectField
-                label={i18n.t('Aggregation method')}
-                items={types}
-                multiple={!classes}
-                value={aggregationType}
-                onChange={type => setAggregationType(classes ? type.id : type)}
-            />
-        </div>
+        <SelectField
+            label={i18n.t('Aggregation method')}
+            items={types}
+            multiple={!classes}
+            value={aggregationType}
+            onChange={type => setAggregationType(classes ? type.id : type)}
+        />
     );
 };
 

--- a/src/components/edit/earthEngine/BandSelect.js
+++ b/src/components/edit/earthEngine/BandSelect.js
@@ -4,19 +4,16 @@ import i18n from '@dhis2/d2-i18n';
 import { connect } from 'react-redux';
 import { SelectField } from '../../core';
 import { setBand } from '../../../actions/layerEdit';
-import styles from './styles/SelectField.module.css';
 
 const BandSelect = ({ band = [], bands, setBand, errorText }) => (
-    <div className={styles.root}>
-        <SelectField
-            label={i18n.t('Groups')}
-            items={bands}
-            multiple={true}
-            value={band}
-            onChange={setBand}
-            errorText={!band.length && errorText ? errorText : null}
-        />
-    </div>
+    <SelectField
+        label={i18n.t('Groups')}
+        items={bands}
+        multiple={true}
+        value={band}
+        onChange={setBand}
+        errorText={!band.length && errorText ? errorText : null}
+    />
 );
 
 BandSelect.propTypes = {

--- a/src/components/edit/earthEngine/styles/SelectField.module.css
+++ b/src/components/edit/earthEngine/styles/SelectField.module.css
@@ -1,3 +1,0 @@
-.root {
-    max-width: 360px;
-}


### PR DESCRIPTION
This PR makes the select fields in the EE data tab full width. 

After this PR: 
<img width="615" alt="Screenshot 2021-03-02 at 11 12 35" src="https://user-images.githubusercontent.com/548708/109633647-9c97fc00-7b48-11eb-9090-a3f351b80f90.png">

Before: 
<img width="609" alt="Screenshot 2021-03-02 at 11 13 10" src="https://user-images.githubusercontent.com/548708/109633669-a28ddd00-7b48-11eb-9974-1f7a8c3a7e40.png">
