### PR TITLE
fix: include legend title for facility and org unit layers (DHIS2-11922)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-09-14T11:41:24.358Z\n"
-"PO-Revision-Date: 2021-09-14T11:41:24.358Z\n"
+"POT-Creation-Date: 2021-10-03T11:49:34.873Z\n"
+"PO-Revision-Date: 2021-10-03T11:49:34.873Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -1232,10 +1232,10 @@ msgstr ""
 msgid "Event"
 msgstr ""
 
-msgid "No facilities found"
+msgid "Facilities"
 msgstr ""
 
-msgid "Facilities"
+msgid "No facilities found"
 msgstr ""
 
 msgid "Organisation units"

--- a/src/loaders/facilityLoader.js
+++ b/src/loaders/facilityLoader.js
@@ -16,6 +16,7 @@ const facilityLoader = async config => {
     const d2 = await getD2();
     const displayProperty = getDisplayProperty(d2).toUpperCase();
     const { contextPath } = d2.system.systemInfo;
+    const name = i18n.t('Facilities');
 
     const requests = [
         d2.geoFeatures
@@ -54,6 +55,8 @@ const facilityLoader = async config => {
         contextPath
     );
 
+    legend.title = name;
+
     if (areaRadius) {
         legend.explanation = [`${areaRadius} ${'m'} ${'buffer'}`];
     }
@@ -65,7 +68,7 @@ const facilityLoader = async config => {
     return {
         ...config,
         data: styledFeatures,
-        name: i18n.t('Facilities'),
+        name,
         legend,
         alerts,
         isLoaded: true,

--- a/src/loaders/orgUnitLoader.js
+++ b/src/loaders/orgUnitLoader.js
@@ -15,6 +15,7 @@ const orgUnitLoader = async config => {
     const d2 = await getD2();
     const displayProperty = getDisplayProperty(d2).toUpperCase();
     const { contextPath } = d2.system.systemInfo;
+    const name = i18n.t('Organisation units');
 
     const requests = [
         d2.geoFeatures
@@ -46,6 +47,8 @@ const orgUnitLoader = async config => {
         orgUnitLevels
     );
 
+    legend.title = name;
+
     const alerts = !features.length
         ? [{ warning: true, message: i18n.t('No coordinates found') }]
         : undefined;
@@ -53,7 +56,7 @@ const orgUnitLoader = async config => {
     return {
         ...config,
         data: styledFeatures,
-        name: i18n.t('Organisation units'),
+        name,
         legend,
         alerts,
         isLoaded: true,


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11922

This PR fixes a bug where layer titles were not shown in the map legend on dashboards. 

After this PR: 
<img width="377" alt="Screenshot 2021-10-03 at 17 18 31" src="https://user-images.githubusercontent.com/548708/135760908-f87e1f31-e910-4c6c-904e-010fcb8e7620.png">

Before: 
<img width="393" alt="Screenshot 2021-10-03 at 17 28 09" src="https://user-images.githubusercontent.com/548708/135760913-e5496301-6eac-4c08-921f-6aefe9d672d1.png">

