### PR TITLE
fix: place map loading mask below favorites dialog (DHIS2-10801)

### DIFF
--- a/src/components/map/MapLoadingMask.js
+++ b/src/components/map/MapLoadingMask.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { ComponentCover, CenteredContent, CircularLoader } from '@dhis2/ui';
+import styles from './styles/MapLoadingMask.module.css';
 
 const MapLoadingMask = () => (
-    <ComponentCover translucent>
+    <ComponentCover translucent className={styles.cover}>
         <CenteredContent>
             <CircularLoader />
         </CenteredContent>

--- a/src/components/map/styles/MapLoadingMask.module.css
+++ b/src/components/map/styles/MapLoadingMask.module.css
@@ -1,0 +1,9 @@
+/* 
+  TODO: 
+  Remove z-index style after @dhis2/d2-ui-favorites-dialog is upgraded 
+  from MUI to @dhis2/ui (DHIS2-10801) 
+  https://github.com/dhis2/d2-ui/blob/master/packages/favorites-dialog/src/Favorites.js
+*/
+.cover {
+    z-index: 1299 !important;
+}


### PR DESCRIPTION
Temporarily fixes: https://jira.dhis2.org/browse/DHIS2-10801

This fix in temporary until the favorites dialog (opened from the file menu) is upgraded from MUI to DHIS2 UI. 
The DHIS2 UI  ComponentCover has a z-index of 2000, while the MUI dialog uses 1300. 

As a general rule, we should not uses "!important" to override styles, but it was the only way to change the ordering without creating a custom cover component. 

After this PR: 

<img width="1452" alt="Screenshot 2021-03-29 at 12 30 04" src="https://user-images.githubusercontent.com/548708/112825509-1eb60a80-908c-11eb-870a-235c26f90d3f.png">

Before this PR: 

![image (1)](https://user-images.githubusercontent.com/548708/112825590-41e0ba00-908c-11eb-94e5-1a87be7d2948.png)

