### PR TITLE
fix: only opening/closed dates if org unit is a point facility

### DIFF
--- a/src/components/orgunits/OrgUnitInfo.js
+++ b/src/components/orgunits/OrgUnitInfo.js
@@ -25,6 +25,7 @@ const OrgUnitInfo = ({
     contactPerson,
     description,
     email,
+    featureType,
     groupSets,
     id,
     imageId,
@@ -71,12 +72,22 @@ const OrgUnitInfo = ({
             ))}
             <ListItem label={i18n.t('Code')}>{code}</ListItem>
             <ListItem label={i18n.t('Short name')}>{shortName}</ListItem>
-            <ListItem label={i18n.t('Opening date')} formatter={formatDate}>
-                {openingDate}
-            </ListItem>
-            <ListItem label={i18n.t('Closed date')} formatter={formatDate}>
-                {closedDate}
-            </ListItem>
+            {featureType === 'POINT' && (
+                <>
+                    <ListItem
+                        label={i18n.t('Opening date')}
+                        formatter={formatDate}
+                    >
+                        {openingDate}
+                    </ListItem>
+                    <ListItem
+                        label={i18n.t('Closed date')}
+                        formatter={formatDate}
+                    >
+                        {closedDate}
+                    </ListItem>
+                </>
+            )}
             {url && (
                 <ListItem label={i18n.t('URL')}>
                     <a href={url} target="_blank" rel="noreferrer">
@@ -114,6 +125,7 @@ OrgUnitInfo.propTypes = {
     contactPerson: PropTypes.string,
     description: PropTypes.string,
     email: PropTypes.string,
+    featureType: PropTypes.string,
     groupSets: PropTypes.array.isRequired,
     id: PropTypes.string.isRequired,
     imageId: PropTypes.string,

--- a/src/components/orgunits/__tests__/OrgUnitInfo.spec.js
+++ b/src/components/orgunits/__tests__/OrgUnitInfo.spec.js
@@ -117,10 +117,15 @@ describe('Org unit profile (location details)', () => {
         expect(getListItem(wrapper, 'Phone')).toEqual(phoneNumber);
     });
 
-    it('should render formatted dates', () => {
+    it('should render formatted dates if featureType is POINT', () => {
         const openingDate = '1970-01-01T00:00:00.000';
         const closedDate = '2021-06-09T00:00:00.000';
-        const wrapper = renderWithProps({ openingDate, closedDate });
+        let featureType = 'POINT';
+        let wrapper = renderWithProps({
+            openingDate,
+            closedDate,
+            featureType,
+        });
         const opening = getListItem(wrapper, 'Opening date');
         const closed = getListItem(wrapper, 'Closed date');
 
@@ -128,6 +133,19 @@ describe('Org unit profile (location details)', () => {
         expect(opening).toEqual(formatDate(openingDate));
         expect(closed).not.toEqual(closedDate);
         expect(closed).toEqual(formatDate(closedDate));
+
+        expect(wrapper.find('[label="Opening date"]').isEmpty()).toEqual(false);
+        expect(wrapper.find('[label="Closed date"]').isEmpty()).toEqual(false);
+
+        featureType = 'POLYGON';
+        wrapper = renderWithProps({
+            openingDate,
+            closedDate,
+            featureType,
+        });
+
+        expect(wrapper.find('[label="Opening date"]').isEmpty()).toEqual(true);
+        expect(wrapper.find('[label="Closed date"]').isEmpty()).toEqual(true);
     });
 
     it('should render formatted longitude and latitude', () => {


### PR DESCRIPTION
Improves: https://jira.dhis2.org/browse/DHIS2-11178

This PR will only show opening/closed date in the org unit profile if the selected unit is a point facility. "Opening date" is a mandatory field for all org units, but they don't apply to district levels. 

After this PR: 

<img width="302" alt="Screenshot 2021-08-23 at 12 53 02" src="https://user-images.githubusercontent.com/548708/130435827-62bcb9c6-8912-4f12-8d3a-9452eff09f71.png">

Before this PR: 

<img width="301" alt="Screenshot 2021-08-23 at 12 53 37" src="https://user-images.githubusercontent.com/548708/130435862-7d74cc15-5e9f-4aa1-8a1f-324069b2dd35.png">
