### PR TITLE
chore: tests for adding map layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,34 @@
 
 DHIS2 Maps App
 
-Travis CI: https://travis-ci.com/dhis2/maps-app
-
 ## Running Tests
 
-We run two types of tests on this project, **unit** and **integration/browser**. Both are run automatically by Travis.
+There are two types of tests on this project, **unit** and **integration/browser**. Both are run automatically on CI on PRs using Github actions.
+
+### Linting and unit tests
 
 ```sh
-# Linting and unit tests
 > yarn lint # Evaluate code linting rules
 > yarn test # Run JEST for unit testing
-
-# Before running browser tests, start a development server at http://localhost:8082 or another addess exported as CYPRESS_ROOT_URL
-> yarn start
-> export CYPRESS_ROOT_URL=http://localhost:8082
-> export CYPRESS_EXTERNAL_API=http://localhost:8080 # Tell Cypress where the DHIS2 core server lives.  Must match application's DHIS2 config, running server only required for E2E tests
-
-# Browser tests
-> yarn cy:stub:open # Run interactive GUI Cypress browser tests (against a stubbed backend network)
-> yarn cy:stub:run # Run headless Cypress browser tests (against a stubbed backend network)
-> yarn cy:e2e:open # Run interactive GUI Cypress browser tests against a real backend
-> yarn cy:e2e:run # Run headless Cypress browser tests against a real backend
-> yarn cy:e2e:update # Run headless Cypress browser tests against a real backend an generate new netowrk stubbing fixtures
 ```
 
-Cypress tests live at [cypress/integration/\*\*.spec.js](./cypress/integration/). Network fixtures are in the [cypress/fixtures](./cypress/fixtures/) directory and **should** be committed to source control.
+### Browser tests (Cypress)
+
+To run the Cypress tests locally, first set up the `cypress.env.json` file at the root of the repository. `dhis2_base_url` should be set to the DHIS2 api instance.
+
+```
+{
+    "dhis2_username": "admin",
+    "dhis2_password": "district",
+    "dhis2_base_url": "http://localhost:8080"
+}
+```
+
+Use the following commands to run the tests:
+
+```
+> yarn cy:open # runs tests in interactive mode
+> yarn cy:run # runs tests in headless browser mode
+```
+
+Cypress tests are located at [cypress/integration/\*\*.cy.js](./cypress/integration/).

--- a/cypress/elements/boundary_layer.js
+++ b/cypress/elements/boundary_layer.js
@@ -1,0 +1,12 @@
+import { Layer } from './layer';
+
+export class BoundaryLayer extends Layer {
+    selectOuLevel(level) {
+        cy.get('[data-test="orgunitlevelselect"]').click();
+
+        cy.contains(level).click();
+        cy.get('body').click(); // Close the modal menu
+
+        return this;
+    }
+}

--- a/cypress/elements/event_layer.js
+++ b/cypress/elements/event_layer.js
@@ -7,4 +7,19 @@ export class EventLayer extends Layer {
 
         return this;
     }
+
+    selectStage(stage) {
+        cy.get('[data-test="programstageselect"]').click();
+        cy.contains(stage).click();
+
+        return this;
+    }
+
+    validateStage(stage) {
+        cy.get('[data-test="programstageselect"]')
+            .contains(stage)
+            .should('be.visible');
+
+        return this;
+    }
 }

--- a/cypress/elements/event_layer.js
+++ b/cypress/elements/event_layer.js
@@ -1,0 +1,10 @@
+import { Layer } from './layer';
+
+export class EventLayer extends Layer {
+    selectProgram(program) {
+        cy.get('[data-test="programselect"]').click();
+        cy.contains(program).click();
+
+        return this;
+    }
+}

--- a/cypress/elements/facility_layer.js
+++ b/cypress/elements/facility_layer.js
@@ -1,0 +1,21 @@
+import { Layer } from './layer';
+
+export class FacilityLayer extends Layer {
+    selectGroupSet(groupSet) {
+        cy.get('[data-test="orgunitgroupsetselect"]').click();
+
+        cy.contains(groupSet).click();
+        cy.get('body').click(); // Close the modal menu
+
+        return this;
+    }
+
+    selectOuLevel(level) {
+        cy.get('[data-test="orgunitlevelselect"]').click();
+
+        cy.contains(level).click();
+        cy.get('body').click(); // Close the modal menu
+
+        return this;
+    }
+}

--- a/cypress/elements/layer.js
+++ b/cypress/elements/layer.js
@@ -31,16 +31,22 @@ export class Layer {
         }
     }
 
-    validateCard(title, items) {
+    validateCardTitle(title) {
         cy.get('[data-test="layercard"]')
             .contains(title)
             .should('be.visible');
 
+        return this;
+    }
+
+    validateCardItems(items) {
         items.forEach(item => {
             cy.get('[data-test="layercard"]')
                 .find('[data-test="layerlegend-item"]')
                 .contains(item)
                 .should('be.visible');
         });
+
+        return this;
     }
 }

--- a/cypress/elements/layer.js
+++ b/cypress/elements/layer.js
@@ -1,0 +1,46 @@
+export class Layer {
+    openDialog(layer) {
+        cy.get('button')
+            .contains('Add layer')
+            .click();
+        cy.get(`[data-test="addlayeritem-${layer}"]`).click();
+
+        return this;
+    }
+
+    selectTab(tab) {
+        cy.get('[data-test="dhis2-uicore-tabbar-tabs"]')
+            .find('button')
+            .contains(tab)
+            .click();
+
+        return this;
+    }
+
+    addToMap() {
+        cy.get('[data-test="dhis2-uicore-modalactions"]')
+            .contains('Add layer')
+            .click();
+    }
+
+    validateDialogClosed(closed) {
+        if (closed) {
+            cy.get('[data-test="dhis2-uicore-card"]').should('not.exist');
+        } else {
+            cy.get('[data-test="dhis2-uicore-card"]').should('be.visible');
+        }
+    }
+
+    validateCard(title, items) {
+        cy.get('[data-test="layercard"]')
+            .contains(title)
+            .should('be.visible');
+
+        items.forEach(item => {
+            cy.get('[data-test="layercard"]')
+                .find('[data-test="layerlegend-item"]')
+                .contains(item)
+                .should('be.visible');
+        });
+    }
+}

--- a/cypress/elements/thematic_layer.js
+++ b/cypress/elements/thematic_layer.js
@@ -1,0 +1,24 @@
+import { Layer } from './layer';
+
+export class ThematicLayer extends Layer {
+    selectIndicatorGroup(indicatorGroup) {
+        cy.get('[data-test="indicatorgroupselect"]').click();
+        cy.contains(indicatorGroup).click();
+
+        return this;
+    }
+
+    selectIndicator(indicator) {
+        cy.get('[data-test="indicatorselect"]').click();
+        cy.contains(indicator).click();
+
+        return this;
+    }
+
+    selectPeriodType(periodType) {
+        cy.get('[data-test="periodtypeselect"]').click();
+        cy.contains(periodType).click();
+
+        return this;
+    }
+}

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,5 +1,0 @@
-{
-  "name": "Using fixtures to represent data",
-  "email": "hello@cypress.io",
-  "body": "Fixtures are a great way to mock data for responses to routes"
-}

--- a/cypress/integration/layers/boundarylayer.cy.js
+++ b/cypress/integration/layers/boundarylayer.cy.js
@@ -1,0 +1,29 @@
+import { BoundaryLayer } from '../../elements/boundary_layer';
+
+context('Boundary Layers', () => {
+    beforeEach(() => {
+        cy.visit('/');
+    });
+
+    const Layer = new BoundaryLayer();
+
+    it('shows error if no orgunit selected', () => {
+        Layer.openDialog('Boundaries').addToMap();
+
+        Layer.validateDialogClosed(false);
+
+        cy.contains('No organisation units are selected').should('be.visible');
+    });
+
+    it('adds a boundary layer', () => {
+        Layer.openDialog('Boundaries')
+            .selectOuLevel('District')
+            .addToMap();
+
+        Layer.validateDialogClosed(true);
+
+        // TODO: use visual snapshot testing to check the rendering of the map
+
+        Layer.validateCard('Boundaries', ['District']);
+    });
+});

--- a/cypress/integration/layers/boundarylayer.cy.js
+++ b/cypress/integration/layers/boundarylayer.cy.js
@@ -24,6 +24,7 @@ context('Boundary Layers', () => {
 
         // TODO: use visual snapshot testing to check the rendering of the map
 
-        Layer.validateCard('Boundaries', ['District']);
+        Layer.validateCardTitle('Boundaries');
+        Layer.validateCardItems(['District']);
     });
 });

--- a/cypress/integration/layers/eventlayer.cy.js
+++ b/cypress/integration/layers/eventlayer.cy.js
@@ -1,8 +1,9 @@
 import { EventLayer } from '../../elements/event_layer';
+import { EXTENDED_TIMEOUT } from '../../support/extendedTimeout';
 
 context('Event Layers', () => {
     beforeEach(() => {
-        cy.visit('/');
+        cy.visit('/', EXTENDED_TIMEOUT);
     });
 
     const Layer = new EventLayer();
@@ -18,10 +19,12 @@ context('Event Layers', () => {
     it('adds an event layer', () => {
         Layer.openDialog('Events')
             .selectProgram('Inpatient morbidity and mortality')
+            .validateStage('Inpatient morbidity and mortality')
             .addToMap();
 
         Layer.validateDialogClosed(true);
 
-        Layer.validateCard('Inpatient morbidity and mortality', ['Event']);
+        Layer.validateCardTitle('Inpatient morbidity and mortality');
+        Layer.validateCardItems(['Event']);
     });
 });

--- a/cypress/integration/layers/eventlayer.cy.js
+++ b/cypress/integration/layers/eventlayer.cy.js
@@ -1,0 +1,27 @@
+import { EventLayer } from '../../elements/event_layer';
+
+context('Event Layers', () => {
+    beforeEach(() => {
+        cy.visit('/');
+    });
+
+    const Layer = new EventLayer();
+
+    it('shows error if no program selected', () => {
+        Layer.openDialog('Events').addToMap();
+
+        Layer.validateDialogClosed(false);
+
+        cy.contains('Program is required').should('be.visible');
+    });
+
+    it('adds an event layer', () => {
+        Layer.openDialog('Events')
+            .selectProgram('Inpatient morbidity and mortality')
+            .addToMap();
+
+        Layer.validateDialogClosed(true);
+
+        Layer.validateCard('Inpatient morbidity and mortality', ['Event']);
+    });
+});

--- a/cypress/integration/layers/facilitylayer.cy.js
+++ b/cypress/integration/layers/facilitylayer.cy.js
@@ -1,0 +1,47 @@
+import { FacilityLayer } from '../../elements/facility_layer';
+
+context('Facility Layers', () => {
+    beforeEach(() => {
+        cy.visit('/');
+    });
+
+    const Layer = new FacilityLayer();
+
+    it('shows error if no group selected', () => {
+        Layer.openDialog('Facilities').addToMap();
+
+        Layer.validateDialogClosed(false);
+
+        cy.contains('Group set is required').should('be.visible');
+    });
+
+    it('shows error if no orgunit level selected', () => {
+        Layer.openDialog('Facilities')
+            .selectGroupSet('Facility Type')
+            .addToMap();
+
+        Layer.validateDialogClosed(false);
+
+        cy.contains('No organisation units are selected').should('be.visible');
+    });
+
+    it('adds a facilities layer', () => {
+        Layer.openDialog('Facilities')
+            .selectGroupSet('Facility Type')
+            .selectTab('Organisation Units')
+            .selectOuLevel('District')
+            .addToMap();
+
+        Layer.validateDialogClosed(true);
+
+        // TODO: use visual snapshot testing to check the rendering of the map
+
+        Layer.validateCard('Facilities', [
+            'Hospital',
+            'Clinic',
+            'CHP',
+            'CHC',
+            'MCHP',
+        ]);
+    });
+});

--- a/cypress/integration/layers/facilitylayer.cy.js
+++ b/cypress/integration/layers/facilitylayer.cy.js
@@ -36,12 +36,7 @@ context('Facility Layers', () => {
 
         // TODO: use visual snapshot testing to check the rendering of the map
 
-        Layer.validateCard('Facilities', [
-            'Hospital',
-            'Clinic',
-            'CHP',
-            'CHC',
-            'MCHP',
-        ]);
+        Layer.validateCardTitle('Facilities');
+        Layer.validateCardItems(['Hospital', 'Clinic', 'CHP', 'CHC', 'MCHP']);
     });
 });

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -1,0 +1,47 @@
+import { ThematicLayer } from '../../elements/thematic_layer';
+
+context('Thematic Layers', () => {
+    beforeEach(() => {
+        cy.visit('/');
+    });
+
+    const Layer = new ThematicLayer();
+
+    it('shows error if no indicator group selected', () => {
+        Layer.openDialog('Thematic').addToMap();
+
+        Layer.validateDialogClosed(false);
+
+        cy.contains('Indicator group is required').should('be.visible');
+    });
+
+    it('shows error if no indicator selected', () => {
+        Layer.openDialog('Thematic')
+            .selectIndicatorGroup('HIV')
+            .addToMap();
+
+        Layer.validateDialogClosed(false);
+        cy.contains('Indicator is required').should('be.visible');
+    });
+
+    it('adds a thematic layer', () => {
+        Layer.openDialog('Thematic')
+            .selectIndicatorGroup('HIV')
+            .selectIndicator('VCCT post-test counselling rate')
+            .selectTab('Period')
+            .selectPeriodType('Yearly')
+            .addToMap();
+
+        Layer.validateDialogClosed(true);
+
+        // TODO: use visual snapshot testing to check the rendering of the map
+
+        Layer.validateCard('VCCT post-test counselling rate', [
+            '70.2 - 76.72 (1)',
+            '76.72 - 83.24 (1)',
+            '83.24 - 89.76 (2)',
+            '89.76 - 96.28 (3)',
+            '96.28 - 102.8 (4)',
+        ]);
+    });
+});

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -36,7 +36,8 @@ context('Thematic Layers', () => {
 
         // TODO: use visual snapshot testing to check the rendering of the map
 
-        Layer.validateCard('VCCT post-test counselling rate', [
+        Layer.validateCardTitle('VCCT post-test counselling rate');
+        Layer.validateCardItems([
             '70.2 - 76.72 (1)',
             '76.72 - 83.24 (1)',
             '83.24 - 89.76 (2)',

--- a/cypress/support/extendedTimeout.js
+++ b/cypress/support/extendedTimeout.js
@@ -1,0 +1,1 @@
+export const EXTENDED_TIMEOUT = { timeout: 15000 };

--- a/src/components/core/SelectField.js
+++ b/src/components/core/SelectField.js
@@ -70,12 +70,7 @@ export const SelectField = props => {
             >
                 {items &&
                     items.map(({ id, name }) => (
-                        <Option
-                            key={id}
-                            value={String(id)}
-                            label={name}
-                            dataTest="selectfield-menuitem"
-                        />
+                        <Option key={id} value={String(id)} label={name} />
                     ))}
             </Select>
         </div>

--- a/src/components/edit/FacilityDialog.js
+++ b/src/components/edit/FacilityDialog.js
@@ -103,12 +103,7 @@ class FacilityDialog extends Component {
             <div data-test="facilitydialog">
                 <Tabs value={tab} onChange={tab => this.setState({ tab })}>
                     <Tab value="group">{i18n.t('Group Set')}</Tab>
-                    <Tab
-                        value="orgunits"
-                        dataTest="facilitydialog-tabs-orgunits"
-                    >
-                        {i18n.t('Organisation Units')}
-                    </Tab>
+                    <Tab value="orgunits">{i18n.t('Organisation Units')}</Tab>
                     <Tab value="style">{i18n.t('Style')}</Tab>
                 </Tabs>
                 <div className={styles.tabContent}>

--- a/src/components/indicator/IndicatorSelect.js
+++ b/src/components/indicator/IndicatorSelect.js
@@ -56,7 +56,7 @@ export class IndicatorSelect extends Component {
                 onChange={dataItem => onChange(dataItem, 'indicator')}
                 className={className}
                 errorText={!indicator && errorText ? errorText : null}
-                data-test="indicatorselect"
+                dataTest="indicatorselect"
             />
         );
     }

--- a/src/components/layers/overlays/AddLayerButton.js
+++ b/src/components/layers/overlays/AddLayerButton.js
@@ -13,7 +13,7 @@ const AddLayerButton = () => {
     return (
         <Fragment>
             <div className={styles.addLayerBtn} ref={buttonRef}>
-                <MenuButton onClick={toggleDialog} dataTest="addlayerbutton">
+                <MenuButton onClick={toggleDialog}>
                     <span className={styles.btnContent}>
                         <IconAddCircle24 />
                         {i18n.t('Add layer')}

--- a/src/components/orgunits/OrgUnitGroupSetSelect.js
+++ b/src/components/orgunits/OrgUnitGroupSetSelect.js
@@ -42,7 +42,7 @@ export class OrgUnitGroupSetSelect extends Component {
                 onChange={onChange}
                 errorText={!value && errorText ? errorText : null}
                 className={className}
-                data-test="orgunitgroupsetselect"
+                dataTest="orgunitgroupsetselect"
             />
         );
     }

--- a/src/components/program/ProgramSelect.js
+++ b/src/components/program/ProgramSelect.js
@@ -64,7 +64,7 @@ export class ProgramSelect extends Component {
                 onChange={this.onChange}
                 className={className}
                 errorText={!program && errorText ? errorText : null}
-                data-test="programselect"
+                dataTest="programselect"
             />
         );
     }

--- a/src/components/program/ProgramStageSelect.js
+++ b/src/components/program/ProgramStageSelect.js
@@ -69,7 +69,7 @@ export class ProgramStageSelect extends Component {
                 onChange={onChange}
                 className={className}
                 errorText={!programStage && errorText ? errorText : null}
-                data-test="programstageselect"
+                dataTest="programstageselect"
             />
         );
     }


### PR DESCRIPTION
Test adding map layers. It does not yet test the actual rendered map.

The files in the /elements folder are a first attempt at page objects. They are classes that hide complexity of interacting with the page so that the actual tests in the /integration folder read nicely. Most methods in the page objects return `this` so that the tests can chain the methods.

I'm not generally a big fan of complex class inheritance, but in the case of the page object layers, it made sense to me. Open to other ideas though.