### PR TITLE
fix: load all translations by preventing d2-i18n dual package hazard and upgrading dhis2/analytics [DHIS2-10846]

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
         "analyze-bundle": "webpack --profile --json --progress > .webpack-profile.json && webpack-bundle-analyzer .webpack-profile.json"
     },
     "dependencies": {
-        "@dhis2/analytics": "^16.0.13",
+        "@dhis2/analytics": "^16.0.18",
         "@dhis2/app-runtime": "^2.8.0",
-        "@dhis2/d2-i18n": "^1.1.0",
+        "@dhis2/d2-i18n": "<1.1.0",
         "@dhis2/d2-ui-core": "^7.1.6",
         "@dhis2/d2-ui-interpretations": "^7.1.6",
         "@dhis2/d2-ui-org-unit-dialog": "^7.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,10 +1255,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@dhis2/analytics@^16.0.13":
-  version "16.0.13"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-16.0.13.tgz#2be86f4734d52d1416262a1007c3ffb7d42bfc59"
-  integrity sha512-qhjrhDrtm+fMZwLdqvPTT1yfsUQLbgkXuydahwDL30/W+DRWEDlHkoXhb+5aLQHyRRQr8DOHA8IxRT8DLhWCeQ==
+"@dhis2/analytics@^16.0.18":
+  version "16.0.18"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-16.0.18.tgz#c082011ed10a02fb2b30e293d4169748477b4cd9"
+  integrity sha512-yTBtzLzonFCm0un/yEkaNa7/mFnXKLOc+ytZvmr2R61Rmsp+RNUuMFzg5wSVimvyEwAhUI5HAcuRlbysIrJsNQ==
   dependencies:
     "@dhis2/d2-ui-favorites-dialog" "^7.1.5"
     "@dhis2/d2-ui-org-unit-dialog" "^7.1.5"
@@ -1394,7 +1394,15 @@
     moment "^2.22.1"
     rimraf "^2.6.2"
 
-"@dhis2/d2-i18n@^1.0.5", "@dhis2/d2-i18n@^1.1.0":
+"@dhis2/d2-i18n@<1.1.0":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.6.tgz#2914be8acf296f3a6bf7b51c76c46da6a120b0ff"
+  integrity sha512-7YdA4ppFosjuyf7ZMm47BrdsA5TWLM9lmS0lUPgjcCVeeWfUgagqzf4W5JGB9XQ3w1vzK+yy5zH2Ij8IgRAGhA==
+  dependencies:
+    i18next "^10.3"
+    moment "^2.24.0"
+
+"@dhis2/d2-i18n@^1.0.5":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.1.0.tgz#ec777c5091f747e4c5aa4f9801c62ba4d1ef3d16"
   integrity sha512-x3u58goDQsMfBzy50koxNrJjofJTtjRZOfz6f6Py/wMMJfp/T6vZjWMQgcfWH0JrV6d04K1RTt6bI05wqsVQvg==


### PR DESCRIPTION
Some library translations don't load because there were multiple copies of d2-i18n (both cjs and es).  This downgrades d2-i18n to before the es build was included, and upgrades `@dhis2/analytics` to latest in order to ensure translations are loaded correctly.