### PR TITLE
fix: show "hide data tabel" i layer menu when table is open

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-02-22T16:51:45.512Z\n"
-"PO-Revision-Date: 2021-02-22T16:51:45.512Z\n"
+"POT-Creation-Date: 2021-03-04T08:41:44.683Z\n"
+"PO-Revision-Date: 2021-03-04T08:41:44.683Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -505,6 +505,9 @@ msgid "Set layer opacity"
 msgstr ""
 
 msgid "More actions"
+msgstr ""
+
+msgid "Hide data table"
 msgstr ""
 
 msgid "Show data table"

--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -1,5 +1,6 @@
 import React, { Fragment, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
 import {
     Popover,
@@ -23,6 +24,7 @@ export const LayerToolbarMoreMenu = ({
     toggleDataTable,
     openAs,
     downloadData,
+    dataTableOpen,
 }) => {
     const [isOpen, setIsOpen] = useState(false);
     const anchorRef = useRef();
@@ -63,7 +65,11 @@ export const LayerToolbarMoreMenu = ({
                         <Menu dense>
                             {toggleDataTable && (
                                 <MenuItem
-                                    label={i18n.t('Show data table')}
+                                    label={
+                                        dataTableOpen
+                                            ? i18n.t('Hide data table')
+                                            : i18n.t('Show data table')
+                                    }
                                     icon={<IconTable16 />}
                                     onClick={() => {
                                         setIsOpen(false);
@@ -128,6 +134,9 @@ LayerToolbarMoreMenu.propTypes = {
     toggleDataTable: PropTypes.func,
     openAs: PropTypes.func,
     downloadData: PropTypes.func,
+    dataTableOpen: PropTypes.bool,
 };
 
-export default LayerToolbarMoreMenu;
+export default connect(({ dataTable }) => ({
+    dataTableOpen: !!dataTable,
+}))(LayerToolbarMoreMenu);

--- a/src/components/layers/toolbar/__tests__/LayerToolbar.spec.js
+++ b/src/components/layers/toolbar/__tests__/LayerToolbar.spec.js
@@ -17,7 +17,6 @@ describe('LayerToolbar', () => {
         const wrapper = shallowRenderLayerToolbar();
         expect(wrapper.find('[dataTest="visibilitybutton"]').length).toBe(1); // Visibility toggle
         expect(wrapper.find('OpacitySlider').length).toBe(1);
-        expect(wrapper.find('LayerToolbarMoreMenu').length).toBe(1);
     });
 
     it('Should show SvgView24 when visible', () => {
@@ -58,7 +57,6 @@ describe('LayerToolbar', () => {
         });
         expect(wrapper.find('[dataTest="visibilitybutton"]').length).toBe(1);
         expect(wrapper.find('OpacitySlider').length).toBe(1);
-        expect(wrapper.find('LayerToolbarMoreMenu').length).toBe(1);
     });
 
     it('Should match toolbar snapshot WITH Edit button', () => {

--- a/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbar.spec.js.snap
+++ b/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbar.spec.js.snap
@@ -41,7 +41,7 @@ exports[`LayerToolbar Should match toolbar snapshot WITH Edit button 1`] = `
       />
     </Tooltip>
   </div>
-  <LayerToolbarMoreMenu
+  <Connect(LayerToolbarMoreMenu)
     onEdit={[Function]}
   />
 </div>
@@ -77,6 +77,6 @@ exports[`LayerToolbar Should match toolbar snapshot without Edit button 1`] = `
       />
     </Tooltip>
   </div>
-  <LayerToolbarMoreMenu />
+  <Connect(LayerToolbarMoreMenu) />
 </div>
 `;

--- a/src/components/legend/Legend.js
+++ b/src/components/legend/Legend.js
@@ -62,7 +62,9 @@ const Legend = ({
             <div className={styles.source}>
                 {i18n.t('Source')}:&nbsp;
                 {sourceUrl ? (
-                    <a href={sourceUrl}>{source}</a>
+                    <a href={sourceUrl} target="_blank" rel="noreferrer">
+                        {source}
+                    </a>
                 ) : (
                     <span>{source}</span>
                 )}


### PR DESCRIPTION
This PR will change the layer menu label to "Hide data table" when the table is open. It also includes a fix to open data source links in a new browser tab.

After this PR: 

<img width="329" alt="Screenshot 2021-03-03 at 20 16 18" src="https://user-images.githubusercontent.com/548708/109859512-57b1b980-7c5d-11eb-8f28-16676ae8ec5a.png">

<img width="402" alt="Screenshot 2021-03-03 at 20 16 03" src="https://user-images.githubusercontent.com/548708/109859526-5bddd700-7c5d-11eb-8f2a-b19616625f63.png">
