### PR TITLE
fix: don't pass empty feature array for ee layers

### DIFF
--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -36,6 +36,17 @@ const earthEngineLoader = async config => {
                 },
             ];
         }
+
+        if (!features.length) {
+            alerts = [
+                {
+                    warning: true,
+                    message: `${i18n.t('Selected org units')}: ${i18n.t(
+                        'No coordinates found'
+                    )}`,
+                },
+            ];
+        }
     }
 
     if (typeof config.config === 'string') {

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -80,6 +80,8 @@ const earthEngineLoader = async config => {
     } = layer;
 
     const period = getPeriodNameFromFilter(filter);
+    const data =
+        Array.isArray(features) && features.length ? features : undefined;
 
     const groups =
         band && Array.isArray(bands) && bands.length
@@ -110,7 +112,7 @@ const earthEngineLoader = async config => {
         ...layer,
         legend,
         aggregationType,
-        data: features,
+        data,
         alerts,
         isLoaded: true,
         isExpanded: true,


### PR DESCRIPTION
For some org unit selections, the features returned don't have geometry (this is the case for top level Sierra Leone in the demo db). 

If only this feature is returned the data features array will be empty. I've added an extra check so we don't pass empty feature arrays. The EE API requires at least on feature in a collection. 

This PR removes this error message: 

<img width="416" alt="Screenshot 2021-03-10 at 17 16 31" src="https://user-images.githubusercontent.com/548708/110662252-9dbece00-81c5-11eb-905a-8457b751cc64.png">

and adds this message: 

<img width="451" alt="Screenshot 2021-03-10 at 17 44 40" src="https://user-images.githubusercontent.com/548708/110665268-79b0bc00-81c8-11eb-80c6-a690bc943303.png">
