### PR TITLE
fix: use debug/dev for now until test instance is fixed

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -141,11 +141,10 @@ jobs:
                   COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
                   SERVER_START_CMD: 'yarn cypress:start'
                   SERVER_URL: 'http://localhost:8082'
-                  DHIS2_BASE_URL: 'https://debug.dhis2.org/dboard-dev-e2e'
-                  cypress_dhis2_base_url: 'https://debug.dhis2.org/dboard-dev-e2e'
+                  DHIS2_BASE_URL: 'https://debug.dhis2.org/dev'
+                  cypress_dhis2_base_url: 'https://debug.dhis2.org/dev'
                   cypress_dhis2_username: 'admin'
                   cypress_dhis2_password: 'district'
-
 
     publish:
         runs-on: ubuntu-latest


### PR DESCRIPTION
dboard-dev-e2e is down, so use dev for cypress tests for now.