### PR TITLE
fix: set default legend set for event layers (DHIS2-10821)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-03-30T11:15:14.675Z\n"
-"PO-Revision-Date: 2021-03-30T11:15:14.675Z\n"
+"POT-Creation-Date: 2021-04-09T13:07:47.994Z\n"
+"PO-Revision-Date: 2021-04-09T13:07:47.994Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -283,6 +283,9 @@ msgstr ""
 msgid "No organisation units are selected."
 msgstr ""
 
+msgid "No legend set is selected"
+msgstr ""
+
 msgid "Event status"
 msgstr ""
 
@@ -332,9 +335,6 @@ msgid "Program indicator is required"
 msgstr ""
 
 msgid "Period is required"
-msgstr ""
-
-msgid "No legend set is selected"
 msgstr ""
 
 msgid "Indicator"

--- a/src/components/classification/NumericLegendStyle.js
+++ b/src/components/classification/NumericLegendStyle.js
@@ -18,6 +18,7 @@ const NumericLegendStyle = props => {
         mapType,
         method,
         dataItem,
+        legendSet,
         setClassification,
         setLegendSet,
         legendSetError,
@@ -31,14 +32,20 @@ const NumericLegendStyle = props => {
         // Set default classification method
         if (!method) {
             // Use predefined legend if defined for data item
-            if (dataItem && dataItem.legendSet) {
-                setClassification(CLASSIFICATION_PREDEFINED);
-                setLegendSet(dataItem.legendSet);
-            } else {
-                setClassification(CLASSIFICATION_EQUAL_INTERVALS);
-            }
+            setClassification(
+                dataItem && dataItem.legendSet
+                    ? CLASSIFICATION_PREDEFINED
+                    : CLASSIFICATION_EQUAL_INTERVALS
+            );
         }
-    }, [method, dataItem, setClassification, setLegendSet]);
+    }, [method, dataItem, setClassification]);
+
+    useEffect(() => {
+        // Set legend set defined for data item in use by default
+        if (isPredefined && !legendSet && dataItem.legendSet) {
+            setLegendSet(dataItem.legendSet);
+        }
+    }, [isPredefined, legendSet, dataItem, setLegendSet]);
 
     return (
         <div style={style}>

--- a/src/components/dataItem/StyleByDataItem.js
+++ b/src/components/dataItem/StyleByDataItem.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
+import { Help } from '@dhis2/ui';
 import DataItemSelect from './DataItemSelect';
 import DataItemStyle from './DataItemStyle';
 import { setStyleDataItem } from '../../actions/layerEdit';
@@ -14,6 +15,7 @@ export const StyleByDataItem = ({
     programStage,
     styleDataItem,
     setStyleDataItem,
+    error,
 }) => (
     <div>
         <DataItemSelect
@@ -34,6 +36,7 @@ export const StyleByDataItem = ({
         {styleDataItem && (
             <DataItemStyle key="style" dataItem={styleDataItem} />
         )}
+        {error && <Help error>{error}</Help>}
     </div>
 );
 
@@ -48,6 +51,7 @@ StyleByDataItem.propTypes = {
         id: PropTypes.string.isRequired,
     }),
     setStyleDataItem: PropTypes.func.isRequired,
+    error: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
 };
 
 export default connect(

--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -20,6 +20,7 @@ import {
     EVENT_COLOR,
     EVENT_RADIUS,
     EVENT_BUFFER,
+    CLASSIFICATION_PREDEFINED,
 } from '../../../constants/layers';
 import styles from '../styles/LayerDialog.module.css';
 
@@ -57,6 +58,8 @@ export class EventDialog extends Component {
         eventPointColor: PropTypes.string,
         eventPointRadius: PropTypes.number,
         filters: PropTypes.array,
+        legendSet: PropTypes.object,
+        method: PropTypes.number,
         onLayerValidation: PropTypes.func.isRequired,
         program: PropTypes.shape({
             id: PropTypes.string.isRequired,
@@ -137,6 +140,7 @@ export class EventDialog extends Component {
             programStage,
             rows = [],
             startDate,
+            legendSet,
         } = this.props;
 
         const {
@@ -159,6 +163,7 @@ export class EventDialog extends Component {
             programStageError,
             periodError,
             orgUnitsError,
+            legendSetError,
         } = this.state;
 
         const period = getPeriodFromFilters(filters) || {
@@ -325,7 +330,9 @@ export class EventDialog extends Component {
                             </div>
                             <div className={styles.flexColumn}>
                                 {program ? (
-                                    <StyleByDataItem />
+                                    <StyleByDataItem
+                                        error={!legendSet && legendSetError}
+                                    />
                                 ) : (
                                     <div className={styles.notice}>
                                         <NoticeBox>
@@ -361,6 +368,8 @@ export class EventDialog extends Component {
             filters,
             startDate,
             endDate,
+            method,
+            legendSet,
         } = this.props;
 
         const period = getPeriodFromFilters(filters) || {
@@ -395,6 +404,14 @@ export class EventDialog extends Component {
                 'orgUnitsError',
                 i18n.t('No organisation units are selected.'),
                 'orgunits'
+            );
+        }
+
+        if (method === CLASSIFICATION_PREDEFINED && !legendSet) {
+            return this.setErrorState(
+                'legendSetError',
+                i18n.t('No legend set is selected'),
+                'style'
             );
         }
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10821

This PR makes it required to select a legend set, if predefined legend is selected for "style by data item" for event layer. It will autoselect the legend set associated with the data item, also when the user is switching between automatic and predefined legends. 

After this PR: 

<img width="275" alt="Screenshot 2021-04-09 at 15 30 37" src="https://user-images.githubusercontent.com/548708/114187694-9287cb00-9948-11eb-8f0b-e1d8345f484a.png">

This error will only show if the data item don't have a legend set defined, and no selection is made. 

![ezgif com-gif-maker](https://user-images.githubusercontent.com/548708/114188134-1c379880-9949-11eb-8f09-8059b2b6cce6.gif)

Previously, the legend set select would be empty when switching back from automatic. 