### PR TITLE
fix: remove style data item on program change (DHIS2-11920)

### DIFF
--- a/src/reducers/layerEdit.js
+++ b/src/reducers/layerEdit.js
@@ -41,7 +41,7 @@ const layerEdit = (state = null, action) => {
                 program: program ? { ...program } : null,
                 columns: [],
                 programStage: null,
-                styleDataElement: null,
+                styleDataItem: null,
             };
 
         case types.LAYER_EDIT_PROGRAM_STAGE_SET:
@@ -51,7 +51,7 @@ const layerEdit = (state = null, action) => {
                     ...action.programStage,
                 },
                 columns: [],
-                styleDataElement: null,
+                styleDataItem: null,
             };
 
         case types.LAYER_EDIT_VALUE_TYPE_SET:


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11920

This PR makes sure the style by data item is removed when program (+stage) is changed for event layers. It avoids an app crash. 

After this PR: 
![ezgif com-gif-maker](https://user-images.githubusercontent.com/548708/135724424-212dc848-5173-44a2-87be-153ba33714c5.gif)

