### PR TITLE
fix: show color in data table for thematic layers (DHIS2-10872)

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -317,18 +317,17 @@ class DataTable extends Component {
                         <ColumnHeader type="string" {...props} />
                     )}
                 />
-                {isThematic ||
-                    (styleDataItem && (
-                        <Column
-                            dataKey="color"
-                            label={i18n.t('Color')}
-                            width={100}
-                            headerRenderer={props => (
-                                <ColumnHeader type="string" {...props} />
-                            )}
-                            cellRenderer={ColorCell}
-                        />
-                    ))}
+                {(isThematic || styleDataItem) && (
+                    <Column
+                        dataKey="color"
+                        label={i18n.t('Color')}
+                        width={100}
+                        headerRenderer={props => (
+                            <ColumnHeader type="string" {...props} />
+                        )}
+                        cellRenderer={ColorCell}
+                    />
+                )}
 
                 {isEarthEngine &&
                     EarthEngineColumns({ aggregationType, legend, data })}


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10872

This PR will include color in the data table for thematic layer. It was present earlier, but a bug from 2.35 removed it. 

After this PR: 
<img width="832" alt="Screenshot 2021-04-08 at 17 57 21" src="https://user-images.githubusercontent.com/548708/114058789-103dcf00-9894-11eb-98ca-7a63102966f6.png">

Before this PR: 
<img width="830" alt="Screenshot 2021-04-08 at 17 58 09" src="https://user-images.githubusercontent.com/548708/114058810-1633b000-9894-11eb-9021-ae13e1c9273a.png">

