### PR TITLE
fix: use hyphen in locale strings passed to the browser 2.34 backport (DHIS2-11335)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "34.0.48",
+    "version": "34.0.49",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {
@@ -50,7 +50,7 @@
         "@dhis2/d2-ui-analytics": "^0.0.3",
         "@dhis2/d2-ui-core": "^7.2.0",
         "@dhis2/d2-ui-file-menu": "^7.2.0",
-        "@dhis2/d2-ui-interpretations": "^7.2.0",
+        "@dhis2/d2-ui-interpretations": "^7.3.1",
         "@dhis2/d2-ui-org-unit-dialog": "^7.2.0",
         "@dhis2/d2-ui-org-unit-tree": "^7.2.0",
         "@dhis2/maps-gl": "^1.8.6",

--- a/src/constants/periods.js
+++ b/src/constants/periods.js
@@ -5,7 +5,7 @@ export const getPeriodTypes = () => [
     { id: 'Daily', name: i18n.t('Daily') },
     { id: 'Weekly', name: i18n.t('Weekly') },
     { id: 'Monthly', name: i18n.t('Monthly') },
-    { id: 'BiMonthly', name: i18n.t('Bi-monthly)') },
+    { id: 'BiMonthly', name: i18n.t('Bi-monthly') },
     { id: 'Quarterly', name: i18n.t('Quarterly') },
     { id: 'SixMonthly', name: i18n.t('Six-monthly') },
     { id: 'SixMonthlyApril', name: i18n.t('Six-monthly April') },

--- a/src/util/periods.js
+++ b/src/util/periods.js
@@ -11,9 +11,12 @@ import {
     timeSecond,
     timeMillisecond,
 } from 'd3-time';
+import { dateLocale } from './time';
 
 export const createPeriods = (locale, periodType, year) => {
-    const localePeriodGenerator = createPeriodGeneratorsForLocale(locale);
+    const localePeriodGenerator = createPeriodGeneratorsForLocale(
+        dateLocale(locale)
+    );
 
     const periodGenerator =
         localePeriodGenerator[`generate${periodType}PeriodsForYear`] ||

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -2,6 +2,10 @@ import i18n from '@dhis2/d2-i18n';
 
 const DEFAULT_LOCALE = 'en';
 
+// BCP 47 locale format
+export const dateLocale = locale =>
+    locale && locale.includes('_') ? locale.replace('_', '-') : locale;
+
 /**
  * Converts a date string or timestamp to a date object
  * @param {String|Number|Date} date
@@ -56,11 +60,14 @@ export const hasIntlSupport =
  */
 export const formatLocaleDate = (dateString, locale, showYear = true) =>
     hasIntlSupport
-        ? new Intl.DateTimeFormat(locale || i18n.language || DEFAULT_LOCALE, {
-              year: showYear ? 'numeric' : undefined,
-              month: 'short',
-              day: 'numeric',
-          }).format(toDate(dateString))
+        ? new Intl.DateTimeFormat(
+              dateLocale(locale || i18n.language || DEFAULT_LOCALE),
+              {
+                  year: showYear ? 'numeric' : undefined,
+                  month: 'short',
+                  day: 'numeric',
+              }
+          ).format(toDate(dateString))
         : fallbackDateFormat(dateString);
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -235,6 +235,17 @@
     material-ui "^0.20.0"
     rxjs "^5.5.7"
 
+"@dhis2/d2-ui-core@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.3.1.tgz#8ee0bce960890234815835909a9ac921c23d7235"
+  integrity sha512-ntdngkL+nojkGElFsZd92JcGggRGnZ3HdgFVPIFqhpTjMBOWgHFmkAKBGVWhRQIQZAZ31LCt/NR5Dhk+ouYhMA==
+  dependencies:
+    babel-runtime "^6.26.0"
+    d2 "~31.7"
+    lodash "^4.17.10"
+    material-ui "^0.20.0"
+    rxjs "^5.5.7"
+
 "@dhis2/d2-ui-favorites-dialog@7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-7.2.0.tgz#b1f853c63d3e352af81b44b275c3881d2dea3c6d"
@@ -263,14 +274,14 @@
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.6.0"
 
-"@dhis2/d2-ui-interpretations@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-interpretations/-/d2-ui-interpretations-7.2.0.tgz#9be8e8270a1a5bbb8d857dadb3f67314bb6a0172"
-  integrity sha512-VC+SSp8t3WKizWhq0HzwN2lZb/AS3N7HHz99KRXVTx4diG/1TZg2s+rkBSqUfvXislpntjxpzWvHA9z7GMDlOA==
+"@dhis2/d2-ui-interpretations@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-interpretations/-/d2-ui-interpretations-7.3.1.tgz#a2836a60bbbfe28deef62ace6f3a40995be46dd1"
+  integrity sha512-/UD4z8FdM9x7YiENu+8iG6DaUjoh1dcvESBRaX17vzlFJq7q65Qj3dik6/Ty1jkULEp4gFCdXvTI8DEoLGW7Sg==
   dependencies:
-    "@dhis2/d2-ui-mentions-wrapper" "7.2.0"
-    "@dhis2/d2-ui-rich-text" "7.2.0"
-    "@dhis2/d2-ui-sharing-dialog" "7.2.0"
+    "@dhis2/d2-ui-mentions-wrapper" "7.3.1"
+    "@dhis2/d2-ui-rich-text" "7.3.1"
+    "@dhis2/d2-ui-sharing-dialog" "7.3.1"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
@@ -280,10 +291,10 @@
     prop-types "^15.5.10"
     react-portal "^4.1.5"
 
-"@dhis2/d2-ui-mentions-wrapper@7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-mentions-wrapper/-/d2-ui-mentions-wrapper-7.2.0.tgz#41b216cd5a2895a59cf02c42da9a9c244ee2ec61"
-  integrity sha512-WN21hMLT6x4E+FUL80BH9m7nfU26FplSd3jj3W1qj1QplfYUE1eABxQPxaDfPFAeFOyOaN4QZxKUY/KmirO9WA==
+"@dhis2/d2-ui-mentions-wrapper@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-mentions-wrapper/-/d2-ui-mentions-wrapper-7.3.1.tgz#24e5b7d1d2c60eaf25b61a137bb0d304f68485e9"
+  integrity sha512-m9VPgGD/OWBJngdIqJZ3Xzli91fVRnUnfV/XJasYp2LyAU7XtB1dSGZI8+1gaRiVGK4scy5PJ+G3YqEhgQN3Rg==
   dependencies:
     "@material-ui/core" "^3.3.1"
     lodash "^4.17.10"
@@ -347,10 +358,10 @@
     react-sortable-hoc "^0.8.4"
     redux "^4.0.1"
 
-"@dhis2/d2-ui-rich-text@7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-7.2.0.tgz#7960c35dab453aeaad2cee427ecaba19fca270ba"
-  integrity sha512-lMFMZeHINd3lX97z/RDWITcW4epoMnWA8z4Zbh9O6VlM1TXT52m6OCVdeZmF6bW0gPIqOgWKopNz+9Au7HqoeA==
+"@dhis2/d2-ui-rich-text@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-7.3.1.tgz#cb59b96da13d8e4c0feaaf17ca51ab180d5632d6"
+  integrity sha512-+9AAphwrBB3by3mnbQfTUxFct8T7FRcs0W6BXr37gFOv5pGN3u5b8hVoWNq1eIEyZSUKbkPc9yXljM1LaWG3xw==
   dependencies:
     babel-runtime "^6.26.0"
     markdown-it "^8.4.2"
@@ -362,6 +373,20 @@
   integrity sha512-l12r7yoI9lU5NWxH6yWBlPdXVpIqqRQ96oq5M5taRG/r1UxLNf3KTigOjT8Ghg+LtCnJGFebyXi5ZTFCwN0c/Q==
   dependencies:
     "@dhis2/d2-ui-core" "7.2.0"
+    "@material-ui/core" "^3.3.1"
+    "@material-ui/icons" "^3.0.1"
+    babel-runtime "^6.26.0"
+    downshift "^2.2.2"
+    prop-types "^15.5.10"
+    recompose "^0.26.0"
+    rxjs "^5.5.7"
+
+"@dhis2/d2-ui-sharing-dialog@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.3.1.tgz#2e56a030f7a5744a632c8823d60401ca10aa1c6e"
+  integrity sha512-HAyvJ9R7D626gN53R3g9iG3DFdjStN85C5XMlfmlmHHyRecvE/8n+jqCQnInpoJpKoLue45uCSEZ01hZoLUVEA==
+  dependencies:
+    "@dhis2/d2-ui-core" "7.3.1"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
Fixes for 2.34: https://jira.dhis2.org/browse/DHIS2-11335

DHIS2 uses underscore to define locales, while the browser/JS APIs use hyphen (BCP 47). This PR will replace underscores with hyphens before the locale is passed to ECMAScript Internationalization API.

Avoids a crash when opening the interpretations panel with a locale with language_country format
See dhis2/d2-ui#700

After this PR with interface language set to "Arabic (Iraq)":
<img width="380" alt="Screenshot 2021-06-24 at 20 10 42" src="https://user-images.githubusercontent.com/548708/123312234-5700a400-d528-11eb-8519-c36209b89f1f.png">
<img width="377" alt="Screenshot 2021-06-24 at 20 11 00" src="https://user-images.githubusercontent.com/548708/123312244-5962fe00-d528-11eb-88de-7341728e3a67.png">
