### PR TITLE
fix: only include icon url in feature properties

### DIFF
--- a/src/loaders/facilityLoader.js
+++ b/src/loaders/facilityLoader.js
@@ -109,10 +109,7 @@ const toGeoJson = (facility, group, contextPath) => ({
         id: facility.id,
         name: facility.na,
         label: `${facility.na} (${group.name})`,
-        icon: {
-            iconUrl: `${contextPath}/images/orgunitgroup/${group.symbol}`,
-            iconSize: [16, 16],
-        },
+        iconUrl: `${contextPath}/images/orgunitgroup/${group.symbol}`,
         type: 'Point', // Accessible in data table
     },
     geometry: {


### PR DESCRIPTION
This PR will remove the icon size from the feature properties passed to the maps-gl api. Icon size is not in use, and we would also like to support different icon sizes. 

This PR depends on https://github.com/dhis2/maps-gl/pull/389/