### PR TITLE
fix: upgrade landcover dataset in maps v33 (DHIS2-10912)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-07T12:04:18.927Z\n"
-"PO-Revision-Date: 2020-09-07T12:04:18.927Z\n"
+"POT-Creation-Date: 2021-04-15T19:10:59.934Z\n"
+"PO-Revision-Date: 2021-04-15T19:10:59.934Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -201,7 +201,7 @@ msgstr ""
 msgid "Max °C"
 msgstr ""
 
-msgid "17 distinct landcover types collected from satellites."
+msgid "Distinct landcover types collected from satellites."
 msgstr ""
 
 msgid ""
@@ -954,12 +954,6 @@ msgstr ""
 msgid "Landcover"
 msgstr ""
 
-msgid "Distinct landcover types collected from satellites."
-msgstr ""
-
-msgid "Water"
-msgstr ""
-
 msgid "Evergreen Needleleaf forest"
 msgstr ""
 
@@ -1008,7 +1002,7 @@ msgstr ""
 msgid "Barren or sparsely vegetated"
 msgstr ""
 
-msgid "Unclassified"
+msgid "Water"
 msgstr ""
 
 msgid "Access denied"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "33.0.36",
+    "version": "33.0.37",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/components/edit/EarthEngineDialog.js
+++ b/src/components/edit/EarthEngineDialog.js
@@ -57,10 +57,10 @@ const getDatasets = () => ({
         minLabel: i18n.t('Min °C'),
         maxLabel: i18n.t('Max °C'),
     },
-    'MODIS/051/MCD12Q1': {
+    'MODIS/006/MCD12Q1': {
         // Landcover
         description: i18n.t(
-            '17 distinct landcover types collected from satellites.'
+            'Distinct landcover types collected from satellites.'
         ),
         valueLabel: i18n.t('Select year'),
     },
@@ -355,7 +355,13 @@ class EarthEngineDialog extends Component {
 
 export default connect(
     null,
-    { setParams, setFilter, setPeriodName },
+    {
+        setParams,
+        setFilter,
+        setPeriodName,
+    },
     null,
-    { withRef: true }
+    {
+        withRef: true,
+    }
 )(withStyles(styles)(EarthEngineDialog));

--- a/src/epics/earthEngine.js
+++ b/src/epics/earthEngine.js
@@ -108,10 +108,10 @@ const collections = {
             )
         );
     },
-    'MODIS/051/MCD12Q1': resolve => {
+    'MODIS/006/MCD12Q1': resolve => {
         // Landcover
         const imageCollection = ee
-            .ImageCollection('MODIS/051/MCD12Q1')
+            .ImageCollection('MODIS/006/MCD12Q1')
             .sort('system:time_start', false);
 
         const featureCollection = ee

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -90,14 +90,14 @@ const getDatasets = () => ({
                 'https://explorer.earthengine.google.com/#detail/MODIS%2FMOD11A2',
         },
     },
-    'MODIS/051/MCD12Q1': {
+    'MODIS/006/MCD12Q1': {
         name: i18n.t('Landcover'),
-        band: 'Land_Cover_Type_1',
+        band: 'LC_Type1',
         params: {
-            min: 0,
+            min: 1,
             max: 17,
             palette:
-                'aec3d6,162103,235123,399b38,38eb38,39723b,6a2424,c3a55f,b76124,d99125,92af1f,10104c,cdb400,cc0202,332808,d7cdcc,f7e174,743411',
+                '162103,235123,399b38,38eb38,39723b,6a2424,c3a55f,b76124,d99125,92af1f,10104c,cdb400,cc0202,332808,d7cdcc,f7e174,aec3d6',
         },
         mask: false,
         legend: {
@@ -106,79 +106,76 @@ const getDatasets = () => ({
             ),
             source: 'NASA LP DAAC / Google Earth Engine',
             sourceUrl:
-                'https://code.earthengine.google.com/dataset/MODIS/051/MCD12Q1',
+                'https://developers.google.com/earth-engine/datasets/catalog/MODIS_006_MCD12Q1',
             items: [
+                // http://www.eomf.ou.edu/static/IGBP.pdf
                 {
-                    color: '#aec3d6',
-                    name: i18n.t('Water'),
-                },
-                {
-                    color: '#162103',
                     name: i18n.t('Evergreen Needleleaf forest'),
+                    color: '#162103',
                 },
                 {
-                    color: '#235123',
                     name: i18n.t('Evergreen Broadleaf forest'),
+                    color: '#235123',
                 },
                 {
-                    color: '#399b38',
                     name: i18n.t('Deciduous Needleleaf forest'),
+                    color: '#399b38',
                 },
                 {
-                    color: '#38eb38',
                     name: i18n.t('Deciduous Broadleaf forest'),
+                    color: '#38eb38',
                 },
                 {
-                    color: '#39723b',
                     name: i18n.t('Mixed forest'),
+                    color: '#39723b',
                 },
                 {
-                    color: '#6a2424',
                     name: i18n.t('Closed shrublands'),
+                    color: '#6a2424',
                 },
                 {
-                    color: '#c3a55f',
                     name: i18n.t('Open shrublands'),
+                    color: '#c3a55f',
                 },
                 {
-                    color: '#b76124',
                     name: i18n.t('Woody savannas'),
+                    color: '#b76124',
                 },
                 {
-                    color: '#d99125',
                     name: i18n.t('Savannas'),
+                    color: '#d99125',
                 },
                 {
-                    color: '#92af1f',
                     name: i18n.t('Grasslands'),
+                    color: '#92af1f',
                 },
                 {
-                    color: '#10104c',
                     name: i18n.t('Permanent wetlands'),
+                    color: '#10104c',
                 },
                 {
-                    color: '#cdb400',
                     name: i18n.t('Croplands'),
+                    color: '#cdb400',
                 },
                 {
-                    color: '#cc0202',
                     name: i18n.t('Urban and built-up'),
+                    color: '#cc0202',
                 },
                 {
-                    color: '#332808',
                     name: i18n.t('Cropland/Natural vegetation mosaic'),
+                    color: '#332808',
                 },
                 {
-                    color: '#d7cdcc',
                     name: i18n.t('Snow and ice'),
+                    color: '#d7cdcc',
                 },
                 {
-                    color: '#f7e174',
                     name: i18n.t('Barren or sparsely vegetated'),
+                    color: '#f7e174',
                 },
                 {
-                    color: '#743411',
-                    name: i18n.t('Unclassified'),
+                    name: i18n.t('Water'),
+                    color: '#aec3d6',
                 },
             ],
         },

--- a/src/reducers/layers.js
+++ b/src/reducers/layers.js
@@ -83,7 +83,7 @@ const defaultLayers = () => [
     },
     {
         layer: 'earthEngine',
-        datasetId: 'MODIS/051/MCD12Q1',
+        datasetId: 'MODIS/006/MCD12Q1',
         type: i18n.t('Landcover'),
         img: 'images/landcover.png',
         opacity: 0.9,


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-10912

The Landcover dataset we used in 2.33 is no longer supported, and this PR changes the dataset to a new version.

Note that we have improved the Earth Engine code in 2.36, and the dataset id 'MODIS/006/MCD12Q1' is no longer at multiple places in the code. This si not backported as it required a large refactor. 

After this PR the landcover layer shows: 

<img width="827" alt="Screenshot 2021-04-15 at 21 27 04" src="https://user-images.githubusercontent.com/548708/114927110-6af59e80-9e31-11eb-9201-c387e5d74d65.png">
