### PR TITLE
fix: set min buffer radius to 0

### DIFF
--- a/src/components/edit/shared/BufferRadius.js
+++ b/src/components/edit/shared/BufferRadius.js
@@ -35,11 +35,12 @@ const BufferRadius = ({
             {showBuffer && (
                 <NumberField
                     label={i18n.t('Radius in meters')}
-                    value={radius || ''}
+                    value={Number.isInteger(radius) ? radius : ''}
                     disabled={disabled}
                     onChange={value =>
                         setBufferRadius(value !== '' ? parseInt(value, 10) : '')
                     }
+                    min={0}
                 />
             )}
         </div>


### PR DESCRIPTION
This PR sets the min buffer radius to 0, and also allows the value 0 to be shown. 

![ezgif com-gif-maker (8)](https://user-images.githubusercontent.com/548708/110653513-9dbad000-81bd-11eb-8a9c-66ed6026afc3.gif)
