### PR TITLE
fix: reduce event page size to 100k

### DIFF
--- a/src/constants/layers.js
+++ b/src/constants/layers.js
@@ -63,7 +63,7 @@ export const getThematicMapTypes = () => [
 ];
 
 /* EVENT LAYER */
-export const EVENT_CLIENT_PAGE_SIZE = 500000;
+export const EVENT_CLIENT_PAGE_SIZE = 100000;
 export const EVENT_SERVER_CLUSTER_COUNT = 2000;
 export const EVENT_COLOR = '#333333';
 export const EVENT_RADIUS = 6;


### PR DESCRIPTION
This PR reduces the number of events that can be downloaded in one request to 100k. 

The backend is slow returning more than 100k events due to partitioning. Will be improved in 2.37. 
Maps app can have difficulties showing more than 100k when not clustered. 