### PR TITLE
fix: don't check event count when styling by data item (DHIS2-10867)

### DIFF
--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -96,11 +96,12 @@ const loadEventLayer = async config => {
     // Delete serverCluster option if previously set
     delete config.serverCluster;
 
-    if (spatialSupport && eventClustering) {
+    // Check if events should be clustered on the server or the client
+    // Style by data item is only supported in the client (donuts)
+    if (spatialSupport && eventClustering && !styleDataItem) {
         const response = await getCount(analyticsRequest);
         config.bounds = getBounds(response.extent);
-        config.serverCluster =
-            useServerCluster(response.count) && !styleDataItem;
+        config.serverCluster = useServerCluster(response.count);
     }
 
     if (!config.serverCluster) {


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10867

Counting the number of events can be heavy for the backend, and should only be performed when needed. We check the event count to decide if the events should be clustered on the server or the client. When the user is "styling by data item" we don't need to check the event count, as this is only supported using client donut clusters. 

 "config.bounds" is only needed for server cluster when we zoom the map to the combined bounds of all the events. 