### PR TITLE
fix: don't use const with arrow function for maps plugin

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -238,7 +238,7 @@ const PluginContainer = () => {
     };
 };
 
-const mapPlugin = new PluginContainer();
+const mapPlugin = PluginContainer();
 
 global.mapPlugin = mapPlugin;
 

--- a/src/map.js
+++ b/src/map.js
@@ -15,7 +15,7 @@ import { translateConfig } from './util/favorites';
 import { apiVersion } from './constants/settings';
 import { defaultBasemaps } from './constants/basemaps';
 
-const PluginContainer = () => {
+const pluginContainer = () => {
     let _configs = [];
     let _components = {};
     let _isReady = false;
@@ -238,7 +238,7 @@ const PluginContainer = () => {
     };
 };
 
-const mapPlugin = PluginContainer();
+const mapPlugin = pluginContainer();
 
 global.mapPlugin = mapPlugin;
 

--- a/src/map.js
+++ b/src/map.js
@@ -15,7 +15,7 @@ import { translateConfig } from './util/favorites';
 import { apiVersion } from './constants/settings';
 import { defaultBasemaps } from './constants/basemaps';
 
-const pluginContainer = () => {
+function PluginContainer() {
     let _configs = [];
     let _components = {};
     let _isReady = false;
@@ -236,9 +236,9 @@ const pluginContainer = () => {
         unmount,
         remove: unmount,
     };
-};
+}
 
-const mapPlugin = pluginContainer();
+const mapPlugin = new PluginContainer();
 
 global.mapPlugin = mapPlugin;
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10684

The map plugin us created using `NEW`, and it is not working after upgrading the webpack/transpiler setup in #1565

The plugin loads fine after this PR: 

<img width="530" alt="Screenshot 2021-03-12 at 14 48 52" src="https://user-images.githubusercontent.com/548708/110948812-1a76b700-8342-11eb-9c9c-a253c408efe5.png">

Before this PR: 

<img width="481" alt="Screenshot 2021-03-12 at 14 34 28" src="https://user-images.githubusercontent.com/548708/110948755-0468f680-8342-11eb-99ee-311668295997.png">
