### PR TITLE
fix: reset coordinate field on program change

### DIFF
--- a/src/components/dataItem/CoordinateField.js
+++ b/src/components/dataItem/CoordinateField.js
@@ -25,7 +25,13 @@ export class CoordinateField extends Component {
         this.loadData();
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps) {
+        const { program, onChange } = this.props;
+
+        if (program !== prevProps.program) {
+            onChange('event');
+        }
+
         this.loadData();
     }
 
@@ -56,7 +62,7 @@ export class CoordinateField extends Component {
             <SelectField
                 label={i18n.t('Coordinate field')}
                 items={fields}
-                value={value || 'event'}
+                value={fields.find(f => f.id === value) ? value : 'event'}
                 onChange={field => onChange(field.id)}
                 className={className}
             />


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10721

Two fixes where applied: 

1. Check if the coordinate field exist before selecting it. An invalid value was accepted by Material UI, but not by the DHIS2 UI select field. 
2. Reset the coordinate field if the program is changed. 

I've checked that the coordinate field is kept when a saved map is loaded. 

After this PR:

![ezgif com-gif-maker (12)](https://user-images.githubusercontent.com/548708/111665071-b60c9980-8812-11eb-8edf-e80a201b782b.gif)
