### PR TITLE
fix: don't reset year selection for ee layers

### DIFF
--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -71,7 +71,7 @@ const EarthEngineDialog = props => {
 
     // Set most recent period by default
     useEffect(() => {
-        if (!period) {
+        if (period === undefined) {
             if (Array.isArray(periods) && periods.length) {
                 setPeriod(periods[0]);
             }

--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -56,7 +56,7 @@ const EarthEngineDialog = props => {
 
     const period = getPeriodFromFilter(filter);
 
-    const setPeriod = period => setFilter(period ? filters(period) : undefined);
+    const setPeriod = period => setFilter(period ? filters(period) : null);
 
     const noBandSelected = Array.isArray(bands) && (!band || !band.length);
 
@@ -71,12 +71,12 @@ const EarthEngineDialog = props => {
 
     // Set most recent period by default
     useEffect(() => {
-        if (period === undefined) {
+        if (filter === undefined) {
             if (Array.isArray(periods) && periods.length) {
                 setPeriod(periods[0]);
             }
         }
-    }, [periods, period]);
+    }, [periods, filter]);
 
     useEffect(() => {
         if (!rows) {

--- a/src/components/edit/earthEngine/PeriodSelect.js
+++ b/src/components/edit/earthEngine/PeriodSelect.js
@@ -45,14 +45,10 @@ const EarthEnginePeriodSelect = ({
     );
 
     useEffect(() => {
-        if (byYear) {
-            if (period) {
-                setYear(period.year);
-            } else if (years) {
-                setYear(years[0].id);
-            }
+        if (byYear && period) {
+            setYear(period.year);
         }
-    }, [byYear, period, years]);
+    }, [byYear, period]);
 
     const items = byYear ? byYearPeriods : periods;
 

--- a/src/util/earthEngine.js
+++ b/src/util/earthEngine.js
@@ -16,16 +16,18 @@ export const getStartEndDate = data =>
         false
     );
 
-export const getPeriodFromFilter = (filter = []) => {
-    const f = filter[0];
+export const getPeriodFromFilter = filter => {
+    if (!Array.isArray(filter) || !filter.length) {
+        return null;
+    }
 
-    return f
-        ? {
-              id: f.id || f.arguments[1],
-              name: f.name,
-              year: f.year,
-          }
-        : null;
+    const { id, name, year, arguments: args } = filter[0];
+
+    return {
+        id: id || args[1],
+        name,
+        year,
+    };
 };
 
 // Returns period name from filter
@@ -37,7 +39,9 @@ export const getPeriodNameFromFilter = filter => {
     }
 
     const { name, year } = period;
-    return `${name}${year ? ` ${year}` : ''}`;
+    const showYear = year && String(year) !== name;
+
+    return `${name}${showYear ? ` ${year}` : ''}`;
 };
 
 const setAuthToken = ({ client_id, access_token, expires_in }) =>


### PR DESCRIPTION
This PR fixes two issues with the period selection for EE layers: 

1. Don't reset year selection to latest value

![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/548708/110650509-e755eb80-81ba-11eb-9fef-6f7d40f0d974.gif)

2 Don't show year twice for landcover

<img width="293" alt="Screenshot 2021-03-10 at 16 09 36" src="https://user-images.githubusercontent.com/548708/110650693-0c4a5e80-81bb-11eb-9070-51b1022c1a16.png">



