### PR TITLE
fix: constrasting event stroke and cluster count color

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@dhis2/d2-ui-interpretations": "^7.3.2",
         "@dhis2/d2-ui-org-unit-dialog": "^7.3.2",
         "@dhis2/d2-ui-org-unit-tree": "^7.3.2",
-        "@dhis2/maps-gl": "^2.1.1",
+        "@dhis2/maps-gl": "^2.1.3",
         "@dhis2/ui": "^6.20.0",
         "abortcontroller-polyfill": "^1.5.0",
         "array-move": "^3.0.1",

--- a/src/components/legend/LegendItem.js
+++ b/src/components/legend/LegendItem.js
@@ -11,6 +11,7 @@ const LegendItem = ({
     type,
     image,
     color,
+    strokeColor,
     radius,
     weight,
     name,
@@ -26,6 +27,10 @@ const LegendItem = ({
         backgroundImage: image ? `url(${image})` : 'none',
         backgroundColor: color ? color : 'transparent',
     };
+
+    if (strokeColor) {
+        symbol.border = `1px solid ${strokeColor}`;
+    }
 
     if (radius) {
         const r = Math.min(radius, maxRadius) * 2;
@@ -62,6 +67,7 @@ LegendItem.propTypes = {
     type: PropTypes.string,
     image: PropTypes.string,
     color: PropTypes.string,
+    strokeColor: PropTypes.string,
     radius: PropTypes.number,
     weight: PropTypes.number,
     name: PropTypes.string,

--- a/src/components/map/layers/EventLayer.js
+++ b/src/components/map/layers/EventLayer.js
@@ -6,6 +6,7 @@ import EventPopup from './EventPopup';
 import { getDisplayPropertyUrl } from '../../../util/helpers';
 import { formatCount } from '../../../util/numbers';
 import { filterData } from '../../../util/filter';
+import { getContrastColor } from '../../../util/colors';
 import { EVENT_COLOR, EVENT_RADIUS } from '../../../constants/layers';
 
 class EventLayer extends Layer {
@@ -45,6 +46,12 @@ class EventLayer extends Layer {
                 ? '#' + eventPointColor
                 : eventPointColor;
 
+        const fillColor = color || EVENT_COLOR;
+        const strokeColor = !styleDataItem
+            ? getContrastColor(fillColor)
+            : undefined;
+        const radius = eventPointRadius || EVENT_RADIUS;
+
         const map = this.context.map;
         let d2;
         let eventRequest;
@@ -60,8 +67,9 @@ class EventLayer extends Layer {
             opacity,
             isVisible,
             data: filteredData,
-            fillColor: color || EVENT_COLOR,
-            radius: eventPointRadius || EVENT_RADIUS,
+            fillColor,
+            strokeColor,
+            radius,
             onClick: this.onEventClick.bind(this),
         };
 

--- a/src/components/map/layers/EventLayer.js
+++ b/src/components/map/layers/EventLayer.js
@@ -50,6 +50,7 @@ class EventLayer extends Layer {
         const strokeColor = !styleDataItem
             ? getContrastColor(fillColor)
             : undefined;
+        const countColor = strokeColor;
         const radius = eventPointRadius || EVENT_RADIUS;
 
         const map = this.context.map;
@@ -69,6 +70,7 @@ class EventLayer extends Layer {
             data: filteredData,
             fillColor,
             strokeColor,
+            countColor,
             radius,
             onClick: this.onEventClick.bind(this),
         };

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -22,7 +22,7 @@ import {
     EVENT_RADIUS,
 } from '../constants/layers';
 import { formatLocaleDate } from '../util/time';
-import { cssColor } from '../util/colors';
+import { cssColor, getContrastColor } from '../util/colors';
 
 // Server clustering if more than 2000 events
 const useServerCluster = count => count > EVENT_SERVER_CLUSTER_COUNT;
@@ -115,34 +115,8 @@ const loadEventLayer = async config => {
         config.data = data;
 
         if (Array.isArray(config.data) && config.data.length) {
-            let explanation = [];
-
             if (styleDataItem) {
                 await styleByDataItem(config);
-            } else {
-                config.legend.items = [
-                    {
-                        name: i18n.t('Event'),
-                        color: cssColor(eventPointColor) || EVENT_COLOR,
-                        radius: eventPointRadius || EVENT_RADIUS,
-                    },
-                ];
-            }
-
-            if (eventStatus) {
-                explanation.push(
-                    `${i18n.t('Event status')}: ${
-                        getEventStatuses().find(s => s.id === eventStatus).name
-                    }`
-                );
-            }
-
-            if (areaRadius) {
-                explanation.push(`${i18n.t('Buffer')}: ${areaRadius} ${'m'}`);
-            }
-
-            if (explanation.length) {
-                config.legend.explanation = explanation;
             }
 
             if (total > EVENT_CLIENT_PAGE_SIZE) {
@@ -174,6 +148,38 @@ const loadEventLayer = async config => {
             });
 
         config.headers = response.headers;
+    }
+
+    if (!styleDataItem) {
+        const color = cssColor(eventPointColor) || EVENT_COLOR;
+        const strokeColor = getContrastColor(color);
+
+        config.legend.items = [
+            {
+                name: i18n.t('Event'),
+                color,
+                strokeColor,
+                radius: eventPointRadius || EVENT_RADIUS,
+            },
+        ];
+    }
+
+    let explanation = [];
+
+    if (eventStatus) {
+        explanation.push(
+            `${i18n.t('Event status')}: ${
+                getEventStatuses().find(s => s.id === eventStatus).name
+            }`
+        );
+    }
+
+    if (areaRadius) {
+        explanation.push(`${i18n.t('Buffer')}: ${areaRadius} ${'m'}`);
+    }
+
+    if (explanation.length) {
+        config.legend.explanation = explanation;
     }
 
     if (alert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2268,10 +2268,10 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-2.1.1.tgz#c9635136d684452228c5409d7ab380a8e707b9a0"
-  integrity sha512-kdpm4iD7jUOlq9csaJz7N0wWW26lm76cqJaKs4ZaGT0MI5lwoV5By42B+E+W7DuPSl+XTC6QCyVu5EN+HMUHtQ==
+"@dhis2/maps-gl@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-2.1.3.tgz#840620d5174d719352002be6e9a75e6097727144"
+  integrity sha512-xF43LnFDejpP+1wZuspTJzGGZiBFmDfG7brgT/l5sdrhJGBP5rBRE+s3ozdXplst45epaI2/V+5WShYmGYcY4w==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.3.0"


### PR DESCRIPTION
This PR will add a contrasting stroke and cluster count color for events. If the event color is dark, the stroke/vount color will be bright, and opposite. Stroke will only be used for single color maps, not when events that are "styled by data item". 

Storke is also added to the legend item, and legend item is added for server cluster (see screenshot below). 

Depends on https://github.com/dhis2/maps-gl/pull/398

After this PR: 

<img width="1322" alt="Screenshot 2021-09-13 at 09 58 54" src="https://user-images.githubusercontent.com/548708/133045952-60a3d0d9-0a7b-4921-aafa-9f995b8d4ae4.png">

Before: 

<img width="1323" alt="Screenshot 2021-09-13 at 09 59 24" src="https://user-images.githubusercontent.com/548708/133046013-dfce4f98-af4b-4641-a8fc-e7d5c43d073a.png">


