### PR TITLE
fix: show error message when org unit selection is wrong

### DIFF
--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n';
 import { getInstance as getD2 } from 'd2';
 import { precisionRound } from 'd3-format';
 import { getEarthEngineLayer } from '../constants/earthEngine';
@@ -14,17 +15,27 @@ const earthEngineLoader = async config => {
     let layerConfig = {};
     let dataset;
     let features;
+    let alerts;
 
     if (orgUnits && orgUnits.length) {
         const d2 = await getD2();
         const displayProperty = getDisplayProperty(d2).toUpperCase();
         const orgUnitParams = orgUnits.map(item => item.id);
 
-        features = await d2.geoFeatures
-            .byOrgUnit(orgUnitParams)
-            .displayProperty(displayProperty)
-            .getAll()
-            .then(toGeoJson);
+        try {
+            features = await d2.geoFeatures
+                .byOrgUnit(orgUnitParams)
+                .displayProperty(displayProperty)
+                .getAll()
+                .then(toGeoJson);
+        } catch (error) {
+            alerts = [
+                {
+                    critical: true,
+                    message: `${i18n.t('Error')}: ${error.message}`,
+                },
+            ];
+        }
     }
 
     if (typeof config.config === 'string') {
@@ -98,6 +109,7 @@ const earthEngineLoader = async config => {
         ...layer,
         data: features,
         aggregationType,
+        alerts,
         isLoaded: true,
         isExpanded: true,
         isVisible: true,


### PR DESCRIPTION
This PR will show the error message from the Web API if the org unit selection is wrong: 

<img width="969" alt="Screenshot 2021-03-08 at 13 48 54" src="https://user-images.githubusercontent.com/548708/110323959-a1abee00-8015-11eb-8f9d-0cb5a97e2cf8.png">

This is the same behaviour as we have for other layers. The layer will still load, allowing the user to change the org unit selection. 

Before this PR the layer will not load and no error message is shown to the user:

<img width="1171" alt="Screenshot 2021-03-08 at 13 51 07" src="https://user-images.githubusercontent.com/548708/110324021-b9837200-8015-11eb-988d-647c11db1190.png">

The error message shown to the user should be improved in a later release. 