### PR TITLE
fix: update file menu when map is saved (DHIS2-10656) 

### DIFF
--- a/src/epics/favorites.js
+++ b/src/epics/favorites.js
@@ -1,7 +1,7 @@
 import { combineEpics } from 'redux-observable';
 import i18n from '@dhis2/d2-i18n';
 import * as types from '../constants/actionTypes';
-import { setMapProps } from '../actions/map';
+import { loadFavorite } from '../actions/favorites';
 import { setAlert } from '../actions/alerts';
 import { apiFetch } from '../util/api';
 import { cleanMapConfig } from '../util/favorites';
@@ -58,10 +58,10 @@ export const saveNewFavorite = (action$, store) =>
                         : response
                 );
         })
-        .mergeMap(({ id, name, description, message }) =>
+        .mergeMap(({ id, name, message }) =>
             name
                 ? [
-                      setMapProps({ id, name, description }),
+                      loadFavorite(id),
                       setAlert({
                           success: true,
                           message: getSavedMessage(name),


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10585

To enable all file menu options, the map is now loaded instantly after it is saved. This gives us the map sharing and access setting applied on the server. 

After this PR: 
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/548708/110316159-9f906200-800a-11eb-836e-e614b1e2bf63.gif)

<img width="608" alt="Screenshot 2021-03-08 at 12 25 32" src="https://user-images.githubusercontent.com/548708/110315360-6dcacb80-8009-11eb-83b5-d3cccf2e9376.png">

Before this PR
<img width="550" alt="Screenshot 2021-03-08 at 12 24 46" src="https://user-images.githubusercontent.com/548708/110315381-74f1d980-8009-11eb-8091-2b4d3414b5a2.png">

A later optimalisation would be to only load the properties needed, to avoid triggering a reload of the layer data and a redraw of the map. 