### PR TITLE
fix: add loading spinner to org unit profile

### DIFF
--- a/src/components/orgunits/OrgUnitProfile.js
+++ b/src/components/orgunits/OrgUnitProfile.js
@@ -27,6 +27,7 @@ export const OrgUnitProfile = ({ id, closeOrgUnitProfile }) => {
     // https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/org-unit-profile.html
     useEffect(() => {
         if (id) {
+            setProfile(); // Clear profile
             apiFetch(
                 `/organisationUnitProfile/${id}/data?period=${defaultPeriod.id}`
             ).then(setProfile);

--- a/src/components/orgunits/OrgUnitProfile.js
+++ b/src/components/orgunits/OrgUnitProfile.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
-import { IconCross24 } from '@dhis2/ui';
+import { CenteredContent, CircularLoader, IconCross24 } from '@dhis2/ui';
 import Drawer from '../core/Drawer';
 import OrgUnitInfo from './OrgUnitInfo';
 import OrgUnitData from './OrgUnitData';
@@ -46,7 +46,7 @@ export const OrgUnitProfile = ({ id, closeOrgUnitProfile }) => {
                 </span>
             </div>
             <div className={styles.content}>
-                {profile && (
+                {profile ? (
                     <>
                         <OrgUnitInfo
                             {...profile.info}
@@ -60,6 +60,10 @@ export const OrgUnitProfile = ({ id, closeOrgUnitProfile }) => {
                             data={profile.dataItems}
                         />
                     </>
+                ) : (
+                    <CenteredContent>
+                        <CircularLoader />
+                    </CenteredContent>
                 )}
             </div>
         </Drawer>


### PR DESCRIPTION
This PR will add a circular loader to the org unit profile: 

<img width="303" alt="Screenshot 2021-09-14 at 13 50 19" src="https://user-images.githubusercontent.com/548708/133252976-99fc1f73-12f1-41db-9874-b7d4ecce58cd.png">
