### PR TITLE
fix: set max page size for event analytics (DHIS2-10807)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-03-11T09:23:04.866Z\n"
-"PO-Revision-Date: 2021-03-11T09:23:04.866Z\n"
+"POT-Creation-Date: 2021-03-30T11:15:14.675Z\n"
+"PO-Revision-Date: 2021-03-30T11:15:14.675Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -1294,6 +1294,9 @@ msgid "An unknown error occurred while reading layer data"
 msgstr ""
 
 msgid "Event"
+msgstr ""
+
+msgid "Displaying first {{pageSize}} events out of {{total}}"
 msgstr ""
 
 msgid "No data found"

--- a/src/constants/layers.js
+++ b/src/constants/layers.js
@@ -63,6 +63,8 @@ export const getThematicMapTypes = () => [
 ];
 
 /* EVENT LAYER */
+export const EVENT_CLIENT_PAGE_SIZE = 500000;
+export const EVENT_SERVER_CLUSTER_COUNT = 2000;
 export const EVENT_COLOR = '#333333';
 export const EVENT_RADIUS = 6;
 export const EVENT_BUFFER = 100;


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10807

Allows us to show more than 50 events in a map layer.  Max number of events loaded by the client is set to 500,000 - we show a warning if the total number is higher. 

After this PR:

<img width="1143" alt="Screenshot 2021-03-24 at 11 06 48" src="https://user-images.githubusercontent.com/548708/112292760-b634eb00-8c91-11eb-9dee-aceeeb4636d2.png">

(500 is only for illustration, it is 500000)
<img width="950" alt="Screenshot 2021-03-30 at 13 23 05" src="https://user-images.githubusercontent.com/548708/112981194-209acf00-915b-11eb-9409-4301cb08896f.png">

Before this PR:

<img width="1144" alt="Screenshot 2021-03-24 at 11 08 18" src="https://user-images.githubusercontent.com/548708/112292793-bfbe5300-8c91-11eb-9e9e-a57e17ab9a31.png">
