### PR TITLE
fix: exclude attribution toggle button from download (DHIS2-11143)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "34.0.47",
+    "version": "34.0.48",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/src/components/download/DownloadDialog.js
+++ b/src/components/download/DownloadDialog.js
@@ -151,7 +151,8 @@ export class DownloadDialog extends Component {
             el.classList.contains('mapboxgl-ctrl-attrib') ||
             !(
                 el.classList.contains('mapboxgl-ctrl') ||
-                el.classList.contains('dhis2-map-bing-logo')
+                el.classList.contains('dhis2-map-bing-logo') ||
+                el.classList.contains('mapboxgl-ctrl-attrib-button')
             );
 
         const options = {

--- a/src/components/map/MapContainer.js
+++ b/src/components/map/MapContainer.js
@@ -29,6 +29,19 @@ const styles = {
         '& .dhis2-map-period': {
             bottom: '10px!important',
         },
+        '& .mapboxgl-compact': {
+            padding: '0 5px',
+            backgroundColor: 'hsla(0,0%,100%,.5)',
+            margin: '0!important',
+            minHeight: 0,
+            borderRadius: 0,
+        },
+        '& .mapboxgl-ctrl-attrib-button': {
+            display: 'none!important',
+        },
+        '& .mapboxgl-ctrl-attrib-inner': {
+            display: 'block!important',
+        },
     },
 };
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11143

2.34 backport of #1712

This PR will exclude the attribution toggle button from the map download, as it's not supported by the dom-to-image dependency. It will show the text attribution instead. 
