### PR TITLE
fix: show circular loader in org unit dialog

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-03-04T09:19:28.040Z\n"
-"PO-Revision-Date: 2021-03-04T09:19:28.040Z\n"
+"POT-Creation-Date: 2021-03-08T17:11:22.603Z\n"
+"PO-Revision-Date: 2021-03-08T17:11:22.603Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -673,6 +673,9 @@ msgid "Options"
 msgstr ""
 
 msgid "Code"
+msgstr ""
+
+msgid "Loading data"
 msgstr ""
 
 msgid "No data found for this period."

--- a/src/components/orgunits/OrgUnitDialog.js
+++ b/src/components/orgunits/OrgUnitDialog.js
@@ -8,6 +8,7 @@ import {
     ModalContent,
     ModalActions,
     Button,
+    CircularLoader,
 } from '@dhis2/ui';
 import PeriodSelect from '../periods/PeriodSelect';
 import OrgUnitDialogTable from './OrgUnitDialogTable';
@@ -46,6 +47,7 @@ export class OrgUnitDialog extends Component {
             period &&
             (id !== prevProps.id || period !== prevState.period)
         ) {
+            this.setState({ data: null });
             loadData(id, period.id, dataItems).then(data =>
                 this.setState({ data })
             );
@@ -99,7 +101,14 @@ export class OrgUnitDialog extends Component {
                                 period={period}
                                 onChange={this.onPeriodChange}
                             />
-                            <OrgUnitDialogTable data={data} />
+                            {data ? (
+                                <OrgUnitDialogTable data={data} />
+                            ) : (
+                                <div className={styles.loading}>
+                                    <CircularLoader small />
+                                    {i18n.t('Loading data')}
+                                </div>
+                            )}
                         </div>
                     </div>
                 </ModalContent>

--- a/src/components/orgunits/styles/OrgUnitDialog.module.css
+++ b/src/components/orgunits/styles/OrgUnitDialog.module.css
@@ -18,3 +18,8 @@
     float: left;
     width: 345px;
 }
+
+.loading {
+    display: flex;
+    align-items: center;
+}


### PR DESCRIPTION
This PR shows a circular loader while data is loading in the org unit dialog: 

<img width="598" alt="Screenshot 2021-03-08 at 18 07 50" src="https://user-images.githubusercontent.com/548708/110356104-33c5ed80-803a-11eb-8479-415670e9fd3c.png">
