### PR TITLE
feat: switch from mapbox-gl to maplibre-gl

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@dhis2/d2-ui-interpretations": "^7.3.1",
         "@dhis2/d2-ui-org-unit-dialog": "^7.3.1",
         "@dhis2/d2-ui-org-unit-tree": "^7.3.1",
-        "@dhis2/maps-gl": "^1.8.6",
+        "@dhis2/maps-gl": "^2.0.0",
         "@dhis2/ui": "^6.5.5",
         "abortcontroller-polyfill": "^1.5.0",
         "array-move": "^3.0.1",

--- a/src/components/download/DownloadDialog.js
+++ b/src/components/download/DownloadDialog.js
@@ -122,15 +122,15 @@ export class DownloadDialog extends Component {
             .substring(7)}.png`;
 
         // Skip map controls in download except attribution and scale
-        // Mapbox map controls contains inline SVG for CSS background-image, which
+        // MapLibre map controls contains inline SVG for CSS background-image, which
         // is not accepted by dom-to-image
         // Bing Maps logo is blocked by CORS policy
         const skipElements = el =>
             !el.classList ||
-            el.classList.contains('mapboxgl-ctrl-scale') ||
-            el.classList.contains('mapboxgl-ctrl-attrib-button') ||
+            el.classList.contains('maplibregl-ctrl-scale') ||
+            el.classList.contains('maplibregl-ctrl-attrib-button') ||
             !(
-                el.classList.contains('mapboxgl-ctrl') ||
+                el.classList.contains('maplibregl-ctrl') ||
                 el.classList.contains('dhis2-map-bing-logo')
             );
 

--- a/src/components/map/styles/Popup.css
+++ b/src/components/map/styles/Popup.css
@@ -2,7 +2,7 @@
     max-width: 80%;
 }
 
-.dhis2-map-popup .mapboxgl-popup-content {
+.dhis2-map-popup .maplibregl-popup-content {
     padding-top: var(--spacers-dp16);
     min-width: 150px;
 }

--- a/src/components/orgunits/RelocateDialog.js
+++ b/src/components/orgunits/RelocateDialog.js
@@ -22,7 +22,7 @@ const RelocateDialog = props => {
     useEffect(() => {
         const container = map
             .getContainer()
-            .getElementsByClassName('mapboxgl-interactive')[0];
+            .getElementsByClassName('maplibregl-interactive')[0];
 
         container.style.cursor = 'crosshair';
         map.getMapGL().on('click', onMapClick);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2091,10 +2091,10 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@^1.8.6":
-  version "1.8.6"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-1.8.6.tgz#f3509f01b4de5d1a6caae5af06f9bb3af792f7cf"
-  integrity sha512-5mDPvu4aIB3+YGW+ZabI/VG6qgef/iPR2nBbyogDXzmZZnQfJpMTfzcORP4TunwjGhGvvSSXn7KN6HNx8ue3tw==
+"@dhis2/maps-gl@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-2.0.0.tgz#631b52703372ee6d22da9d2045caace3efef3128"
+  integrity sha512-DfesctU3UhgrvhmBq5gCIIYE/4dLGmzqXlN6MLwtEle5bBAxGCg0WTjTPy8daxUUdg8YJ7HZtW07nDJFzm59QQ==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.3.0"
@@ -2105,8 +2105,7 @@
     "@turf/length" "^6.3.0"
     fetch-jsonp "^1.1.3"
     lodash.throttle "^4.1.1"
-    mapbox-gl "^1.13.1"
-    mapboxgl-spiderifier "^1.0.9"
+    maplibre-gl "^1.15.0"
     polylabel "^1.1.0"
     suggestions "^1.7.1"
     uuid "^8.3.2"
@@ -14055,10 +14054,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapbox-gl@^1.13.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-1.13.1.tgz#322efe75ab4c764fc4c776da1506aad58d5a5b9d"
-  integrity sha512-GSyubcoSF5MyaP8z+DasLu5v7KmDK2pp4S5+VQ5WdVQUOaAqQY4jwl4JpcdNho3uWm2bIKs7x1l7q3ynGmW60g==
+maplibre-gl@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/maplibre-gl/-/maplibre-gl-1.15.0.tgz#6efa96b5fdda218390cb9db3eb1e901dc6ca9f51"
+  integrity sha512-C3Mq7HDTndvAs8w+Ai1QzvVdN7xG2+2iHjtp3Pkmk7tJeSMcqZzQYHKyOCBkpTs7g2P/aFqMU8Tg853RIZxIZg==
   dependencies:
     "@mapbox/geojson-rewind" "^0.5.0"
     "@mapbox/geojson-types" "^1.0.2"
@@ -14083,11 +14082,6 @@ mapbox-gl@^1.13.1:
     supercluster "^7.1.0"
     tinyqueue "^2.0.3"
     vt-pbf "^3.1.1"
-
-mapboxgl-spiderifier@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/mapboxgl-spiderifier/-/mapboxgl-spiderifier-1.0.9.tgz#332d3f53eff9b4a0ea9e062dc480ddaae581f244"
-  integrity sha512-qox8WOWU9MGdH4IL8wtUO/inEyivCi44e4lYStJ9BXuTGU0t2TVdu6SsnStRNqnE67n0423FfCDXycGUj9XROA==
 
 markdown-it@^8.4.2:
   version "8.4.2"


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11406

This PR upgrades to @dhis2/maps-gl 2.0.0 where mapbox-gl is replaced by maplibre-gl: https://github.com/dhis2/maps-gl/pull/374

Some class names had to be changed from "mapboxgl-" to "maplibregl-". 