### PR TITLE
fix: restrict aggregation types shown

### DIFF
--- a/src/components/edit/earthEngine/AggregationSelect.js
+++ b/src/components/edit/earthEngine/AggregationSelect.js
@@ -11,22 +11,22 @@ import { setAggregationType } from '../../../actions/layerEdit';
 import { hasClasses } from '../../../util/earthEngine';
 
 const AggregationSelect = ({
-    aggregation,
-    defaultAggregation,
+    aggregations,
+    defaultAggregations,
     aggregationType,
     setAggregationType,
 }) => {
-    const classes = hasClasses(defaultAggregation);
+    const classes = hasClasses(defaultAggregations);
 
     const types = classes
         ? getEarthEngineStatisticTypes()
-        : getEarthEngineAggregationTypes(aggregation);
+        : getEarthEngineAggregationTypes(aggregations);
 
     useEffect(() => {
-        if (!aggregationType && defaultAggregation) {
-            setAggregationType(defaultAggregation);
+        if (!aggregationType && defaultAggregations) {
+            setAggregationType(defaultAggregations);
         }
-    }, [aggregationType, defaultAggregation]);
+    }, [aggregationType, defaultAggregations]);
 
     return (
         <SelectField
@@ -40,8 +40,8 @@ const AggregationSelect = ({
 };
 
 AggregationSelect.propTypes = {
-    aggregation: PropTypes.array,
-    defaultAggregation: PropTypes.oneOfType([
+    aggregations: PropTypes.array,
+    defaultAggregations: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.array,
     ]),
@@ -51,8 +51,8 @@ AggregationSelect.propTypes = {
 
 export default connect(
     ({ layerEdit }) => ({
-        aggregation: layerEdit.aggregation,
-        defaultAggregation: layerEdit.defaultAggregation,
+        aggregations: layerEdit.aggregations,
+        defaultAggregations: layerEdit.defaultAggregations,
         aggregationType: layerEdit.aggregationType,
     }),
     { setAggregationType }

--- a/src/components/edit/earthEngine/AggregationSelect.js
+++ b/src/components/edit/earthEngine/AggregationSelect.js
@@ -11,15 +11,16 @@ import { setAggregationType } from '../../../actions/layerEdit';
 import { hasClasses } from '../../../util/earthEngine';
 
 const AggregationSelect = ({
-    aggregationType,
+    aggregation,
     defaultAggregation,
+    aggregationType,
     setAggregationType,
 }) => {
     const classes = hasClasses(defaultAggregation);
 
     const types = classes
         ? getEarthEngineStatisticTypes()
-        : getEarthEngineAggregationTypes();
+        : getEarthEngineAggregationTypes(aggregation);
 
     useEffect(() => {
         if (!aggregationType && defaultAggregation) {
@@ -39,18 +40,20 @@ const AggregationSelect = ({
 };
 
 AggregationSelect.propTypes = {
-    aggregationType: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+    aggregation: PropTypes.array,
     defaultAggregation: PropTypes.oneOfType([
         PropTypes.string,
         PropTypes.array,
     ]),
+    aggregationType: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
     setAggregationType: PropTypes.func.isRequired,
 };
 
 export default connect(
     ({ layerEdit }) => ({
-        aggregationType: layerEdit.aggregationType,
+        aggregation: layerEdit.aggregation,
         defaultAggregation: layerEdit.defaultAggregation,
+        aggregationType: layerEdit.aggregationType,
     }),
     { setAggregationType }
 )(AggregationSelect);

--- a/src/components/map/layers/earthEngine/EarthEnginePopup.js
+++ b/src/components/map/layers/earthEngine/EarthEnginePopup.js
@@ -18,6 +18,9 @@ const EarthEnginePopup = props => {
     let header = null;
 
     if (values) {
+        const types = Object.keys(values);
+        const onlySum = types.length === 1 && types[0] === 'sum';
+
         if (classes) {
             const valueFormat = numberPrecision(isPercentage ? 2 : 0);
 
@@ -66,11 +69,11 @@ const EarthEnginePopup = props => {
                             ))}
                         </div>
                     )}
-                    <div className={styles.unit}>{unit}</div>
+                    {!onlySum && <div className={styles.unit}>{unit}</div>}
                 </caption>
             );
 
-            rows = Object.keys(values).map(type => {
+            rows = types.map(type => {
                 const precision = getPrecision(
                     Object.values(data).map(d => d[type])
                 );

--- a/src/constants/aggregationTypes.js
+++ b/src/constants/aggregationTypes.js
@@ -20,8 +20,8 @@ export const getEarthEngineStatisticTypes = () => [
 ];
 
 // Earth Engine layer
-export const getEarthEngineAggregationTypes = (types = []) =>
-    [
+export const getEarthEngineAggregationTypes = filter => {
+    const types = [
         { id: 'min', name: i18n.t('Min') },
         { id: 'max', name: i18n.t('Max') },
         { id: 'mean', name: i18n.t('Mean') },
@@ -29,7 +29,10 @@ export const getEarthEngineAggregationTypes = (types = []) =>
         { id: 'sum', name: i18n.t('Sum') },
         { id: 'stdDev', name: i18n.t('Standard deviation') },
         { id: 'variance', name: i18n.t('Variance') },
-    ].filter(({ id }) => types.includes(id));
+    ];
+
+    return filter ? types.filter(({ id }) => filter.includes(id)) : types;
+};
 
 export const getEarthEngineStatisticType = id =>
     (getEarthEngineStatisticTypes().find(t => t.id === id) || {}).name;

--- a/src/constants/aggregationTypes.js
+++ b/src/constants/aggregationTypes.js
@@ -20,17 +20,16 @@ export const getEarthEngineStatisticTypes = () => [
 ];
 
 // Earth Engine layer
-// TODO: Align names with thematic types
-export const getEarthEngineAggregationTypes = () => [
-    { id: 'min', name: i18n.t('Min') },
-    { id: 'max', name: i18n.t('Max') },
-    { id: 'mean', name: i18n.t('Mean') },
-    { id: 'median', name: i18n.t('Median') },
-    { id: 'sum', name: i18n.t('Sum') },
-    { id: 'stdDev', name: i18n.t('Standard deviation') },
-    { id: 'variance', name: i18n.t('Variance') },
-    { id: 'count', name: i18n.t('Count') },
-];
+export const getEarthEngineAggregationTypes = (types = []) =>
+    [
+        { id: 'min', name: i18n.t('Min') },
+        { id: 'max', name: i18n.t('Max') },
+        { id: 'mean', name: i18n.t('Mean') },
+        { id: 'median', name: i18n.t('Median') },
+        { id: 'sum', name: i18n.t('Sum') },
+        { id: 'stdDev', name: i18n.t('Standard deviation') },
+        { id: 'variance', name: i18n.t('Variance') },
+    ].filter(({ id }) => types.includes(id));
 
 export const getEarthEngineStatisticType = id =>
     (getEarthEngineStatisticTypes().find(t => t.id === id) || {}).name;

--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -218,6 +218,7 @@ export const earthEngineLayers = () => [
         sourceUrl:
             'https://explorer.earthengine.google.com/#detail/USGS%2FSRTMGL1_003',
         img: 'images/elevation.png',
+        aggregation: ['min', 'max', 'mean', 'median', 'stdDev', 'variance'],
         defaultAggregation: ['min', 'max', 'mean'],
         band: 'elevation',
         params: {

--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -241,7 +241,8 @@ export const earthEngineLayers = () => [
             'https://explorer.earthengine.google.com/#detail/UCSB-CHG%2FCHIRPS%2FPENTAD',
         periodType: 'Custom',
         band: 'precipitation',
-        defaultAggregation: ['sum', 'min', 'max', 'mean'],
+        aggregation: ['min', 'max', 'mean', 'median', 'stdDev', 'variance'],
+        defaultAggregation: ['min', 'max', 'mean'],
         mask: true,
         img: 'images/precipitation.png',
         params: {
@@ -263,6 +264,7 @@ export const earthEngineLayers = () => [
         sourceUrl:
             'https://explorer.earthengine.google.com/#detail/MODIS%2FMOD11A2',
         img: 'images/temperature.png',
+        aggregation: ['min', 'max', 'mean', 'median', 'stdDev', 'variance'],
         defaultAggregation: ['min', 'max', 'mean'],
         periodType: 'Custom',
         band: 'LST_Day_1km',

--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -13,7 +13,7 @@ export const earthEngineLayers = () => [
         sourceUrl:
             'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop',
         img: 'images/population.png',
-        defaultAggregation: ['sum', 'mean'],
+        defaultAggregations: ['sum', 'mean'],
         periodType: 'Yearly',
         filters: ({ id, name, year }) => [
             {
@@ -44,7 +44,7 @@ export const earthEngineLayers = () => [
             'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop_age_sex',
         img: 'images/population.png',
         periodType: 'Yearly',
-        defaultAggregation: ['sum', 'mean'],
+        defaultAggregations: ['sum', 'mean'],
         bands: [
             {
                 id: 'M_0',
@@ -218,8 +218,8 @@ export const earthEngineLayers = () => [
         sourceUrl:
             'https://explorer.earthengine.google.com/#detail/USGS%2FSRTMGL1_003',
         img: 'images/elevation.png',
-        aggregation: ['min', 'max', 'mean', 'median', 'stdDev', 'variance'],
-        defaultAggregation: ['min', 'max', 'mean'],
+        aggregations: ['min', 'max', 'mean', 'median', 'stdDev', 'variance'],
+        defaultAggregations: ['min', 'max', 'mean'],
         band: 'elevation',
         params: {
             min: 0,
@@ -241,8 +241,8 @@ export const earthEngineLayers = () => [
             'https://explorer.earthengine.google.com/#detail/UCSB-CHG%2FCHIRPS%2FPENTAD',
         periodType: 'Custom',
         band: 'precipitation',
-        aggregation: ['min', 'max', 'mean', 'median', 'stdDev', 'variance'],
-        defaultAggregation: ['min', 'max', 'mean'],
+        aggregations: ['min', 'max', 'mean', 'median', 'stdDev', 'variance'],
+        defaultAggregations: ['min', 'max', 'mean'],
         mask: true,
         img: 'images/precipitation.png',
         params: {
@@ -264,8 +264,8 @@ export const earthEngineLayers = () => [
         sourceUrl:
             'https://explorer.earthengine.google.com/#detail/MODIS%2FMOD11A2',
         img: 'images/temperature.png',
-        aggregation: ['min', 'max', 'mean', 'median', 'stdDev', 'variance'],
-        defaultAggregation: ['min', 'max', 'mean'],
+        aggregations: ['min', 'max', 'mean', 'median', 'stdDev', 'variance'],
+        defaultAggregations: ['min', 'max', 'mean'],
         periodType: 'Custom',
         band: 'LST_Day_1km',
         mask: true,
@@ -294,7 +294,7 @@ export const earthEngineLayers = () => [
         periodType: 'Yearly',
         band: 'LC_Type1',
         filters: defaultFilters,
-        defaultAggregation: 'percentage',
+        defaultAggregations: 'percentage',
         legend: {
             items: [
                 // http://www.eomf.ou.edu/static/IGBP.pdf


### PR DESCRIPTION
This PR restrict the aggregation types show for different Earth Engine layers, so we only show those that are relevant

"Count" (number of cells) was removed for all layers. "Sum" was removed from all layers except the two population layers. 

After this PR: 

<img width="588" alt="Screenshot 2021-03-04 at 13 56 45" src="https://user-images.githubusercontent.com/548708/109967280-837e7f00-7cf1-11eb-9f28-0304457973ab.png">

Before: 

<img width="589" alt="Screenshot 2021-03-04 at 13 57 34" src="https://user-images.githubusercontent.com/548708/109967351-96914f00-7cf1-11eb-9033-d635359ceff3.png">

The PR also includes a fix so we don't show unit in the popup when only "sum" is selected (confusing for the user). 

After this PR: 

<img width="200" alt="Screenshot 2021-03-04 at 13 51 37" src="https://user-images.githubusercontent.com/548708/109966627-c9871300-7cf0-11eb-9cf9-adaedd32dc83.png">

Before: 

<img width="186" alt="Screenshot 2021-03-04 at 13 53 29" src="https://user-images.githubusercontent.com/548708/109966883-0b17be00-7cf1-11eb-8278-09e3d9197783.png">
