### PR TITLE
fix: period stepper buttons alignment

### DIFF
--- a/src/components/periods/styles/PeriodSelect.module.css
+++ b/src/components/periods/styles/PeriodSelect.module.css
@@ -5,16 +5,19 @@
 
 .select {
     width: calc(100% - 80px);
-    height: 37px;
 }
 
 .stepper {
-    margin: 0 0 6px 4px;
+    margin: 0 0 7px var(--spacers-dp4);
     white-space: nowrap;
 }
 
 .stepper > span {
     display: inline-block;
+}
+
+.stepper span button {
+    height: 35px;
 }
 
 .stepper > span:first-child {


### PR DESCRIPTION
This PR will align the period stepper buttons with the selection field. 

After this PR: 

<img width="458" alt="Screenshot 2021-09-20 at 13 24 20" src="https://user-images.githubusercontent.com/548708/133995165-6101237a-6701-4f8b-8dd2-c6a5da38e775.png">

<img width="303" alt="Screenshot 2021-09-20 at 13 22 36" src="https://user-images.githubusercontent.com/548708/133995178-3f78e0ab-e108-43a9-922e-a5e01769c03b.png">

Before: 

![Screenshot from 2021-09-17 16-53-53](https://user-images.githubusercontent.com/548708/133995237-21213cb9-b6e8-425a-82b0-2ceb593ed103.png)

