### PR TITLE
fix: facility layer and group set styling improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@dhis2/d2-ui-interpretations": "^7.3.2",
         "@dhis2/d2-ui-org-unit-dialog": "^7.3.2",
         "@dhis2/d2-ui-org-unit-tree": "^7.3.2",
-        "@dhis2/maps-gl": "^2.1.0",
+        "@dhis2/maps-gl": "^2.1.1",
         "@dhis2/ui": "^6.20.0",
         "abortcontroller-polyfill": "^1.5.0",
         "array-move": "^3.0.1",

--- a/src/components/groupSet/GroupSetStyle.js
+++ b/src/components/groupSet/GroupSetStyle.js
@@ -5,6 +5,7 @@ import { Help } from '@dhis2/ui';
 import GroupStyle from './GroupStyle';
 import { fetchOrgUnitGroupSet } from '../../util/orgUnits';
 import { STYLE_TYPE_COLOR } from '../../constants/layers';
+import styles from './styles/GroupSetStyle.module.css';
 
 export const GroupSetStyle = ({
     defaultStyleType = STYLE_TYPE_COLOR,
@@ -25,9 +26,17 @@ export const GroupSetStyle = ({
         return <Help error>{error}</Help>;
     }
 
-    return groups.map(group => (
-        <GroupStyle key={group.id} styleType={defaultStyleType} {...group} />
-    ));
+    return (
+        <div className={styles.groupSetStyle}>
+            {groups.map(group => (
+                <GroupStyle
+                    key={group.id}
+                    styleType={defaultStyleType}
+                    {...group}
+                />
+            ))}
+        </div>
+    );
 };
 
 GroupSetStyle.propTypes = {

--- a/src/components/groupSet/styles/GroupSetStyle.module.css
+++ b/src/components/groupSet/styles/GroupSetStyle.module.css
@@ -1,0 +1,3 @@
+.groupSetStyle {
+    margin-top: var(--spacers-dp12);
+}

--- a/src/util/orgUnits.js
+++ b/src/util/orgUnits.js
@@ -11,18 +11,35 @@ import {
     STYLE_TYPE_SYMBOL,
 } from '../constants/layers';
 
-const getColor = getUniqueColor(qualitativeColors);
+const getGroupColor = groups => {
+    const groupsWithoutColors = groups.filter(g => !g.color);
+    const colors = getUniqueColor(qualitativeColors);
+    return group => {
+        const index = groupsWithoutColors.findIndex(g => g.id === group.id);
+        return colors(index);
+    };
+};
+
+// Default symbol 21-25 are coloured circles
+const getGroupSymbol = groups => {
+    const groupsWithoutSymbols = groups.filter(g => !g.symbol);
+    return group => {
+        const index = groupsWithoutSymbols.findIndex(g => g.id === group.id);
+        return index < 5 ? `${21 + index}.png` : '25.png';
+    };
+};
 
 const parseGroupSet = ({ organisationUnitGroups: groups }) => {
     groups.sort((a, b) => a.name.localeCompare(b.name));
-    return groups.map((group, index) => {
-        const {
-            color = getColor(index),
-            symbol = index < 5 ? 21 + index + '.png' : '25.png', // Symbol 21-25 are coloured circles
-        } = group;
 
-        return { ...group, color, symbol };
-    });
+    const getColor = getGroupColor(groups);
+    const getSymbol = getGroupSymbol(groups);
+
+    return groups.map(group => ({
+        ...group,
+        color: group.color || getColor(group),
+        symbol: group.symbol || getSymbol(group),
+    }));
 };
 
 export const fetchOrgUnitGroupSet = id =>

--- a/src/util/orgUnits.js
+++ b/src/util/orgUnits.js
@@ -15,11 +15,14 @@ const getColor = getUniqueColor(qualitativeColors);
 
 const parseGroupSet = ({ organisationUnitGroups: groups }) => {
     groups.sort((a, b) => a.name.localeCompare(b.name));
-    return groups.map((group, index) => ({
-        ...group,
-        color: group.color || getColor(index),
-        symbol: group.symbol || 21 + index + '.png', // Default symbol 21-25 are coloured circles
-    }));
+    return groups.map((group, index) => {
+        const {
+            color = getColor(index),
+            symbol = index < 5 ? 21 + index + '.png' : '25.png', // Symbol 21-25 are coloured circles
+        } = group;
+
+        return { ...group, color, symbol };
+    });
 };
 
 export const fetchOrgUnitGroupSet = id =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2268,10 +2268,10 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-2.1.0.tgz#994ed9289b10bf52e69cba750f536eef7fcb063e"
-  integrity sha512-3v5LsOpzMckzsWMv4xklQCe30pjVq4hTImCtB6initARMN75+IFe98AZPzGhXKEHXbDyNHV6LzAJzDehz+7qtg==
+"@dhis2/maps-gl@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-2.1.1.tgz#c9635136d684452228c5409d7ab380a8e707b9a0"
+  integrity sha512-kdpm4iD7jUOlq9csaJz7N0wWW26lm76cqJaKs4ZaGT0MI5lwoV5By42B+E+W7DuPSl+XTC6QCyVu5EN+HMUHtQ==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.3.0"


### PR DESCRIPTION
This PR fixes the following issues for facility layer: 
- Upgrades maps-gl dependency with symbol opacity fix https://github.com/dhis2/maps-gl/pull/395
- Extra space above the group set preview 
- More bullet proof fallback symbols and colors
- Made the fallback colors more distinguishable

Colors and icon symbols for org unit groups sets needs to be set the maintenance app, but we support some simple fallbacks.

For icon symbols the fallback is colored circles. The icon set we have used for a long time only contains 5 color circles. This PR makes sure we select one of those. If there are more than 5 groups without symbols, the same color circle is used. 

Same with colors except that we have unlimited number of colors: If a group is not having a color set, we will pick from our 12 predefined colors, or a random color if there are more groups.

The icon set should be improved - and we should also allow users to upload their own icons - but it won't happen for 2.37.  

After this PR (more distinguishable colors + extra space above legend): 

![Screenshot 2021-09-10 at 13 24 58](https://user-images.githubusercontent.com/548708/132846543-75b6d68c-984d-4077-a9ff-3f65dfb38b26.png)

Before: 

![Screenshot 2021-09-10 at 13 25 20](https://user-images.githubusercontent.com/548708/132846562-3d99d161-1538-4b83-978a-a52cba3a3395.png)

After this PR: 

![Screenshot 2021-09-10 at 13 28 03](https://user-images.githubusercontent.com/548708/132846785-8d6c2136-1dcd-419d-ab15-7d40742f73cb.png)

Before: 

![Screenshot 2021-09-10 at 13 28 27](https://user-images.githubusercontent.com/548708/132846797-2fba01e6-6f26-46b9-a460-94e0e82912dc.png)
