### PR TITLE
fix: avoid app crash in style tab for thematic layer (DHIS2-11970)

### DIFF
--- a/src/components/classification/NumericLegendStyle.js
+++ b/src/components/classification/NumericLegendStyle.js
@@ -42,7 +42,7 @@ const NumericLegendStyle = props => {
 
     useEffect(() => {
         // Set legend set defined for data item in use by default
-        if (isPredefined && !legendSet && dataItem && dataItem.legendSet) {
+        if (isPredefined && !legendSet && dataItem?.legendSet) {
             setLegendSet(dataItem.legendSet);
         }
     }, [isPredefined, legendSet, dataItem, setLegendSet]);

--- a/src/reducers/layerEdit.js
+++ b/src/reducers/layerEdit.js
@@ -296,8 +296,10 @@ const layerEdit = (state = null, action) => {
 
             if (
                 state.method === CLASSIFICATION_SINGLE_COLOR ||
-                (action.method !== CLASSIFICATION_EQUAL_INTERVALS &&
-                    action.method !== CLASSIFICATION_EQUAL_COUNTS)
+                ![
+                    CLASSIFICATION_EQUAL_INTERVALS,
+                    CLASSIFICATION_EQUAL_COUNTS,
+                ].includes(action.method)
             ) {
                 delete newState.colorScale;
                 delete newState.classes;


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11970

This PR fixes 3 bugs in the style tab for thematic layer: 
- App crash if "Predefined legend" is selected before an indicator/data element is selected.
- App crash if switching from "Single color legend" to "Automatic legend".
- App crash if clicking on "Choropleth" when "Single color legend" is selected. 

After this PR: 
![thematic-style-bug-fixes](https://user-images.githubusercontent.com/548708/136622603-0c831bb5-22a6-454a-8f34-e94ebd73f6bf.gif)
