### PR TITLE
fix: upgrade web api version to 37

### DIFF
--- a/src/constants/settings.js
+++ b/src/constants/settings.js
@@ -1,4 +1,4 @@
-export const apiVersion = 36;
+export const apiVersion = 37;
 
 export const SYSTEM_SETTINGS = [
     'keyAnalysisRelativePeriod',


### PR DESCRIPTION
This PR will upgrade the Web API version to 37 for DHIS2 Maps master. 