### PR TITLE
fix: backward compatibility for EE layers 

### DIFF
--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -61,6 +61,22 @@ const earthEngineLoader = async config => {
             layerConfig.filter[0].arguments[1] = period;
         }
 
+        // Backward compability for layers with periods saved before 2.36
+        // (could also be fixed in a db update script)
+        if (layerConfig.image) {
+            const filter = layerConfig.filter?.[0];
+
+            if (filter) {
+                const period = filter.arguments?.[1];
+
+                if (typeof period === 'string' && period.length > 4) {
+                    filter.year = parseInt(period.substring(0, 4), 10);
+                }
+
+                filter.name = String(layerConfig.image);
+            }
+        }
+
         dataset = getEarthEngineLayer(layerConfig.id);
 
         if (dataset) {

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -68,12 +68,18 @@ const earthEngineLoader = async config => {
 
             if (filter) {
                 const period = filter.arguments?.[1];
+                let name = String(layerConfig.image);
 
                 if (typeof period === 'string' && period.length > 4) {
-                    filter.year = parseInt(period.substring(0, 4), 10);
+                    const year = period.substring(0, 4);
+                    filter.year = parseInt(year, 10);
+
+                    if (name.slice(-4) === year) {
+                        name = name.slice(0, -4);
+                    }
                 }
 
-                filter.name = String(layerConfig.image);
+                filter.name = name;
             }
         }
 

--- a/src/util/earthEngine.js
+++ b/src/util/earthEngine.js
@@ -90,12 +90,12 @@ const connectEarthEngine = () =>
         resolve(window.ee);
     });
 
-export const getPeriods = async id => {
-    const { periodType } = getEarthEngineLayer(id);
+export const getPeriods = async eeId => {
+    const { periodType } = getEarthEngineLayer(eeId);
     const ee = await connectEarthEngine();
 
     const imageCollection = ee
-        .ImageCollection(id)
+        .ImageCollection(eeId)
         .distinct('system:time_start')
         .sort('system:time_start', false);
 
@@ -109,6 +109,11 @@ export const getPeriods = async id => {
             periodType === 'Yearly'
                 ? String(year)
                 : getStartEndDate(properties);
+
+        // Remove when old population should not be supported
+        if (eeId === 'WorldPop/POP') {
+            return { id: name, name, year };
+        }
 
         return { id, name, year };
     };


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11749

We slightly changed the config syntax for Earth Engine layers in 2.36, and there are some EE datasets we no longer support as they are not updated. There are some issues for maps saved before 2.36 as they still have the old syntax. We could update these in a db update script, but for now it was easier to add some checks in the app. 

All layers load before this fix, but the period is not shown in the map legend, and it is not possible to change the period in DHIS2 Maps. This PR fixes both issues. We still allow deprecated layers (e.g. "Nightime lights") to be edited, if they are created in a previous version of DHIS2 Maps.

For the Sierra Leone demo database, the fix applies to the following maps:
- Malaria: LLITN coverage and rainfall EE
- Immunization: FIC at facilities and population density 2016 EE
- EE: Nighttime lights 2013 EE

After this PR:

![Screenshot 2021-09-09 at 17 49 36](https://user-images.githubusercontent.com/548708/132719730-75a12627-acac-4a92-bddb-ffe489b46288.png)
![Screenshot 2021-09-09 at 17 32 51](https://user-images.githubusercontent.com/548708/132719734-7e70ee5d-1c7f-46be-81e1-0f6285040be7.png)
![Screenshot 2021-09-09 at 17 32 28](https://user-images.githubusercontent.com/548708/132719736-76af572a-5bfb-48e5-8006-3464c0f221ef.png)


Before: 

![Screenshot 2021-09-09 at 17 31 08](https://user-images.githubusercontent.com/548708/132716368-6bdcf0b5-77f7-4a25-803d-3b4a79bc3384.png)
![Screenshot 2021-09-09 at 17 31 45](https://user-images.githubusercontent.com/548708/132716359-5160f088-0786-4ac4-bfa9-5ed9d346a677.png)
![Screenshot 2021-09-09 at 17 31 29](https://user-images.githubusercontent.com/548708/132716363-4d366fac-8b87-4d18-bbb2-4613270d8dc4.png)


