### PR TITLE
fix: align tracked entity legend and use polygon symbol for areas

### DIFF
--- a/src/components/legend/styles/LegendItem.module.css
+++ b/src/components/legend/styles/LegendItem.module.css
@@ -10,7 +10,7 @@
 }
 
 .legendItem th span {
-    display: block;
+    display: inline-block;
     width: 100%;
     height: 100%;
     background-repeat: no-repeat;

--- a/src/loaders/trackedEntityLoader.js
+++ b/src/loaders/trackedEntityLoader.js
@@ -144,8 +144,9 @@ const trackedEntityLoader = async config => {
         const relatedTypeId =
             relationshipType.toConstraint.trackedEntityType.id;
         const relatedEntityType = await apiFetch(
-            `/trackedEntityTypes/${relatedTypeId}?fields=displayName`
+            `/trackedEntityTypes/${relatedTypeId}?fields=displayName,featureType`
         );
+        const isPoint = relatedEntityType.featureType === 'POINT';
 
         legend.items.push(
             {
@@ -157,7 +158,10 @@ const trackedEntityLoader = async config => {
             {
                 name: `${relatedEntityType.displayName} (${i18n.t('related')})`,
                 color: relatedPointColor || TEI_RELATED_COLOR,
-                radius: relatedPointRadius || TEI_RELATED_RADIUS,
+                radius: isPoint
+                    ? relatedPointRadius || TEI_RELATED_RADIUS
+                    : undefined,
+                weight: !isPoint ? 1 : undefined,
             }
         );
 


### PR DESCRIPTION
This PR includes some style fixes for tracked entity layer legends: 
- the legend item symbols are center aligned
- "focus area" is represented by a polygon, not point

After this PR: 

<img width="296" alt="Screenshot 2021-09-13 at 15 23 42" src="https://user-images.githubusercontent.com/548708/133091420-d55a5a68-422c-4625-a866-983ecc46d287.png">

Before: 

<img width="292" alt="Screenshot 2021-09-13 at 15 24 25" src="https://user-images.githubusercontent.com/548708/133091509-8570d7fd-d7e4-49cc-a9b8-f16278b035c6.png">

After this PR: 

<img width="295" alt="Screenshot 2021-09-13 at 15 25 11" src="https://user-images.githubusercontent.com/548708/133091628-ff00a6b3-a21b-431f-9cda-3c0c2e714905.png">

Before: 

<img width="292" alt="Screenshot 2021-09-13 at 15 25 53" src="https://user-images.githubusercontent.com/548708/133091745-da52db28-a607-4b72-8627-4e08205a2110.png">
