### PR TITLE
fix: check if response body is empty

### DIFF
--- a/src/util/api.js
+++ b/src/util/api.js
@@ -1,12 +1,12 @@
 import { isString, isObject } from 'lodash/fp';
 import { config } from 'd2';
 
-// The api/configurations/xx endpoints returns an empty string if no config is set
+// The api/configuration/xx endpoints returns an empty body if the config is not set
 // This is a replacement for response.json() which gives error if body is empty
 // https://stackoverflow.com/a/51320025
 const getJsonResponse = async response => {
     const string = await response.text();
-    const json = string === '' ? {} : JSON.parse(string);
+    const json = string === '' ? undefined : JSON.parse(string);
     return json;
 };
 

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -1,6 +1,15 @@
 import { isString, isObject } from 'lodash/fp';
 import { config } from 'd2';
 
+// The api/configurations/xx endpoints returns an empty string if no config is set
+// This is a replacement for response.json() which gives error if body is empty
+// https://stackoverflow.com/a/51320025
+const getJsonResponse = async response => {
+    const string = await response.text();
+    const json = string === '' ? {} : JSON.parse(string);
+    return json;
+};
+
 export const apiFetch = async (url, method, body) => {
     const options = {
         headers: {
@@ -30,7 +39,7 @@ export const apiFetch = async (url, method, body) => {
         .then(response =>
             ['POST', 'PUT', 'PATCH'].includes(method)
                 ? response
-                : response.json()
+                : getJsonResponse(response)
         )
         .catch(error => console.log('Error: ', error)); // eslint-disable-line
 };


### PR DESCRIPTION
This PR fixes an issue with new configuration endpoints in 2.37: 
https://debug.dhis2.org/dev/api/37/configuration/facilityOrgUnitLevel
https://debug.dhis2.org/dev/api/37/configuration/facilityOrgUnitGroupSet

If the config is not set, it returns an empty body, which gives an error when we use response.json()

This fix checks if the response is an empty string before trying to parse it. 
I found the solution on https://stackoverflow.com/a/51320025

@larshelge is this empty response by design? 