### PR TITLE
fix: hide data table only if table belongs to layer

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -239,7 +239,9 @@ class DataTable extends Component {
                         headerRenderer={props => (
                             <ColumnHeader type="date" {...props} />
                         )}
-                        cellRenderer={({ cellData }) => formatTime(cellData)}
+                        cellRenderer={({ cellData }) =>
+                            cellData ? formatTime(cellData) : ''
+                        }
                     />
                 )}
                 {isEvent &&

--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -66,7 +66,7 @@ export const LayerToolbarMoreMenu = ({
                             {toggleDataTable && (
                                 <MenuItem
                                     label={
-                                        dataTableOpen
+                                        dataTableOpen === layer.id
                                             ? i18n.t('Hide data table')
                                             : i18n.t('Show data table')
                                     }
@@ -134,9 +134,9 @@ LayerToolbarMoreMenu.propTypes = {
     toggleDataTable: PropTypes.func,
     openAs: PropTypes.func,
     downloadData: PropTypes.func,
-    dataTableOpen: PropTypes.bool,
+    dataTableOpen: PropTypes.string,
 };
 
 export default connect(({ dataTable }) => ({
-    dataTableOpen: !!dataTable,
+    dataTableOpen: dataTable,
 }))(LayerToolbarMoreMenu);

--- a/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbarMoreMenu.spec.js.snap
+++ b/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbarMoreMenu.spec.js.snap
@@ -38,7 +38,7 @@ exports[`LayerToolbarMoreMenu Should match snapshot 1`] = `
         <MenuItem
           dataTest="dhis2-uicore-menuitem"
           icon={<SvgTable16 />}
-          label="Show data table"
+          label="Hide data table"
           onClick={[Function]}
         />
         <MenuItem


### PR DESCRIPTION
Fixes an issue where "Hide data table" was showing in all layer menus, and not only for the layer where the table is currently open. 

After this PR: 
![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/548708/110638294-a9eb6100-81ae-11eb-8770-781a47ce3984.gif)

The PR also includes an extra check of cell value existence when switching between data tables. 
