### PR TITLE
fix: include org unit path on drill down/up

### DIFF
--- a/src/util/map.js
+++ b/src/util/map.js
@@ -67,16 +67,17 @@ export const toGeoJson = organisationUnits =>
                 geometry.coordinates.length
         );
 
-// TODO: parentGraph is not used
 export const drillUpDown = (layerConfig, parentId, parentGraph, level) => ({
     ...layerConfig,
     rows: [
         {
             dimension: dimConf.organisationUnit.objectName,
-            items: [{ id: parentId }, { id: 'LEVEL-' + level }],
+            items: [
+                { id: parentId, path: `${parentGraph}/${parentId}` },
+                { id: 'LEVEL-' + level },
+            ],
         },
     ],
-    parentGraphMap: {},
 });
 
 // Called when plugin maps enter or exit fullscreen


### PR DESCRIPTION
This PR fixes an issue where parent org unit was not checked in the org unit tree after drill down/up. The fix as to include the org unit path when updating `rows`. 

After this PR: 
<img width="593" alt="Screenshot 2021-03-11 at 13 26 40" src="https://user-images.githubusercontent.com/548708/110787280-728fb980-826d-11eb-9ad0-bcad8e8af1d1.png">
