### PR TITLE
fix: close popup when context menu is shown

### DIFF
--- a/src/components/map/layers/Layer.js
+++ b/src/components/map/layers/Layer.js
@@ -189,6 +189,8 @@ class Layer extends PureComponent {
                 ? container.parentNode.parentNode
                 : container,
         });
+
+        this.setState({ popup: null });
     }
 
     // Called when a map popup is closed

--- a/src/components/map/layers/earthEngine/EarthEngineLayer.js
+++ b/src/components/map/layers/earthEngine/EarthEngineLayer.js
@@ -170,6 +170,11 @@ export default class EarthEngineLayer extends Layer {
         this.setState({ popup: evt });
     }
 
+    onFeatureRightClick(evt) {
+        this.setState({ popup: null });
+        super.onFeatureRightClick(evt);
+    }
+
     onLoad() {
         this.setState({ isLoading: false });
     }

--- a/src/components/map/layers/earthEngine/EarthEngineLayer.js
+++ b/src/components/map/layers/earthEngine/EarthEngineLayer.js
@@ -170,11 +170,6 @@ export default class EarthEngineLayer extends Layer {
         this.setState({ popup: evt });
     }
 
-    onFeatureRightClick(evt) {
-        this.setState({ popup: null });
-        super.onFeatureRightClick(evt);
-    }
-
     onLoad() {
         this.setState({ isLoading: false });
     }


### PR DESCRIPTION
This PR makes sure the popup is closed when the context menu is opened. It avoids reopening the popup when the user drills down/up. 

After this PR: 
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/548708/110321934-a8853180-8012-11eb-80f9-b58b9ac32ab1.gif)

Before: 
<img width="876" alt="Screenshot 2021-03-08 at 13 30 47" src="https://user-images.githubusercontent.com/548708/110321852-8a1f3600-8012-11eb-82eb-44ed8f5b2979.png">
