### PR TITLE
fix: maps-gl upgrade with earth engine fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@dhis2/d2-ui-interpretations": "^7.3.3",
         "@dhis2/d2-ui-org-unit-dialog": "^7.3.3",
         "@dhis2/d2-ui-org-unit-tree": "^7.3.3",
-        "@dhis2/maps-gl": "^2.2.1",
+        "@dhis2/maps-gl": "^2.2.3",
         "@dhis2/ui": "^6.20.0",
         "abortcontroller-polyfill": "^1.5.0",
         "array-move": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2057,16 +2057,6 @@
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.5.10"
 
-"@dhis2/d2-ui-org-unit-tree@7.3.2":
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.3.2.tgz#557265b3960fc4815882eb220ac2a7f55bb39ca3"
-  integrity sha512-13Yk/sqZ4OkcnDyFKdECt6hIY9my1IZHdAheMIoeUkjDShUpLkAA9AtagcA910HeNj+x1AeZLjsdPc92bOlw+w==
-  dependencies:
-    "@dhis2/d2-ui-core" "7.3.2"
-    "@material-ui/core" "^3.3.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.5.10"
-
 "@dhis2/d2-ui-org-unit-tree@7.3.3", "@dhis2/d2-ui-org-unit-tree@^7.3.3":
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.3.3.tgz#86fe4c37468fa845b2a6fe893fef74e1efdfb889"
@@ -2114,10 +2104,10 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@^2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-2.2.1.tgz#d72684f87b02daf2350f62f8b24e4fc7af046b35"
-  integrity sha512-XV1j9l70cBlcQH0yeu+9EdWQen2M0d4c0PUgjhb8yPQnlLoU5YAdsst+c/miiJI0E9DE9BZVgLkkLgQZjTJ1Ow==
+"@dhis2/maps-gl@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-2.2.3.tgz#f785e8474d8285bf3afb4dbf7a1d90c05946958d"
+  integrity sha512-Pa1dD6FJtYXQ6qGp5a0K+CQG65gKmwU1s7BpNkAWUKEYU0qMotxDC3MPhBdu+i0CLFpfeJE2KRQ+1BlQIqYmZQ==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.3.0"


### PR DESCRIPTION
Improves: https://jira.dhis2.org/browse/DHIS2-12013

The maps-gl upgrade include two small fixes that are already approved:

**Don't update auth library for earth engine api**
We don't need to update the Google authentication library when we set the token for the EE API. This small change will remove two Google requests. https://github.com/dhis2/maps-gl/pull/414

**Only reference image scale on the server**
The image scale value is only used in server processing, and we don't need to get the value on the client side. https://github.com/dhis2/maps-gl/pull/416