### PR TITLE
fix: make layer dialog higher to avoid vertical scroll (DHIS2-11038)

### DIFF
--- a/src/components/edit/styles/LayerDialog.module.css
+++ b/src/components/edit/styles/LayerDialog.module.css
@@ -11,7 +11,7 @@
 .tabContent {
     font-size: 14px;
     margin: var(--spacers-dp4) -16px 0;
-    height: 340px;
+    height: 360px;
     overflow-y: auto;
     color: #333;
 }

--- a/src/components/orgunits/styles/OrgUnitTree.module.css
+++ b/src/components/orgunits/styles/OrgUnitTree.module.css
@@ -1,7 +1,7 @@
 .orgUnitTree {
     position: relative;
     width: 100%;
-    height: 310px;
+    height: 350px;
     padding: var(--spacers-dp8);
     overflow: auto;
     box-sizing: border-box;


### PR DESCRIPTION
Fixes: https://github.com/dhis2/maps-app/pull/1862

This PR makes the layer dialog 20 px higher to avoid vertical scroll. The org unit tree selection is made 40 px higher to better fit the space available. 

After this PR:

<img width="612" alt="Screenshot 2021-09-13 at 17 05 33" src="https://user-images.githubusercontent.com/548708/133108656-9dd0f30d-81d1-4d71-9ef5-de9189e6ae88.png">

Before: 

<img width="614" alt="Screenshot 2021-09-13 at 17 06 30" src="https://user-images.githubusercontent.com/548708/133108800-46420f1c-784f-4332-bbfd-c914acd0cffb.png">

After this PR: 

<img width="608" alt="Screenshot 2021-09-13 at 17 07 08" src="https://user-images.githubusercontent.com/548708/133108988-70541edd-f715-47e4-9ef0-df0a74146692.png">

Before: 

<img width="607" alt="Screenshot 2021-09-13 at 17 07 26" src="https://user-images.githubusercontent.com/548708/133109018-366fda9e-bf9d-4cad-9e91-b508ea8f70b2.png">


