### PR TITLE
chore: don't make opacity required in layer toolbar

### DIFF
--- a/src/components/layers/toolbar/LayerToolbar.js
+++ b/src/components/layers/toolbar/LayerToolbar.js
@@ -56,7 +56,7 @@ export const LayerToolbar = ({
 };
 
 LayerToolbar.propTypes = {
-    opacity: PropTypes.number.isRequired,
+    opacity: PropTypes.number,
     isVisible: PropTypes.bool,
     toggleLayerVisibility: PropTypes.func.isRequired,
     onOpacityChange: PropTypes.func.isRequired,


### PR DESCRIPTION
Opacity might be missing in older analytical objects. 