### PR TITLE
fix: unify map label handling

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-08-20T07:13:49.483Z\n"
-"PO-Revision-Date: 2021-08-20T07:13:49.483Z\n"
+"POT-Creation-Date: 2021-08-24T13:11:12.280Z\n"
+"PO-Revision-Date: 2021-08-24T13:11:12.280Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -138,9 +138,6 @@ msgid "Organisation Units"
 msgstr ""
 
 msgid "Style"
-msgstr ""
-
-msgid "Labels"
 msgstr ""
 
 msgid "Point radius"
@@ -293,6 +290,9 @@ msgid "Buffer"
 msgstr ""
 
 msgid "Radius in meters"
+msgstr ""
+
+msgid "Labels"
 msgstr ""
 
 msgid "Aggregation type"

--- a/src/components/edit/BoundaryDialog.js
+++ b/src/components/edit/BoundaryDialog.js
@@ -2,11 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
-import { Tab, Tabs, NumberField, Checkbox, FontStyle } from '../core';
+import { Tab, Tabs, NumberField } from '../core';
 import OrgUnitTree from '../orgunits/OrgUnitTree';
 import OrgUnitGroupSelect from '../orgunits/OrgUnitGroupSelect';
 import OrgUnitLevelSelect from '../orgunits/OrgUnitLevelSelect';
 import UserOrgUnitsSelect from '../orgunits/UserOrgUnitsSelect';
+import Labels from './shared/Labels';
 import styles from './styles/LayerDialog.module.css';
 
 import {
@@ -14,9 +15,6 @@ import {
     setOrgUnitGroups,
     setUserOrgUnits,
     toggleOrgUnit,
-    setLabels,
-    setLabelFontSize,
-    setLabelFontStyle,
     setRadiusLow,
 } from '../../actions/layerEdit';
 
@@ -30,14 +28,8 @@ import {
 
 class BoundaryDialog extends Component {
     static propTypes = {
-        labels: PropTypes.bool,
-        labelFontSize: PropTypes.string,
-        labelFontStyle: PropTypes.string,
         radiusLow: PropTypes.number,
         rows: PropTypes.array,
-        setLabels: PropTypes.func.isRequired,
-        setLabelFontSize: PropTypes.func.isRequired,
-        setLabelFontStyle: PropTypes.func.isRequired,
         setOrgUnitGroups: PropTypes.func.isRequired,
         setOrgUnitLevels: PropTypes.func.isRequired,
         setRadiusLow: PropTypes.func.isRequired,
@@ -62,17 +54,11 @@ class BoundaryDialog extends Component {
     render() {
         const {
             rows = [],
-            labels,
-            labelFontSize,
-            labelFontStyle,
             radiusLow,
             setOrgUnitLevels,
             setOrgUnitGroups,
             setUserOrgUnits,
             toggleOrgUnit,
-            setLabels,
-            setLabelFontSize,
-            setLabelFontStyle,
             setRadiusLow,
         } = this.props;
 
@@ -134,23 +120,7 @@ class BoundaryDialog extends Component {
                             data-test="boundarydialog-styletab"
                         >
                             <div className={styles.flexColumn}>
-                                <div className={styles.flexInnerColumnFlow}>
-                                    <Checkbox
-                                        label={i18n.t('Labels')}
-                                        checked={labels}
-                                        onChange={setLabels}
-                                        className={styles.checkboxInline}
-                                    />
-                                    {labels && (
-                                        <FontStyle
-                                            size={labelFontSize}
-                                            fontStyle={labelFontStyle}
-                                            onSizeChange={setLabelFontSize}
-                                            onStyleChange={setLabelFontStyle}
-                                            className={styles.fontInline}
-                                        />
-                                    )}
-                                </div>
+                                <Labels />
                                 <NumberField
                                     label={i18n.t('Point radius')}
                                     value={
@@ -199,9 +169,6 @@ export default connect(
         setOrgUnitGroups,
         setUserOrgUnits,
         toggleOrgUnit,
-        setLabels,
-        setLabelFontSize,
-        setLabelFontStyle,
         setRadiusLow,
     },
     null,

--- a/src/components/edit/FacilityDialog.js
+++ b/src/components/edit/FacilityDialog.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
 import cx from 'classnames';
-import { Tab, Tabs, Checkbox, FontStyle, Help } from '../core';
+import { Tab, Tabs, Help } from '../core';
 import OrgUnitGroupSetSelect from '../orgunits/OrgUnitGroupSetSelect';
 import OrgUnitTree from '../orgunits/OrgUnitTree';
 import OrgUnitGroupSelect from '../orgunits/OrgUnitGroupSelect';
 import OrgUnitLevelSelect from '../orgunits/OrgUnitLevelSelect';
 import UserOrgUnitsSelect from '../orgunits/UserOrgUnitsSelect';
+import Labels from './shared/Labels';
 import BufferRadius from './shared/BufferRadius';
 import { FACILITY_BUFFER } from '../../constants/layers';
 import styles from './styles/LayerDialog.module.css';
@@ -19,11 +20,6 @@ import {
     setOrgUnitGroups,
     setUserOrgUnits,
     toggleOrgUnit,
-    setLabels,
-    setLabelFontColor,
-    setLabelFontSize,
-    setLabelFontWeight,
-    setLabelFontStyle,
 } from '../../actions/layerEdit';
 
 import {
@@ -36,18 +32,8 @@ import {
 
 class FacilityDialog extends Component {
     static propTypes = {
-        labels: PropTypes.bool,
-        labelFontColor: PropTypes.string,
-        labelFontSize: PropTypes.string,
-        labelFontStyle: PropTypes.string,
-        labelFontWeight: PropTypes.string,
         organisationUnitGroupSet: PropTypes.object,
         rows: PropTypes.array,
-        setLabels: PropTypes.func.isRequired,
-        setLabelFontColor: PropTypes.func.isRequired,
-        setLabelFontSize: PropTypes.func.isRequired,
-        setLabelFontStyle: PropTypes.func.isRequired,
-        setLabelFontWeight: PropTypes.func.isRequired,
         setOrgUnitLevels: PropTypes.func.isRequired,
         setOrgUnitGroups: PropTypes.func.isRequired,
         setOrganisationUnitGroupSet: PropTypes.func.isRequired,
@@ -76,21 +62,11 @@ class FacilityDialog extends Component {
         const {
             rows = [],
             organisationUnitGroupSet,
-            labels,
-            labelFontColor,
-            labelFontSize,
-            labelFontWeight,
-            labelFontStyle,
             setOrganisationUnitGroupSet,
             setOrgUnitLevels,
             setOrgUnitGroups,
             setUserOrgUnits,
             toggleOrgUnit,
-            setLabels,
-            setLabelFontColor,
-            setLabelFontSize,
-            setLabelFontWeight,
-            setLabelFontStyle,
         } = this.props;
 
         const { tab, orgUnitGroupSetError, orgUnitsError } = this.state;
@@ -167,39 +143,13 @@ class FacilityDialog extends Component {
                     )}
                     {tab === 'style' && (
                         <div
-                            className={styles.flexRowFlow}
+                            className={styles.flexColumnFlow}
                             data-test="facilitydialog-styletab"
                         >
-                            <div
-                                className={cx(
-                                    styles.flexInnerColumnFlow,
-                                    styles.singleColumn
-                                )}
-                            >
-                                <Checkbox
-                                    label={i18n.t('Labels')}
-                                    checked={labels}
-                                    onChange={setLabels}
-                                    className={styles.checkboxInline}
-                                />
-                                {labels && (
-                                    <FontStyle
-                                        color={labelFontColor}
-                                        size={labelFontSize}
-                                        weight={labelFontWeight}
-                                        fontStyle={labelFontStyle}
-                                        onColorChange={setLabelFontColor}
-                                        onSizeChange={setLabelFontSize}
-                                        onWeightChange={setLabelFontWeight}
-                                        onStyleChange={setLabelFontStyle}
-                                        className={styles.fontInline}
-                                    />
-                                )}
+                            <div className={cx(styles.flexColumn)}>
+                                <Labels />
+                                <BufferRadius defaultRadius={FACILITY_BUFFER} />
                             </div>
-                            <BufferRadius
-                                defaultRadius={FACILITY_BUFFER}
-                                className={styles.singleColumn}
-                            />
                         </div>
                     )}
                 </div>
@@ -248,11 +198,6 @@ export default connect(
         setOrgUnitGroups,
         setUserOrgUnits,
         toggleOrgUnit,
-        setLabels,
-        setLabelFontColor,
-        setLabelFontSize,
-        setLabelFontWeight,
-        setLabelFontStyle,
     },
     null,
     {

--- a/src/components/edit/shared/Labels.js
+++ b/src/components/edit/shared/Labels.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import i18n from '@dhis2/d2-i18n';
+import { Checkbox, FontStyle } from '../../core';
+import styles from '../styles/LayerDialog.module.css';
+
+import {
+    setLabels,
+    setLabelFontColor,
+    setLabelFontSize,
+    setLabelFontWeight,
+    setLabelFontStyle,
+} from '../../../actions/layerEdit';
+
+const Labels = ({
+    labels,
+    labelFontColor,
+    labelFontSize,
+    labelFontStyle,
+    labelFontWeight,
+    setLabels,
+    setLabelFontColor,
+    setLabelFontSize,
+    setLabelFontWeight,
+    setLabelFontStyle,
+}) => {
+    return (
+        <>
+            <div className={styles.flexInnerColumnFlow}>
+                <Checkbox
+                    label={i18n.t('Labels')}
+                    checked={labels}
+                    onChange={setLabels}
+                />
+            </div>
+            {labels && (
+                <div className={styles.flexInnerColumnFlow}>
+                    <FontStyle
+                        color={labelFontColor}
+                        size={labelFontSize}
+                        weight={labelFontWeight}
+                        fontStyle={labelFontStyle}
+                        onColorChange={setLabelFontColor}
+                        onSizeChange={setLabelFontSize}
+                        onWeightChange={setLabelFontWeight}
+                        onStyleChange={setLabelFontStyle}
+                        className={styles.fontBlock}
+                    />
+                </div>
+            )}
+        </>
+    );
+};
+
+Labels.propTypes = {
+    labels: PropTypes.bool,
+    labelFontColor: PropTypes.string,
+    labelFontSize: PropTypes.string,
+    labelFontStyle: PropTypes.string,
+    labelFontWeight: PropTypes.string,
+    setLabels: PropTypes.func.isRequired,
+    setLabelFontColor: PropTypes.func.isRequired,
+    setLabelFontSize: PropTypes.func.isRequired,
+    setLabelFontWeight: PropTypes.func.isRequired,
+    setLabelFontStyle: PropTypes.func.isRequired,
+};
+
+export default connect(
+    ({ layerEdit }) => ({
+        labels: layerEdit.labels,
+        labelFontColor: layerEdit.labelFontColor,
+        labelFontSize: layerEdit.labelFontSize,
+        labelFontStyle: layerEdit.labelFontStyle,
+        labelFontWeight: layerEdit.labelFontWeight,
+    }),
+    {
+        setLabels,
+        setLabelFontColor,
+        setLabelFontSize,
+        setLabelFontWeight,
+        setLabelFontStyle,
+    }
+)(Labels);

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
-import { Tab, Tabs, Checkbox, FontStyle } from '../../core';
+import { Tab, Tabs } from '../../core';
 import ValueTypeSelect from './ValueTypeSelect';
 import AggregationTypeSelect from './AggregationTypeSelect';
 import NoDataColor from './NoDataColor';
@@ -29,6 +29,7 @@ import UserOrgUnitsSelect from '../../orgunits/UserOrgUnitsSelect';
 import DimensionFilter from '../../dimensions/DimensionFilter';
 import ThematicMapTypeSelect from './ThematicMapTypeSelect';
 import RadiusSelect, { isValidRadius } from './RadiusSelect';
+import Labels from '../shared/Labels';
 import { dimConf } from '../../../constants/dimension';
 import styles from '../styles/LayerDialog.module.css';
 
@@ -45,11 +46,6 @@ import {
     setDataItem,
     setDataElementGroup,
     setIndicatorGroup,
-    setLabels,
-    setLabelFontColor,
-    setLabelFontSize,
-    setLabelFontWeight,
-    setLabelFontStyle,
     setLegendSet,
     setNoDataColor,
     setOperand,
@@ -85,11 +81,6 @@ export class ThematicDialog extends Component {
         columns: PropTypes.array,
         rows: PropTypes.array,
         filters: PropTypes.array,
-        labels: PropTypes.bool,
-        labelFontColor: PropTypes.string,
-        labelFontSize: PropTypes.string,
-        labelFontStyle: PropTypes.string,
-        labelFontWeight: PropTypes.string,
         legendSet: PropTypes.object,
         method: PropTypes.number,
         indicatorGroup: PropTypes.object,
@@ -112,11 +103,6 @@ export class ThematicDialog extends Component {
         setDataItem: PropTypes.func.isRequired,
         setDataElementGroup: PropTypes.func.isRequired,
         setIndicatorGroup: PropTypes.func.isRequired,
-        setLabels: PropTypes.func.isRequired,
-        setLabelFontColor: PropTypes.func.isRequired,
-        setLabelFontSize: PropTypes.func.isRequired,
-        setLabelFontStyle: PropTypes.func.isRequired,
-        setLabelFontWeight: PropTypes.func.isRequired,
         setLegendSet: PropTypes.func.isRequired,
         setNoDataColor: PropTypes.func.isRequired,
         setOperand: PropTypes.func.isRequired,
@@ -237,11 +223,6 @@ export class ThematicDialog extends Component {
             filters,
             id,
             indicatorGroup,
-            labels,
-            labelFontColor,
-            labelFontSize,
-            labelFontStyle,
-            labelFontWeight,
             noDataColor,
             operand,
             periodType,
@@ -260,11 +241,6 @@ export class ThematicDialog extends Component {
             setDataItem,
             setDataElementGroup,
             setIndicatorGroup,
-            setLabels,
-            setLabelFontColor,
-            setLabelFontSize,
-            setLabelFontWeight,
-            setLabelFontStyle,
             setNoDataColor,
             setOperand,
             setOrgUnitLevels,
@@ -556,28 +532,7 @@ export class ThematicDialog extends Component {
                                         className={styles.numberField}
                                     />
                                 </div>
-                                <div className={styles.flexInnerColumnFlow}>
-                                    <Checkbox
-                                        label={i18n.t('Labels')}
-                                        checked={labels}
-                                        onChange={setLabels}
-                                    />
-                                </div>
-                                {labels && (
-                                    <div className={styles.flexInnerColumnFlow}>
-                                        <FontStyle
-                                            color={labelFontColor}
-                                            size={labelFontSize}
-                                            weight={labelFontWeight}
-                                            fontStyle={labelFontStyle}
-                                            onColorChange={setLabelFontColor}
-                                            onSizeChange={setLabelFontSize}
-                                            onWeightChange={setLabelFontWeight}
-                                            onStyleChange={setLabelFontStyle}
-                                            className={styles.fontBlock}
-                                        />
-                                    </div>
-                                )}
+                                <Labels />
                             </div>
                             <div className={styles.flexColumn}>
                                 <NumericLegendStyle
@@ -749,11 +704,6 @@ export default connect(
         setDataItem,
         setDataElementGroup,
         setIndicatorGroup,
-        setLabels,
-        setLabelFontColor,
-        setLabelFontSize,
-        setLabelFontWeight,
-        setLabelFontStyle,
         setLegendSet,
         setNoDataColor,
         setOperand,

--- a/src/components/map/layers/BoundaryLayer.js
+++ b/src/components/map/layers/BoundaryLayer.js
@@ -3,7 +3,7 @@ import i18n from '@dhis2/d2-i18n';
 import Layer from './Layer';
 import Popup from '../Popup';
 import { filterData } from '../../../util/filter';
-import { LABEL_FONT_SIZE, LABEL_FONT_STYLE } from '../../../constants/layers';
+import { getLabelStyle } from '../../../util/labels';
 import { BOUNDARY_LAYER } from '../../../constants/layers';
 
 export default class BoundaryLayer extends Layer {
@@ -19,8 +19,6 @@ export default class BoundaryLayer extends Layer {
             isVisible,
             data,
             labels,
-            labelFontSize,
-            labelFontStyle,
             radiusLow,
             dataFilters,
         } = this.props;
@@ -47,14 +45,8 @@ export default class BoundaryLayer extends Layer {
         };
 
         if (labels) {
-            const fontSize = labelFontSize || LABEL_FONT_SIZE;
-
             config.label = '{name}';
-            config.labelStyle = {
-                fontSize,
-                fontStyle: labelFontStyle || LABEL_FONT_STYLE,
-                lineHeight: parseInt(fontSize, 10) * 1.2 + 'px',
-            };
+            config.labelStyle = getLabelStyle(this.props);
         }
 
         if (radiusLow) {

--- a/src/components/map/layers/FacilityLayer.js
+++ b/src/components/map/layers/FacilityLayer.js
@@ -4,13 +4,7 @@ import { isPlainObject } from 'lodash/fp';
 import Layer from './Layer';
 import Popup from '../Popup';
 import { filterData } from '../../../util/filter';
-import { cssColor } from '../../../util/colors';
-import {
-    LABEL_FONT_SIZE,
-    LABEL_FONT_STYLE,
-    LABEL_FONT_WEIGHT,
-    LABEL_FONT_COLOR,
-} from '../../../constants/layers';
+import { getLabelStyle } from '../../../util/labels';
 
 class FacilityLayer extends Layer {
     state = {
@@ -27,10 +21,6 @@ class FacilityLayer extends Layer {
             dataFilters,
             labels,
             areaRadius,
-            labelFontColor,
-            labelFontSize,
-            labelFontStyle,
-            labelFontWeight,
         } = this.props;
 
         const filteredData = filterData(data, dataFilters);
@@ -52,15 +42,9 @@ class FacilityLayer extends Layer {
 
         // Labels and label style
         if (labels) {
-            const fontSize = labelFontSize || LABEL_FONT_SIZE;
-
             config.label = '{name}';
             config.labelStyle = {
-                fontSize,
-                fontStyle: labelFontStyle || LABEL_FONT_STYLE,
-                fontWeight: labelFontWeight || LABEL_FONT_WEIGHT,
-                lineHeight: parseInt(fontSize, 10) * 1.2 + 'px',
-                color: cssColor(labelFontColor) || LABEL_FONT_COLOR,
+                ...getLabelStyle(this.props),
                 paddingTop: '10px',
             };
         }

--- a/src/components/map/layers/ThematicLayer.js
+++ b/src/components/map/layers/ThematicLayer.js
@@ -5,18 +5,14 @@ import Timeline from '../../periods/Timeline';
 import PeriodName from '../PeriodName';
 import Popup from '../Popup';
 import { filterData } from '../../../util/filter';
-import { cssColor } from '../../../util/colors';
 import { getPeriodFromFilters } from '../../../util/analytics';
 import { polygonsToPoints } from '../../../util/geojson';
+import { getLabelStyle } from '../../../util/labels';
 import {
     RENDERING_STRATEGY_SINGLE,
     RENDERING_STRATEGY_TIMELINE,
     THEMATIC_CHOROPLETH,
     THEMATIC_BUBBLE,
-    LABEL_FONT_SIZE,
-    LABEL_FONT_STYLE,
-    LABEL_FONT_WEIGHT,
-    LABEL_FONT_COLOR,
     BOUNDARY_LAYER,
 } from '../../../constants/layers';
 
@@ -30,10 +26,6 @@ class ThematicLayer extends Layer {
             data,
             dataFilters,
             labels,
-            labelFontSize,
-            labelFontStyle,
-            labelFontWeight,
-            labelFontColor,
             valuesByPeriod,
             renderingStrategy = RENDERING_STRATEGY_SINGLE,
             thematicMapType = THEMATIC_CHOROPLETH,
@@ -83,16 +75,8 @@ class ThematicLayer extends Layer {
         };
 
         if (labels) {
-            const fontSize = labelFontSize || LABEL_FONT_SIZE;
-
             config.label = '{name}';
-            config.labelStyle = {
-                fontSize,
-                fontStyle: labelFontStyle || LABEL_FONT_STYLE,
-                fontWeight: labelFontWeight || LABEL_FONT_WEIGHT,
-                color: cssColor(labelFontColor) || LABEL_FONT_COLOR,
-                lineHeight: parseInt(fontSize, 10) * 1.2 + 'px',
-            };
+            config.labelStyle = getLabelStyle(this.props);
         }
 
         // Add boundaries as a separate layer

--- a/src/util/labels.js
+++ b/src/util/labels.js
@@ -1,0 +1,24 @@
+import { cssColor } from './colors';
+import {
+    LABEL_FONT_SIZE,
+    LABEL_FONT_STYLE,
+    LABEL_FONT_WEIGHT,
+    LABEL_FONT_COLOR,
+} from '../constants/layers';
+
+export const getLabelStyle = ({
+    labelFontSize,
+    labelFontStyle,
+    labelFontWeight,
+    labelFontColor,
+}) => {
+    const fontSize = labelFontSize || LABEL_FONT_SIZE;
+    return {
+        fontSize,
+        fontStyle: labelFontStyle || LABEL_FONT_STYLE,
+        fontWeight: labelFontWeight || LABEL_FONT_WEIGHT,
+        lineHeight: parseInt(fontSize, 10) * 1.2 + 'px',
+        color: cssColor(labelFontColor) || LABEL_FONT_COLOR,
+        paddingTop: '10px',
+    };
+};


### PR DESCRIPTION
Partly implements: https://github.com/dhis2/maps-app/pull/1720

This PR refactors and unifies how we handle map labels in DHIS2 Maps. A lot of code was duplicated across different layer types, and is now reused. 

A separate Labels component was created and shared between Thematic, Boundary and Facility layers. 

Boundary layers will now have the same font styling options as other layers. 

Thematic layer after this PR: 

<img width="597" alt="Screenshot 2021-08-24 at 16 27 10" src="https://user-images.githubusercontent.com/548708/130634901-e314e419-882e-4506-a7bd-df8fe4b59045.png">

This is the same as before. 

Facility layer after this PR: 

<img width="593" alt="Screenshot 2021-08-24 at 16 28 21" src="https://user-images.githubusercontent.com/548708/130635069-7d2c93b6-9b2a-41a5-8509-2756e820b970.png">

Before (only layout change): 

<img width="596" alt="Screenshot 2021-08-24 at 16 28 55" src="https://user-images.githubusercontent.com/548708/130635194-efc5353b-4a8c-45fa-94c8-94ceb6cf28f0.png">

Boundary layer after this PR: 

<img width="597" alt="Screenshot 2021-08-24 at 16 30 02" src="https://user-images.githubusercontent.com/548708/130635371-e66fd0c1-f717-4350-82f7-e5ef89ed897c.png">

Before (not possible to change font color and set bold style): 

<img width="595" alt="Screenshot 2021-08-24 at 16 30 36" src="https://user-images.githubusercontent.com/548708/130635476-76b94d4a-9439-4869-9e25-a1aeaaebc21f.png">

Boundary map after this PR: 

<img width="1189" alt="Screenshot 2021-08-24 at 16 32 27" src="https://user-images.githubusercontent.com/548708/130635802-200881d8-5da1-4d66-af6b-180b3d75b4d1.png">

Before it was not possible to set font color and bold style. 


