### PR TITLE
fix: use hyphen in locale strings passed to the browser (DHIS2-11335)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "36.0.0",
+    "version": "37.0.0",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {
@@ -44,10 +44,10 @@
         "@dhis2/analytics": "^18.2.1",
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/d2-i18n": "<1.1.0",
-        "@dhis2/d2-ui-core": "^7.3.0",
-        "@dhis2/d2-ui-interpretations": "^7.3.0",
-        "@dhis2/d2-ui-org-unit-dialog": "^7.3.0",
-        "@dhis2/d2-ui-org-unit-tree": "^7.3.0",
+        "@dhis2/d2-ui-core": "^7.3.1",
+        "@dhis2/d2-ui-interpretations": "^7.3.1",
+        "@dhis2/d2-ui-org-unit-dialog": "^7.3.1",
+        "@dhis2/d2-ui-org-unit-tree": "^7.3.1",
         "@dhis2/maps-gl": "^1.8.6",
         "@dhis2/ui": "^6.5.5",
         "abortcontroller-polyfill": "^1.5.0",

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -2,6 +2,10 @@ import i18n from '@dhis2/d2-i18n';
 
 const DEFAULT_LOCALE = 'en';
 
+// BCP 47 locale format
+export const dateLocale = locale =>
+    locale && locale.includes('_') ? locale.replace('_', '-') : locale;
+
 /**
  * Converts a date string or timestamp to a date object
  * @param {String|Number|Date} date
@@ -56,11 +60,14 @@ export const hasIntlSupport =
  */
 export const formatLocaleDate = (dateString, locale, showYear = true) =>
     hasIntlSupport
-        ? new Intl.DateTimeFormat(locale || i18n.language || DEFAULT_LOCALE, {
-              year: showYear ? 'numeric' : undefined,
-              month: 'short',
-              day: 'numeric',
-          }).format(toDate(dateString))
+        ? new Intl.DateTimeFormat(
+              dateLocale(locale || i18n.language || DEFAULT_LOCALE),
+              {
+                  year: showYear ? 'numeric' : undefined,
+                  month: 'short',
+                  day: 'numeric',
+              }
+          ).format(toDate(dateString))
         : fallbackDateFormat(dateString);
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1936,10 +1936,21 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/d2-ui-core@7.3.0", "@dhis2/d2-ui-core@^7.3.0":
+"@dhis2/d2-ui-core@7.3.0":
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.3.0.tgz#d30fe5aea507a1d1f203d524f2172e293b0a9bf9"
   integrity sha512-0mklIH4aQX6qonv1oaM+p3jlijszKmvykb0/cL7xkSb40No5KsBxwlT5gL+xCmqWxX9UhNUPtqiuU2kNmGaoEg==
+  dependencies:
+    babel-runtime "^6.26.0"
+    d2 "~31.7"
+    lodash "^4.17.10"
+    material-ui "^0.20.0"
+    rxjs "^5.5.7"
+
+"@dhis2/d2-ui-core@7.3.1", "@dhis2/d2-ui-core@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.3.1.tgz#8ee0bce960890234815835909a9ac921c23d7235"
+  integrity sha512-ntdngkL+nojkGElFsZd92JcGggRGnZ3HdgFVPIFqhpTjMBOWgHFmkAKBGVWhRQIQZAZ31LCt/NR5Dhk+ouYhMA==
   dependencies:
     babel-runtime "^6.26.0"
     d2 "~31.7"
@@ -1963,14 +1974,14 @@
     redux-logger "^3.0.6"
     redux-thunk "^2.2.0"
 
-"@dhis2/d2-ui-interpretations@^7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-interpretations/-/d2-ui-interpretations-7.3.0.tgz#d64517af15b1c7a4935bf50b707ff77f269c2be0"
-  integrity sha512-mt1HC4OTolkX9e1VnlmA8I8s5rqd4fk+FGA3ew0WbArPFBi+ymx2ANa8Dv16GfBH646IJQeLPWAq7Kl0HfHZBQ==
+"@dhis2/d2-ui-interpretations@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-interpretations/-/d2-ui-interpretations-7.3.1.tgz#a2836a60bbbfe28deef62ace6f3a40995be46dd1"
+  integrity sha512-/UD4z8FdM9x7YiENu+8iG6DaUjoh1dcvESBRaX17vzlFJq7q65Qj3dik6/Ty1jkULEp4gFCdXvTI8DEoLGW7Sg==
   dependencies:
-    "@dhis2/d2-ui-mentions-wrapper" "7.3.0"
-    "@dhis2/d2-ui-rich-text" "7.3.0"
-    "@dhis2/d2-ui-sharing-dialog" "7.3.0"
+    "@dhis2/d2-ui-mentions-wrapper" "7.3.1"
+    "@dhis2/d2-ui-rich-text" "7.3.1"
+    "@dhis2/d2-ui-sharing-dialog" "7.3.1"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
@@ -1980,16 +1991,16 @@
     prop-types "^15.5.10"
     react-portal "^4.1.5"
 
-"@dhis2/d2-ui-mentions-wrapper@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-mentions-wrapper/-/d2-ui-mentions-wrapper-7.3.0.tgz#77d022aec3af1eefe758de39cbcf38cc267e1ed6"
-  integrity sha512-wx5dTn37xu7OQtnScVXIkVufuD/Iq1bIoHwAh/ATxnPKRbDGgKY/YzB5TJ9NNI+FxR5dnSjz179jw3pRNtqMog==
+"@dhis2/d2-ui-mentions-wrapper@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-mentions-wrapper/-/d2-ui-mentions-wrapper-7.3.1.tgz#24e5b7d1d2c60eaf25b61a137bb0d304f68485e9"
+  integrity sha512-m9VPgGD/OWBJngdIqJZ3Xzli91fVRnUnfV/XJasYp2LyAU7XtB1dSGZI8+1gaRiVGK4scy5PJ+G3YqEhgQN3Rg==
   dependencies:
     "@material-ui/core" "^3.3.1"
     lodash "^4.17.10"
     prop-types "^15.6.2"
 
-"@dhis2/d2-ui-org-unit-dialog@^7.2.0", "@dhis2/d2-ui-org-unit-dialog@^7.3.0":
+"@dhis2/d2-ui-org-unit-dialog@^7.2.0":
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-7.3.0.tgz#3fd04fc532d6f4aaaa5fd67fa1149c008877e129"
   integrity sha512-1trQ3ZQqajhXPDdOjK4Qvq/oaocYvBv9yk0FiglYPsby2lt8vRWx7id7gk/vGD5Zw7IMHyQISdNjwiPqYo+mpQ==
@@ -1999,7 +2010,17 @@
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.5.10"
 
-"@dhis2/d2-ui-org-unit-tree@7.3.0", "@dhis2/d2-ui-org-unit-tree@^7.3.0":
+"@dhis2/d2-ui-org-unit-dialog@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-7.3.1.tgz#d5cd90898be70aaa2d0f3be152eb351b51e6384a"
+  integrity sha512-6+37xaUXIa8A+DkUj+luwh8Lfv/nLDZkizVk0ZBLEVM/hKhu7hUlSvWZNyAeWUBTHC6DagskBfJ0NUECjEiMnw==
+  dependencies:
+    "@dhis2/d2-ui-org-unit-tree" "7.3.1"
+    "@material-ui/core" "^3.3.1"
+    "@material-ui/icons" "^3.0.1"
+    prop-types "^15.5.10"
+
+"@dhis2/d2-ui-org-unit-tree@7.3.0":
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.3.0.tgz#181696b8a5fb6e365c83fd36976beb97b596a40b"
   integrity sha512-rox7AzstgcSvE0VFEcDalzQJ9/px0R/l6CqHwU9O6jbdoykDOe1n3r95CPNAaaOrJM6HMrZHQ5zgv44kHn21Vg==
@@ -2009,10 +2030,20 @@
     babel-runtime "^6.26.0"
     prop-types "^15.5.10"
 
-"@dhis2/d2-ui-rich-text@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-7.3.0.tgz#4125f66a3a053936a52a7a8a37b41b668cc67d87"
-  integrity sha512-unoLEK8ysQRlqgH6WlfXNh62JKqv/gLHfhmQPAk2wE6zeg2XVap1G1A9rOsLxkSdu6lzc7fb6zv277V8PlYr7w==
+"@dhis2/d2-ui-org-unit-tree@7.3.1", "@dhis2/d2-ui-org-unit-tree@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.3.1.tgz#8f17c47546cf31c18480e94c63b544bff7247457"
+  integrity sha512-TKIJN+TuggHDidEDPoYsEIbmTpiabYb/PfhXlPcH9TOuUSQaMFOHotvJNM1+o5qNwpeR33mD9ywCbzAl/wpD1Q==
+  dependencies:
+    "@dhis2/d2-ui-core" "7.3.1"
+    "@material-ui/core" "^3.3.1"
+    babel-runtime "^6.26.0"
+    prop-types "^15.5.10"
+
+"@dhis2/d2-ui-rich-text@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-7.3.1.tgz#cb59b96da13d8e4c0feaaf17ca51ab180d5632d6"
+  integrity sha512-+9AAphwrBB3by3mnbQfTUxFct8T7FRcs0W6BXr37gFOv5pGN3u5b8hVoWNq1eIEyZSUKbkPc9yXljM1LaWG3xw==
   dependencies:
     babel-runtime "^6.26.0"
     markdown-it "^8.4.2"
@@ -2024,6 +2055,20 @@
   integrity sha512-OPDGd0pknd9b4xTqezScwv1AU1ChPWub+Mh7ETvfoWMTc2N+mXaacVOl2RZFrjEX9aVpl8OwzWpEzj1o0j6esQ==
   dependencies:
     "@dhis2/d2-ui-core" "7.3.0"
+    "@material-ui/core" "^3.3.1"
+    "@material-ui/icons" "^3.0.1"
+    babel-runtime "^6.26.0"
+    downshift "^2.2.2"
+    prop-types "^15.5.10"
+    recompose "^0.26.0"
+    rxjs "^5.5.7"
+
+"@dhis2/d2-ui-sharing-dialog@7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.3.1.tgz#2e56a030f7a5744a632c8823d60401ca10aa1c6e"
+  integrity sha512-HAyvJ9R7D626gN53R3g9iG3DFdjStN85C5XMlfmlmHHyRecvE/8n+jqCQnInpoJpKoLue45uCSEZ01hZoLUVEA==
+  dependencies:
+    "@dhis2/d2-ui-core" "7.3.1"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
Fixes in master: https://jira.dhis2.org/browse/DHIS2-11335

DHIS2 uses underscore to define locales, while the browser/JS APIs use hyphen (BCP 47). This PR will replace underscores with hyphens before the locale is passed to ECMAScript Internationalization API.

Avoids a crash when opening the interpretations panel with a locale with language_country format
See dhis2/d2-ui#700

After this PR with interface language set to "Arabic (Iraq)":
<img width="728" alt="Screenshot 2021-06-24 at 20 55 35" src="https://user-images.githubusercontent.com/548708/123317723-a21db580-d52e-11eb-8f0f-788eb25af22b.png">
