### PR TITLE
fix: define name before it's used

### DIFF
--- a/src/loaders/facilityLoader.js
+++ b/src/loaders/facilityLoader.js
@@ -46,6 +46,8 @@ const facilityLoader = async config => {
         facilitiesReq,
     ]);
 
+    const name = i18n.t('Facilities');
+
     if (groupSet && facilities) {
         // Convert API response to GeoJSON features
         features = facilities.map(facility => {
@@ -66,8 +68,6 @@ const facilityLoader = async config => {
             legend.explanation = [`${areaRadius} ${'m'} ${'buffer'}`];
         }
     }
-
-    const name = i18n.t('Facilities');
 
     return {
         ...config,


### PR DESCRIPTION
Fixes an issue where name was used before it was defined. It probably worked before because const was transpiled to var. 