### PR TITLE
fix: use hyphen in locale strings passed to the browser(DHIS2-11335)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "@dhis2/d2-ui-analytics": "^0.0.3",
         "@dhis2/d2-ui-core": "^7.1.6",
         "@dhis2/d2-ui-file-menu": "^7.1.6",
-        "@dhis2/d2-ui-interpretations": "^7.1.6",
+        "@dhis2/d2-ui-interpretations": "^7.3.1",
         "@dhis2/d2-ui-org-unit-dialog": "^7.1.6",
         "@dhis2/d2-ui-org-unit-tree": "^7.1.6",
         "@dhis2/maps-gl": "^1.8.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "35.0.19",
+    "version": "35.0.20",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/util/i18n.js
+++ b/src/util/i18n.js
@@ -13,6 +13,3 @@ export const configI18n = userSettings => {
 
     i18n.changeLanguage(uiLocale);
 };
-
-export const browserLocale = locale =>
-    locale && locale.includes('_') ? locale.replace('_', '-') : locale;

--- a/src/util/i18n.js
+++ b/src/util/i18n.js
@@ -13,3 +13,6 @@ export const configI18n = userSettings => {
 
     i18n.changeLanguage(uiLocale);
 };
+
+export const browserLocale = locale =>
+    locale && locale.includes('_') ? locale.replace('_', '-') : locale;

--- a/src/util/periods.js
+++ b/src/util/periods.js
@@ -11,9 +11,12 @@ import {
     timeSecond,
     timeMillisecond,
 } from 'd3-time';
+import { browserLocale } from './i18n';
 
 export const createPeriods = (locale, periodType, year) => {
-    const localePeriodGenerator = createPeriodGeneratorsForLocale(locale);
+    const localePeriodGenerator = createPeriodGeneratorsForLocale(
+        browserLocale(locale)
+    );
 
     const periodGenerator =
         localePeriodGenerator[`generate${periodType}PeriodsForYear`] ||

--- a/src/util/periods.js
+++ b/src/util/periods.js
@@ -11,11 +11,11 @@ import {
     timeSecond,
     timeMillisecond,
 } from 'd3-time';
-import { browserLocale } from './i18n';
+import { dateLocale } from './time';
 
 export const createPeriods = (locale, periodType, year) => {
     const localePeriodGenerator = createPeriodGeneratorsForLocale(
-        browserLocale(locale)
+        dateLocale(locale)
     );
 
     const periodGenerator =

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -1,7 +1,9 @@
 import i18n from '@dhis2/d2-i18n';
-import { browserLocale } from './i18n';
-
 const DEFAULT_LOCALE = 'en';
+
+// BCP 47 locale format
+export const dateLocale = locale =>
+    locale && locale.includes('_') ? locale.replace('_', '-') : locale;
 
 /**
  * Converts a date string or timestamp to a date object
@@ -58,7 +60,7 @@ export const hasIntlSupport =
 export const formatLocaleDate = (dateString, locale, showYear = true) =>
     hasIntlSupport
         ? new Intl.DateTimeFormat(
-              browserLocale(locale || i18n.language || DEFAULT_LOCALE),
+              dateLocale(locale || i18n.language || DEFAULT_LOCALE),
               {
                   year: showYear ? 'numeric' : undefined,
                   month: 'short',

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -1,4 +1,5 @@
 import i18n from '@dhis2/d2-i18n';
+import { browserLocale } from './i18n';
 
 const DEFAULT_LOCALE = 'en';
 
@@ -56,11 +57,14 @@ export const hasIntlSupport =
  */
 export const formatLocaleDate = (dateString, locale, showYear = true) =>
     hasIntlSupport
-        ? new Intl.DateTimeFormat(locale || i18n.language || DEFAULT_LOCALE, {
-              year: showYear ? 'numeric' : undefined,
-              month: 'short',
-              day: 'numeric',
-          }).format(toDate(dateString))
+        ? new Intl.DateTimeFormat(
+              browserLocale(locale || i18n.language || DEFAULT_LOCALE),
+              {
+                  year: showYear ? 'numeric' : undefined,
+                  month: 'short',
+                  day: 'numeric',
+              }
+          ).format(toDate(dateString))
         : fallbackDateFormat(dateString);
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,7 +224,7 @@
     lodash "^4.17.10"
     material-ui "^0.20.0"
 
-"@dhis2/d2-ui-core@7.1.6", "@dhis2/d2-ui-core@^7.1.6":
+"@dhis2/d2-ui-core@7.1.6":
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.1.6.tgz#2bc65f86f1cbf0e04ca17accfb164968e5fcb7d4"
   integrity sha512-zF5Xnts5NLmGkPJHR3QI4H9KLruHSp3JPAmR2lxNtturSpwEzecnauydo/Og76wcscd4V3ylEmIY2d5Ey2o9OA==
@@ -235,15 +235,27 @@
     material-ui "^0.20.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-favorites-dialog@7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-7.1.6.tgz#78c9ca9a20bfc0a9c5bcc852a295f960af03d849"
-  integrity sha512-wNRdx0MJTPF9PRdK1MVjJGYnF2SPno8FoG8t2mk7KVdZPwpgKFiMjnn052jkEGJ2aaH2BLS4BnZ7KD48udA4OQ==
+"@dhis2/d2-ui-core@7.3.1", "@dhis2/d2-ui-core@^7.1.6":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.3.1.tgz#8ee0bce960890234815835909a9ac921c23d7235"
+  integrity sha512-ntdngkL+nojkGElFsZd92JcGggRGnZ3HdgFVPIFqhpTjMBOWgHFmkAKBGVWhRQIQZAZ31LCt/NR5Dhk+ouYhMA==
   dependencies:
-    "@dhis2/d2-ui-sharing-dialog" "7.1.6"
+    babel-runtime "^6.26.0"
+    d2 "~31.7"
+    lodash "^4.17.10"
+    material-ui "^0.20.0"
+    rxjs "^5.5.7"
+
+"@dhis2/d2-ui-favorites-dialog@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-7.3.1.tgz#be42b761329ecf6db8cb73acf8b90c44985c6a00"
+  integrity sha512-JKGYtX7obKcNblG21SqBgfYb1aQQtMO7xGpJUHyOzQIRCqANl9e21drcOXMqgMcpUqNjZA70BpYi+MqrpL70EQ==
+  dependencies:
+    "@dhis2/d2-ui-sharing-dialog" "7.3.1"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
+    lodash "^4.17.10"
     prop-types "^15.6.0"
     react-redux "^5.0.7"
     redux "^3.7.2"
@@ -251,25 +263,25 @@
     redux-thunk "^2.2.0"
 
 "@dhis2/d2-ui-file-menu@^7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-file-menu/-/d2-ui-file-menu-7.1.6.tgz#1af96a241ff50690c5164bd514821ece6df41df2"
-  integrity sha512-ccy2H9xzAy6VfduqxWQYcb2yv96AjUMSBk+rYbUfuvwVxQ7hwQQzuz0qrw/KVg4cdZMewi4gfjW+SYV5nIQJtQ==
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-file-menu/-/d2-ui-file-menu-7.3.1.tgz#76d94cb6f6f85d3598a6174cf377d07fb0e560ce"
+  integrity sha512-gwMj3X2lBJhIw8j2C2JxkE6fozJEWaFdj4NYcMFMjqgFnmSmwEEobqEo0hKPsPdi/96LazyRUBpH8XNEcFZWNQ==
   dependencies:
-    "@dhis2/d2-ui-favorites-dialog" "7.1.6"
-    "@dhis2/d2-ui-sharing-dialog" "7.1.6"
-    "@dhis2/d2-ui-translation-dialog" "7.1.6"
+    "@dhis2/d2-ui-favorites-dialog" "7.3.1"
+    "@dhis2/d2-ui-sharing-dialog" "7.3.1"
+    "@dhis2/d2-ui-translation-dialog" "7.3.1"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.6.0"
 
-"@dhis2/d2-ui-interpretations@^7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-interpretations/-/d2-ui-interpretations-7.1.6.tgz#c6c410141920d919d70b8c4749e16c03841467c6"
-  integrity sha512-AJTvZro8WjKYLWkMyWO7Nmt+K2BX8V0kFfBfr3hr+vO5mGG70YrrWiLXxQP/HxKqK4tncvyzGK3boLgbE9GF+A==
+"@dhis2/d2-ui-interpretations@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-interpretations/-/d2-ui-interpretations-7.3.1.tgz#a2836a60bbbfe28deef62ace6f3a40995be46dd1"
+  integrity sha512-/UD4z8FdM9x7YiENu+8iG6DaUjoh1dcvESBRaX17vzlFJq7q65Qj3dik6/Ty1jkULEp4gFCdXvTI8DEoLGW7Sg==
   dependencies:
-    "@dhis2/d2-ui-mentions-wrapper" "7.1.6"
-    "@dhis2/d2-ui-rich-text" "7.1.6"
-    "@dhis2/d2-ui-sharing-dialog" "7.1.6"
+    "@dhis2/d2-ui-mentions-wrapper" "7.3.1"
+    "@dhis2/d2-ui-rich-text" "7.3.1"
+    "@dhis2/d2-ui-sharing-dialog" "7.3.1"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
@@ -279,10 +291,10 @@
     prop-types "^15.5.10"
     react-portal "^4.1.5"
 
-"@dhis2/d2-ui-mentions-wrapper@7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-mentions-wrapper/-/d2-ui-mentions-wrapper-7.1.6.tgz#6bc8f38f1d2ca069e823a37e38674209ac0f1d6b"
-  integrity sha512-Cg7mcmuMgWR2RLL7jjmNK3fUS5rhdMpQB89pf61G/3kYDx5NAwD+HOYklVJoFLKNur0Sd/fv6aCkV/tXhHOL+g==
+"@dhis2/d2-ui-mentions-wrapper@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-mentions-wrapper/-/d2-ui-mentions-wrapper-7.3.1.tgz#24e5b7d1d2c60eaf25b61a137bb0d304f68485e9"
+  integrity sha512-m9VPgGD/OWBJngdIqJZ3Xzli91fVRnUnfV/XJasYp2LyAU7XtB1dSGZI8+1gaRiVGK4scy5PJ+G3YqEhgQN3Rg==
   dependencies:
     "@material-ui/core" "^3.3.1"
     lodash "^4.17.10"
@@ -346,21 +358,21 @@
     react-sortable-hoc "^0.8.4"
     redux "^4.0.1"
 
-"@dhis2/d2-ui-rich-text@7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-7.1.6.tgz#4cc58f85680b54f99994d25106642c68131a7606"
-  integrity sha512-3I2GdDQJEncxDuHEn9Bh2D3p4Mqi9dy3xhwhaVrLL6o1qu0/nZTo8owODyu4ruvioxWWNsxYmOahNcosHo9q7Q==
+"@dhis2/d2-ui-rich-text@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-7.3.1.tgz#cb59b96da13d8e4c0feaaf17ca51ab180d5632d6"
+  integrity sha512-+9AAphwrBB3by3mnbQfTUxFct8T7FRcs0W6BXr37gFOv5pGN3u5b8hVoWNq1eIEyZSUKbkPc9yXljM1LaWG3xw==
   dependencies:
     babel-runtime "^6.26.0"
     markdown-it "^8.4.2"
     prop-types "^15.6.2"
 
-"@dhis2/d2-ui-sharing-dialog@7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.1.6.tgz#5e07c936a9231c85b9f485c1f3fd1c306a170965"
-  integrity sha512-oERAInDhM6S4ogZ5+CZpKUqGkZ7mxEOAoSSYZYsIi5A5TeMoOYHdf02Yvby0cXPSxLGR6CIHotSdBYN//4fhMA==
+"@dhis2/d2-ui-sharing-dialog@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.3.1.tgz#2e56a030f7a5744a632c8823d60401ca10aa1c6e"
+  integrity sha512-HAyvJ9R7D626gN53R3g9iG3DFdjStN85C5XMlfmlmHHyRecvE/8n+jqCQnInpoJpKoLue45uCSEZ01hZoLUVEA==
   dependencies:
-    "@dhis2/d2-ui-core" "7.1.6"
+    "@dhis2/d2-ui-core" "7.3.1"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
@@ -369,12 +381,12 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-translation-dialog@7.1.6":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-7.1.6.tgz#8251f57ff7b88c7430ee10c0a727ee64a733dead"
-  integrity sha512-MCYSYNEg+vYnwmZXa85Sybojzy91U6wY1+l0MwPf8hd9WH7Jgx2za1+49Wk3AeVJq7H/qWAlcjnP5Uj7eovq1w==
+"@dhis2/d2-ui-translation-dialog@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-7.3.1.tgz#aa10fad9e0cbf134ecc02b7dee6b9e07fa4edae3"
+  integrity sha512-yApQUlj6F3Ll5zkdcnqspAm6m7KosL6Vbj7qa6rHooz/Dvu8fA2Isg/wqYN+ZuKmutaTpX26B7zlN4l1OOP9yw==
   dependencies:
-    "@dhis2/d2-ui-core" "7.1.6"
+    "@dhis2/d2-ui-core" "7.3.1"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
Fixes for 2.35: https://jira.dhis2.org/browse/DHIS2-11335

DHIS2 uses underscore to define locales, while the browser/JS APIs use hyphen (BCP 47). This PR will replace underscores with hyphens before the locale is passed to ECMAScript Internationalization API. 

Avoids a crash when opening the interpretations panel with a locale with language_country format
See dhis2/d2-ui#700

After this PR with interface language set to "Arabic (Iraq)": 
<img width="401" alt="Screenshot 2021-06-24 at 13 41 50" src="https://user-images.githubusercontent.com/548708/123257895-0a4ea600-d4f3-11eb-83d1-d1dfa42b537d.png">



