### PR TITLE
fix: update period in legend and include year

### DIFF
--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -1,6 +1,6 @@
 import { getInstance as getD2 } from 'd2';
 import { getEarthEngineLayer } from '../constants/earthEngine';
-import { getPeriodFromFilter } from '../util/earthEngine';
+import { getPeriodNameFromFilter } from '../util/earthEngine';
 import { getOrgUnitsFromRows } from '../util/analytics';
 import { getDisplayProperty } from '../util/helpers';
 import { toGeoJson } from '../util/map';
@@ -66,7 +66,7 @@ const earthEngineLoader = async config => {
         bands,
     } = layer;
 
-    const period = getPeriodFromFilter(filter);
+    const period = getPeriodNameFromFilter(filter);
 
     const groups =
         band && Array.isArray(bands) && bands.length
@@ -79,7 +79,7 @@ const earthEngineLoader = async config => {
 
     layer.legend = {
         title: name,
-        period: period ? period.name : null,
+        period,
         groups,
         unit,
         description,

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -85,7 +85,6 @@ const earthEngineLoader = async config => {
         description,
         source,
         sourceUrl,
-        ...layer.legend,
     };
 
     // Create legend items from params

--- a/src/util/earthEngine.js
+++ b/src/util/earthEngine.js
@@ -28,6 +28,18 @@ export const getPeriodFromFilter = (filter = []) => {
         : null;
 };
 
+// Returns period name from filter
+export const getPeriodNameFromFilter = filter => {
+    const period = getPeriodFromFilter(filter);
+
+    if (!period) {
+        return null;
+    }
+
+    const { name, year = '' } = period;
+    return `${name} ${year}`;
+};
+
 const setAuthToken = ({ client_id, access_token, expires_in }) =>
     new Promise((resolve, reject) => {
         ee.data.setAuthToken(client_id, 'Bearer', access_token, expires_in);

--- a/src/util/earthEngine.js
+++ b/src/util/earthEngine.js
@@ -36,8 +36,8 @@ export const getPeriodNameFromFilter = filter => {
         return null;
     }
 
-    const { name, year = '' } = period;
-    return `${name} ${year}`;
+    const { name, year } = period;
+    return `${name}${year ? ` ${year}` : ''}`;
 };
 
 const setAuthToken = ({ client_id, access_token, expires_in }) =>


### PR DESCRIPTION
This PR will make sure the period name is updated when changed in the EE layer dialog. It will also include year when a weekly period is selected.

After this PR: 

<img width="293" alt="Screenshot 2021-03-02 at 20 59 55" src="https://user-images.githubusercontent.com/548708/109707292-4653a900-7b9a-11eb-8a81-e6f9da5a9836.png">

Before: 

<img width="294" alt="Screenshot 2021-03-02 at 20 59 24" src="https://user-images.githubusercontent.com/548708/109707314-4ce22080-7b9a-11eb-90e6-35decc695be1.png">
