### PR TITLE
fix: period type in uppercase (DHIS2-11433)

### DIFF
--- a/src/util/infrastructural.js
+++ b/src/util/infrastructural.js
@@ -1,5 +1,4 @@
 import { getInstance as getD2 } from 'd2';
-import i18n from '@dhis2/d2-i18n';
 
 // Loads settings and data for the infrastuctural dialog for org units
 export const loadConfigurations = async () => {
@@ -15,13 +14,12 @@ export const loadConfigurations = async () => {
         api.get('configuration/infrastructuralDataElements'),
     ]);
 
-    const periodType =
-        (infraPeriodType && infraPeriodType.id) || i18n.t('Yearly');
+    const periodType = (infraPeriodType && infraPeriodType.id) || 'Yearly';
     const { indicators = [] } = infraIndicators || {};
     const { dataElements = [] } = infraDataElements || {};
 
     return {
-        periodType,
+        periodType: periodType.toUpperCase(),
         dataItems: [].concat(indicators, dataElements),
     };
 };


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11433

The bug appeared after switching to period generators from @dhis2/analytics in #1734 
For the new period generators the period type needs to be in uppercase, and this was not changed for the infrastructural data (organisation unit dialog). 

After this PR: 
<img width="595" alt="Screenshot 2021-06-30 at 22 09 42" src="https://user-images.githubusercontent.com/548708/124024738-e78b2880-d9ef-11eb-929f-0048048a39f4.png">

Before: 
<img width="597" alt="Screenshot 2021-06-30 at 22 10 25" src="https://user-images.githubusercontent.com/548708/124024811-ff62ac80-d9ef-11eb-843d-a807f3021167.png">
