### PR TITLE
fix: improved map download legend

### DIFF
--- a/src/components/download/styles/DownloadLegend.module.css
+++ b/src/components/download/styles/DownloadLegend.module.css
@@ -4,7 +4,7 @@
     padding: var(--spacers-dp8) var(--spacers-dp8) 0 var(--spacers-dp8);
     z-index: 998;
     font-size: 14px;
-    max-width: 220px;
+    max-width: 240px;
     overflow: hidden;
 }
 
@@ -26,6 +26,7 @@
 
 .period {
     display: block;
+    font-size: 14px;
     font-weight: normal;
 }
 

--- a/src/components/download/styles/DownloadLegend.module.css
+++ b/src/components/download/styles/DownloadLegend.module.css
@@ -28,6 +28,7 @@
     display: block;
     font-size: 14px;
     font-weight: normal;
+    padding-top: 2px;
 }
 
 .topleft {

--- a/src/loaders/trackedEntityLoader.js
+++ b/src/loaders/trackedEntityLoader.js
@@ -68,6 +68,7 @@ const trackedEntityLoader = async config => {
     const name = program ? program.name : i18n.t('Tracked entity');
 
     const legend = {
+        title: name,
         period: `${formatLocaleDate(startDate)} - ${formatLocaleDate(endDate)}`,
         items: [
             {


### PR DESCRIPTION
This PR will improve the legend shown on downloaded maps: 
- Same max width as the left column legend in the maps app
- Include title for TEI layers
- Increased space between title and period

After this PR: 

<img width="262" alt="Screenshot 2021-09-14 at 16 23 30" src="https://user-images.githubusercontent.com/548708/133276228-038b1bac-85bc-4090-8076-009ded903cbe.png">

Before: 

<img width="240" alt="Screenshot 2021-09-14 at 16 27 13" src="https://user-images.githubusercontent.com/548708/133276348-8f4cfa28-af49-4657-8996-bd4d36fb7757.png">
