### PR TITLE
fix: keep start/end dates for event layer (DHIS2-11919)

### DIFF
--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -142,8 +142,7 @@ export class EventDialog extends Component {
             setPeriod({
                 id: defaultPeriod,
             });
-        } else {
-            // Fallback to default start/end dates
+        } else if (!startDate && !endDate) {
             setStartDate(DEFAULT_START_DATE);
             setEndDate(DEFAULT_END_DATE);
         }


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11919

This PR makes sure that the default start/end dates are only set once. 

After this PR the date in the layer dialog is the same as layer card: 
<img width="908" alt="Screenshot 2021-10-02 at 17 49 56" src="https://user-images.githubusercontent.com/548708/135723637-b816cd0b-d333-4d52-b006-32c2e51c26cb.png">

Before the dates are noe equal: 
<img width="907" alt="Screenshot 2021-10-02 at 17 50 21" src="https://user-images.githubusercontent.com/548708/135723643-fffc5848-3d57-49ed-b521-5511241b59b0.png">
