### PR TITLE
fix: improvements to facility and org unit layers

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-09-13T10:01:32.462Z\n"
-"PO-Revision-Date: 2021-09-13T10:01:32.462Z\n"
+"POT-Creation-Date: 2021-09-13T10:56:35.161Z\n"
+"PO-Revision-Date: 2021-09-13T10:56:35.161Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -281,6 +281,9 @@ msgid "No legend set is selected"
 msgstr ""
 
 msgid "Event status"
+msgstr ""
+
+msgid "Boundary color"
 msgstr ""
 
 msgid "Buffer"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-09-10T07:57:53.804Z\n"
-"PO-Revision-Date: 2021-09-10T07:57:53.804Z\n"
+"POT-Creation-Date: 2021-09-13T10:01:32.462Z\n"
+"PO-Revision-Date: 2021-09-13T10:01:32.462Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -1242,9 +1242,6 @@ msgid "No facilities found"
 msgstr ""
 
 msgid "Facilities"
-msgstr ""
-
-msgid "No org units found"
 msgstr ""
 
 msgid "Organisation units"

--- a/src/components/core/Checkbox.js
+++ b/src/components/core/Checkbox.js
@@ -9,6 +9,7 @@ const Checkbox = ({
     label,
     checked = false,
     disabled,
+    dense = true,
     onChange,
     className,
 }) => (
@@ -16,6 +17,7 @@ const Checkbox = ({
         <UiCheckbox
             label={label}
             checked={checked}
+            dense={dense}
             disabled={disabled}
             onChange={({ checked }) => onChange(checked)}
         />
@@ -25,6 +27,7 @@ const Checkbox = ({
 Checkbox.propTypes = {
     label: PropTypes.string,
     checked: PropTypes.bool,
+    dense: PropTypes.bool,
     disabled: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
     className: PropTypes.string,

--- a/src/components/core/FontStyle.js
+++ b/src/components/core/FontStyle.js
@@ -6,7 +6,12 @@ import cx from 'classnames';
 import NumberField from './NumberField';
 import ColorButton from './ColorButton';
 import { cssColor } from '../../util/colors';
-import { LABEL_FONT_SIZE, LABEL_FONT_COLOR } from '../../constants/layers';
+import {
+    LABEL_FONT_SIZE,
+    LABEL_FONT_SIZE_MIN,
+    LABEL_FONT_SIZE_MAX,
+    LABEL_FONT_COLOR,
+} from '../../constants/layers';
 import styles from './styles/FontStyle.module.css';
 
 const FontStyle = ({
@@ -25,6 +30,8 @@ const FontStyle = ({
             <NumberField
                 dense
                 label={i18n.t('Size')}
+                min={LABEL_FONT_SIZE_MIN}
+                max={LABEL_FONT_SIZE_MAX}
                 value={parseInt(
                     size !== undefined ? size : LABEL_FONT_SIZE,
                     10

--- a/src/components/core/Radio.js
+++ b/src/components/core/Radio.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Radio as UiRadio } from '@dhis2/ui';
 import { RadioContext } from './RadioGroup';
 
-const Radio = ({ value, disabled, dataTest, label }) => {
+const Radio = ({ value, disabled, dense = true, dataTest, label }) => {
     const { radio, onChange } = useContext(RadioContext);
 
     // onChange is from the parent component
@@ -16,6 +16,7 @@ const Radio = ({ value, disabled, dataTest, label }) => {
     return (
         <UiRadio
             label={label}
+            dense={dense}
             disabled={disabled}
             checked={value === radio}
             onChange={onClick}
@@ -26,6 +27,7 @@ const Radio = ({ value, disabled, dataTest, label }) => {
 
 Radio.propTypes = {
     label: PropTypes.string.isRequired,
+    dense: PropTypes.bool,
     disabled: PropTypes.bool,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     dataTest: PropTypes.string,

--- a/src/components/core/SelectField.js
+++ b/src/components/core/SelectField.js
@@ -23,6 +23,7 @@ export const SelectField = props => {
         label,
         loading,
         multiple,
+        disabled,
         onChange,
         className,
         value,
@@ -61,6 +62,7 @@ export const SelectField = props => {
                 dense={dense}
                 label={label}
                 selected={!isLoading ? selected : undefined}
+                disabled={disabled}
                 loading={isLoading}
                 error={!!errorText}
                 validationText={errorText}
@@ -87,6 +89,11 @@ SelectField.propTypes = {
      * Render a dense select field
      */
     dense: PropTypes.bool,
+
+    /**
+     * Disable the select field
+     */
+    disabled: PropTypes.bool,
 
     /**
      * If set, shows the help text below the SelectField

--- a/src/components/core/styles/FontStyle.module.css
+++ b/src/components/core/styles/FontStyle.module.css
@@ -2,6 +2,8 @@
     display: flex;
     align-items: flex-end;
     margin-bottom: var(--spacers-dp8);
+    padding-left: 23px;
+    margin-top: -12px;
 }
 
 .fontStyle > * {

--- a/src/components/edit/FacilityDialog.js
+++ b/src/components/edit/FacilityDialog.js
@@ -16,6 +16,8 @@ import {
     ORG_UNIT_RADIUS,
     FACILITY_BUFFER,
     STYLE_TYPE_SYMBOL,
+    MIN_RADIUS,
+    MAX_RADIUS,
 } from '../../constants/layers';
 import styles from './styles/LayerDialog.module.css';
 
@@ -210,6 +212,8 @@ class FacilityDialog extends Component {
                                                     ? radiusLow
                                                     : ORG_UNIT_RADIUS
                                             }
+                                            min={MIN_RADIUS}
+                                            max={MAX_RADIUS}
                                             onChange={setRadiusLow}
                                             disabled={
                                                 !!organisationUnitGroupSet

--- a/src/components/edit/FacilityDialog.js
+++ b/src/components/edit/FacilityDialog.js
@@ -185,6 +185,13 @@ class FacilityDialog extends Component {
                             data-test="facilitydialog-styletab"
                         >
                             <div className={cx(styles.flexColumn)}>
+                                <Labels />
+                                <BufferRadius defaultRadius={FACILITY_BUFFER} />
+                            </div>
+                            <div className={styles.flexColumn}>
+                                <StyleByGroupSet
+                                    defaultStyleType={STYLE_TYPE_SYMBOL}
+                                />
                                 {!organisationUnitGroupSet && (
                                     <>
                                         <ColorPicker
@@ -209,16 +216,8 @@ class FacilityDialog extends Component {
                                             }
                                             className={styles.narrowFieldIcon}
                                         />
-                                        <div className={styles.gap} />
                                     </>
                                 )}
-                                <Labels />
-                                <BufferRadius defaultRadius={FACILITY_BUFFER} />
-                            </div>
-                            <div className={styles.flexColumn}>
-                                <StyleByGroupSet
-                                    defaultStyleType={STYLE_TYPE_SYMBOL}
-                                />
                             </div>
                         </div>
                     )}

--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -23,6 +23,8 @@ import {
     EVENT_RADIUS,
     EVENT_BUFFER,
     CLASSIFICATION_PREDEFINED,
+    MIN_RADIUS,
+    MAX_RADIUS,
 } from '../../../constants/layers';
 import { START_END_DATES } from '../../../constants/periods';
 
@@ -351,6 +353,8 @@ export class EventDialog extends Component {
                                     />
                                     <NumberField
                                         label={i18n.t('Radius')}
+                                        min={MIN_RADIUS}
+                                        max={MAX_RADIUS}
                                         value={eventPointRadius || EVENT_RADIUS}
                                         onChange={setEventPointRadius}
                                     />

--- a/src/components/edit/orgUnit/OrgUnitDialog.js
+++ b/src/components/edit/orgUnit/OrgUnitDialog.js
@@ -13,6 +13,8 @@ import {
     ORG_UNIT_COLOR,
     ORG_UNIT_RADIUS,
     STYLE_TYPE_COLOR,
+    MIN_RADIUS,
+    MAX_RADIUS,
 } from '../../../constants/layers';
 import styles from '../styles/LayerDialog.module.css';
 
@@ -142,6 +144,8 @@ class OrgUnitDialog extends Component {
                                 />
                                 <NumberField
                                     label={i18n.t('Point radius')}
+                                    min={MIN_RADIUS}
+                                    max={MAX_RADIUS}
                                     value={
                                         radiusLow !== undefined
                                             ? radiusLow

--- a/src/components/edit/orgUnit/OrgUnitDialog.js
+++ b/src/components/edit/orgUnit/OrgUnitDialog.js
@@ -135,7 +135,7 @@ class OrgUnitDialog extends Component {
                             <div className={styles.flexColumn}>
                                 <Labels />
                                 <ColorPicker
-                                    label={i18n.t('Color')}
+                                    label={i18n.t('Boundary color')}
                                     color={
                                         organisationUnitColor || ORG_UNIT_COLOR
                                     }

--- a/src/components/edit/shared/BufferRadius.js
+++ b/src/components/edit/shared/BufferRadius.js
@@ -41,6 +41,7 @@ const BufferRadius = ({
                         setBufferRadius(value !== '' ? parseInt(value, 10) : '')
                     }
                     min={0}
+                    className={styles.numberField}
                 />
             )}
         </div>

--- a/src/components/edit/shared/Labels.js
+++ b/src/components/edit/shared/Labels.js
@@ -28,23 +28,25 @@ const Labels = ({
 }) => {
     return (
         <div className={cx(styles.flexInnerColumnFlow)}>
-            <Checkbox
-                label={i18n.t('Labels')}
-                checked={labels}
-                onChange={setLabels}
-            />
-            {labels && (
-                <FontStyle
-                    color={labelFontColor}
-                    size={labelFontSize}
-                    weight={labelFontWeight}
-                    fontStyle={labelFontStyle}
-                    onColorChange={setLabelFontColor}
-                    onSizeChange={setLabelFontSize}
-                    onWeightChange={setLabelFontWeight}
-                    onStyleChange={setLabelFontStyle}
+            <div>
+                <Checkbox
+                    label={i18n.t('Labels')}
+                    checked={labels}
+                    onChange={setLabels}
                 />
-            )}
+                {labels && (
+                    <FontStyle
+                        color={labelFontColor}
+                        size={labelFontSize}
+                        weight={labelFontWeight}
+                        fontStyle={labelFontStyle}
+                        onColorChange={setLabelFontColor}
+                        onSizeChange={setLabelFontSize}
+                        onWeightChange={setLabelFontWeight}
+                        onStyleChange={setLabelFontStyle}
+                    />
+                )}
+            </div>
         </div>
     );
 };

--- a/src/components/edit/shared/styles/BufferRadius.module.css
+++ b/src/components/edit/shared/styles/BufferRadius.module.css
@@ -1,6 +1,4 @@
 .buffer {
-    display: flex;
-    flex-wrap: wrap;
     margin: 0 -8px;
     clear: both;
     align-items: center;
@@ -8,11 +6,9 @@
 }
 
 .buffer > div {
-    flex: 1;
     margin: var(--spacers-dp8);
 }
 
-.buffer > div:first-child {
-    max-width: 155px;
-    padding-top: var(--spacers-dp8);
+.numberField {
+    padding-left: 23px;
 }

--- a/src/components/edit/styles/LayerDialog.module.css
+++ b/src/components/edit/styles/LayerDialog.module.css
@@ -154,7 +154,3 @@
     line-height: 12px;
     margin-left: var(--spacers-dp12);
 }
-
-.gap {
-    margin-bottom: var(--spacers-dp16);
-}

--- a/src/components/edit/trackedEntity/TrackedEntityDialog.js
+++ b/src/components/edit/trackedEntity/TrackedEntityDialog.js
@@ -32,6 +32,8 @@ import {
     TEI_RELATED_COLOR,
     TEI_RELATIONSHIP_LINE_COLOR,
     TEI_RELATED_RADIUS,
+    MIN_RADIUS,
+    MAX_RADIUS,
 } from '../../../constants/layers';
 
 import {
@@ -413,6 +415,8 @@ export class TrackedEntityDialog extends Component {
                                             />
                                             <NumberField
                                                 label={i18n.t('Point size')}
+                                                min={MIN_RADIUS}
+                                                max={MAX_RADIUS}
                                                 value={
                                                     relatedPointRadius ||
                                                     TEI_RELATED_RADIUS

--- a/src/components/orgunits/styles/OrgUnitProfile.module.css
+++ b/src/components/orgunits/styles/OrgUnitProfile.module.css
@@ -15,7 +15,7 @@
 
 .close {
     position: absolute;
-    top: 6px;
+    top: 7px;
     right: var(--spacers-dp4);
     cursor: pointer;
 }

--- a/src/components/periods/styles/PeriodSelect.module.css
+++ b/src/components/periods/styles/PeriodSelect.module.css
@@ -5,10 +5,12 @@
 
 .select {
     width: calc(100% - 80px);
+    height: 37px;
 }
 
 .stepper {
     margin: 0 0 6px 4px;
+    white-space: nowrap;
 }
 
 .stepper > span {

--- a/src/constants/layers.js
+++ b/src/constants/layers.js
@@ -141,6 +141,8 @@ export const getGroupSetStyleTypes = () => [
 
 /* LABEL STYLES */
 export const LABEL_FONT_SIZE = '11px';
+export const LABEL_FONT_SIZE_MIN = 6;
+export const LABEL_FONT_SIZE_MAX = 100;
 export const LABEL_FONT_STYLE = 'normal';
 export const LABEL_FONT_WEIGHT = 'normal';
 export const LABEL_FONT_COLOR = '#333333';

--- a/src/constants/layers.js
+++ b/src/constants/layers.js
@@ -146,3 +146,7 @@ export const LABEL_FONT_WEIGHT = 'normal';
 export const LABEL_FONT_COLOR = '#333333';
 
 export const NO_DATA_COLOR = '#CCCCCC';
+
+/* POINT RADIUS */
+export const MIN_RADIUS = 1;
+export const MAX_RADIUS = 100;

--- a/src/loaders/orgUnitLoader.js
+++ b/src/loaders/orgUnitLoader.js
@@ -47,7 +47,7 @@ const orgUnitLoader = async config => {
     );
 
     const alerts = !features.length
-        ? [{ warning: true, message: i18n.t('No org units found') }]
+        ? [{ warning: true, message: i18n.t('No coordinates found') }]
         : undefined;
 
     return {


### PR DESCRIPTION
Fixes: 
- Org unit layer: "No org units found" -> "No coordinates found"
- When select user org group - deselect level and group (across all layer types)
- Add min and max for radius and label size (across all layer types)
- Org unit profile: align close x
- Org unit profile: make sure next/prev year buttons always are aligned (change browser zoom)
- Org unit layer: Change "Color" to "Boundary colour", and add more space above
- Faciliy layer: Move color and point radius below "Style by group set"
- Checkbox and Radio buttons: add dense property
- Add buffer input field on a separate line (to better support long text translations)

After this PR:

<img width="461" alt="Screenshot 2021-09-13 at 14 05 15" src="https://user-images.githubusercontent.com/548708/133080525-f6254a3d-a748-40e6-a67f-496b348c2fc0.png">

Before: 

<img width="479" alt="Screenshot 2021-09-13 at 14 05 30" src="https://user-images.githubusercontent.com/548708/133080538-ed6c1fc9-e6e4-4709-8387-c3e4175d6528.png">

After this PR: 

<img width="596" alt="Screenshot 2021-09-13 at 14 07 06" src="https://user-images.githubusercontent.com/548708/133080659-0013f04b-57e7-4ac9-be6c-8ce33bf11dd4.png">

Before: 

<img width="595" alt="Screenshot 2021-09-13 at 14 07 57" src="https://user-images.githubusercontent.com/548708/133080755-8a6d943e-9485-42a1-9458-9911c257c7a4.png">

After this PR ('x' moved 1 px down):

<img width="300" alt="Screenshot 2021-09-13 at 14 09 08" src="https://user-images.githubusercontent.com/548708/133081018-61b1f3ec-8bbf-41fc-b28d-7db627fc80dd.png">

Before: 

<img width="300" alt="Screenshot 2021-09-13 at 14 09 47" src="https://user-images.githubusercontent.com/548708/133081038-af0852ee-5d26-4471-9bd6-9300394a0038.png">

After this PR: 

<img width="266" alt="Screenshot 2021-09-13 at 14 10 51" src="https://user-images.githubusercontent.com/548708/133081150-4d394d72-1d05-4154-8801-3ca648024a6c.png">

Before: 

<img width="266" alt="Screenshot 2021-09-13 at 14 11 00" src="https://user-images.githubusercontent.com/548708/133081167-0d17195e-4af5-42f4-bf64-418b3935cdc6.png">

After this PR:

<img width="592" alt="Screenshot 2021-09-13 at 14 13 07" src="https://user-images.githubusercontent.com/548708/133081438-db1c599b-c306-4b7d-aac4-ac2a1baf0d08.png">

Before: 

<img width="594" alt="Screenshot 2021-09-13 at 14 13 20" src="https://user-images.githubusercontent.com/548708/133081455-bf54ba24-fb4a-4d07-951d-c56122138002.png">

After this PR: 

<img width="596" alt="Screenshot 2021-09-13 at 14 14 22" src="https://user-images.githubusercontent.com/548708/133081624-c28c34ce-e22c-4481-88af-188045e0e757.png">

Before: 

<img width="594" alt="Screenshot 2021-09-13 at 14 14 35" src="https://user-images.githubusercontent.com/548708/133081636-e04cfbb8-31a9-4912-b0ad-37603cdd4266.png">

 
