### PR TITLE
fix: map download support and avoid legend overflow

### DIFF
--- a/src/components/download/DownloadDialog.js
+++ b/src/components/download/DownloadDialog.js
@@ -128,7 +128,7 @@ export class DownloadDialog extends Component {
         const skipElements = el =>
             !el.classList ||
             el.classList.contains('mapboxgl-ctrl-scale') ||
-            el.classList.contains('mapboxgl-ctrl-attrib') ||
+            el.classList.contains('mapboxgl-ctrl-attrib-button') ||
             !(
                 el.classList.contains('mapboxgl-ctrl') ||
                 el.classList.contains('dhis2-map-bing-logo')

--- a/src/components/download/DownloadDialog.js
+++ b/src/components/download/DownloadDialog.js
@@ -149,7 +149,7 @@ export class DownloadDialog extends Component {
                 .getComputedStyle(titleEl, null)
                 .getPropertyValue('width');
 
-            titleEl.style.width = parseInt(width, 10) + 1 + 'px';
+            titleEl.style.width = parseFloat(width) + 1 + 'px';
         }
 
         convertToPng(mapEl, options)

--- a/src/components/download/styles/DownloadLegend.module.css
+++ b/src/components/download/styles/DownloadLegend.module.css
@@ -5,6 +5,7 @@
     z-index: 998;
     font-size: 14px;
     max-width: 220px;
+    overflow: hidden;
 }
 
 .downloadLegend div a:link,

--- a/src/components/map/MapContainer.js
+++ b/src/components/map/MapContainer.js
@@ -76,13 +76,13 @@ const MapContainer = props => {
                     closeCoordinatePopup={closeCoordinatePopup}
                     resizeCount={resizeCount}
                 />
-                {isDownload && legendPosition && layers.length && (
+                {isDownload && legendPosition && layers.length ? (
                     <DownloadLegend
                         position={legendPosition}
                         layers={layers}
                         showName={showName}
                     />
-                )}
+                ) : null}
                 {isLoading && <MapLoadingMask />}
             </div>
         </div>

--- a/src/components/map/styles/MapContainer.module.css
+++ b/src/components/map/styles/MapContainer.module.css
@@ -1,6 +1,8 @@
 .container {
     height: 100%;
     width: 100%;
+    position: relative;
+    overflow: hidden;
 }
 
 /* Roboto font is not loaded by dom-to-image => switch to Arial */

--- a/src/components/map/styles/MapContainer.module.css
+++ b/src/components/map/styles/MapContainer.module.css
@@ -4,14 +4,14 @@
 }
 
 /* Roboto font is not loaded by dom-to-image => switch to Arial */
-.download div {
+.download :global(div) {
     font-family: Arial, sans-serif !important;
 }
 
-.download .dhis2-map-timeline {
+.download :global(.dhis2-map-timeline) {
     display: none;
 }
 
-.download .dhis2-map-period {
+.download :global(.dhis2-map-period) {
     bottom: 10px !important;
 }


### PR DESCRIPTION
This PR makes map download work after upgrading to DHIS2 UI. 

Maps can now be downloaded again: 

![map-o6agph](https://user-images.githubusercontent.com/548708/109658027-72edcd80-7b66-11eb-980e-5a913517e7b3.png)

Legend will not overflow the header bar: 

<img width="1209" alt="Screenshot 2021-03-02 at 14 43 33" src="https://user-images.githubusercontent.com/548708/109658100-85680700-7b66-11eb-809c-4a7dceca4c11.png">

Before: 

<img width="1208" alt="Screenshot 2021-03-02 at 14 25 25" src="https://user-images.githubusercontent.com/548708/109658115-8d27ab80-7b66-11eb-9367-a9a54d66c09f.png">
