### PR TITLE
fix: allow buffer to be unchecked and empty value field

### DIFF
--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -85,7 +85,7 @@ const EarthEngineDialog = props => {
     }, [rows, setOrgUnitLevels]);
 
     useEffect(() => {
-        if (!areaRadius) {
+        if (areaRadius === undefined) {
             setBufferRadius(EE_BUFFER);
         }
     }, [areaRadius, setBufferRadius]);
@@ -203,7 +203,7 @@ EarthEngineDialog.propTypes = {
         max: PropTypes.number.isRequired,
         palette: PropTypes.string.isRequired,
     }),
-    areaRadius: PropTypes.number,
+    areaRadius: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     legend: PropTypes.object,
     validateLayer: PropTypes.bool.isRequired,
     setFilter: PropTypes.func.isRequired,

--- a/src/components/edit/shared/BufferRadius.js
+++ b/src/components/edit/shared/BufferRadius.js
@@ -32,7 +32,9 @@ const BufferRadius = ({
                     label={i18n.t('Radius in meters')}
                     value={radius || ''}
                     disabled={disabled}
-                    onChange={setBufferRadius}
+                    onChange={value =>
+                        setBufferRadius(value !== '' ? parseInt(value, 10) : '')
+                    }
                 />
             )}
         </div>
@@ -40,7 +42,7 @@ const BufferRadius = ({
 };
 
 BufferRadius.propTypes = {
-    radius: PropTypes.number,
+    radius: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     defaultRadius: PropTypes.number,
     disabled: PropTypes.bool,
     className: PropTypes.string,

--- a/src/components/edit/shared/BufferRadius.js
+++ b/src/components/edit/shared/BufferRadius.js
@@ -8,6 +8,11 @@ import NumberField from '../../core/NumberField';
 import { setBufferRadius } from '../../../actions/layerEdit';
 import styles from './styles/BufferRadius.module.css';
 
+// Component to set buffer radius (checkbox toggle and number field)
+// radius will be undefined when a layer dialog is opened (can be used to set default value)
+// it will be null when the checkbox is unchecked
+// it will be empty string when the value is deleted
+// it will have a number value when a buffer is typed, or a default set
 const BufferRadius = ({
     radius,
     defaultRadius = 1000,

--- a/src/reducers/layerEdit.js
+++ b/src/reducers/layerEdit.js
@@ -480,7 +480,7 @@ const layerEdit = (state = null, action) => {
         case types.LAYER_EDIT_BUFFER_RADIUS_SET:
             return {
                 ...state,
-                areaRadius: action.radius ? parseInt(action.radius, 10) : null,
+                areaRadius: action.radius,
             };
 
         case types.LAYER_EDIT_RADIUS_LOW_SET:


### PR DESCRIPTION
This PR will fix two issues with the buffer checkbox and input field: 
- The checkbox can now be unchecked 
- The input field can be empty - allow user to delete the value before typing a new one. 

After this PR: 
![buffer](https://user-images.githubusercontent.com/548708/109713092-14921080-7ba1-11eb-88c0-7dde4442b535.gif)


