### PR TITLE
fix: parse date string to array to get correct date in all timezones

### DIFF
--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -21,7 +21,7 @@ import {
     EVENT_COLOR,
     EVENT_RADIUS,
 } from '../constants/layers';
-import { formatLocaleDate } from '../util/time';
+import { formatStartEndDate, getDateArray } from '../util/time';
 import { cssColor, getContrastColor } from '../util/colors';
 
 // Server clustering if more than 2000 events
@@ -89,7 +89,10 @@ const loadEventLayer = async config => {
         title: config.name,
         period: period
             ? getPeriodNameFromId(period.id)
-            : `${formatLocaleDate(startDate)} - ${formatLocaleDate(endDate)}`,
+            : formatStartEndDate(
+                  getDateArray(startDate),
+                  getDateArray(endDate)
+              ),
         items: [],
     };
 

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -18,7 +18,7 @@ import {
     getDataItemFromColumns,
     getApiResponseNames,
 } from '../util/analytics';
-import { formatLocaleDate } from '../util/time';
+import { formatStartEndDate, getDateArray } from '../util/time';
 import {
     THEMATIC_BUBBLE,
     THEMATIC_RADIUS_LOW,
@@ -125,9 +125,10 @@ const thematicLoader = async config => {
         title: name,
         period: period
             ? names[period.id] || period.id
-            : `${formatLocaleDate(config.startDate)} - ${formatLocaleDate(
-                  config.endDate
-              )}`,
+            : formatStartEndDate(
+                  getDateArray(config.startDate),
+                  getDateArray(config.endDate)
+              ),
         items: legendItems,
     };
 

--- a/src/loaders/trackedEntityLoader.js
+++ b/src/loaders/trackedEntityLoader.js
@@ -9,7 +9,7 @@ import {
     TEI_RELATIONSHIP_LINE_COLOR,
 } from '../constants/layers';
 import { getProgramStatuses } from '../constants/programStatuses';
-import { formatLocaleDate } from '../util/time';
+import { formatStartEndDate, getDateArray } from '../util/time';
 import { getDataWithRelationships } from '../util/teiRelationshipsParser';
 
 const fields = [
@@ -69,7 +69,10 @@ const trackedEntityLoader = async config => {
 
     const legend = {
         title: name,
-        period: `${formatLocaleDate(startDate)} - ${formatLocaleDate(endDate)}`,
+        period: formatStartEndDate(
+            getDateArray(startDate),
+            getDateArray(endDate)
+        ),
         items: [
             {
                 name:

--- a/src/util/__tests__/time.spec.js
+++ b/src/util/__tests__/time.spec.js
@@ -1,11 +1,10 @@
 import {
-    toDate,
-    isValidDateFormat,
     formatDate,
     formatLocaleDate,
     formatStartEndDate,
     getStartEndDateError,
     getYear,
+    getDateArray,
 } from '../time';
 
 const validDateString = '2018-12-17T12:00:00';
@@ -13,32 +12,26 @@ const invalidDateString = '2018-13-17T12:00:00';
 const invalidDateStringFormat = '2018-13-7T12:00:00';
 const validTimestamp = 1545044966178;
 const invalidTimestamp = 15450221323142342;
+const validDateArray = [2018, 11, 17];
+const invalidDateArray = [2018, 11, 'a'];
 const validDate = new Date('2018-12-17T12:00:00');
 const invalidDate = new Date('2018-13-17T12:00:00');
 const currentYear = new Date().getFullYear();
 
 // https://stackoverflow.com/questions/1353684/detecting-an-invalid-date-date-instance-in-javascript
-const isValidDate = d => d instanceof Date && !isNaN(d.getTime());
+const isValidDateString = str => {
+    const d = new Date(str);
+    return d instanceof Date && !isNaN(d.getTime());
+};
 
 describe('time utils', () => {
-    it('toDate should return a date object from a valid date string, timestamp or date object', () => {
-        expect(isValidDate(toDate(validDateString))).toBeTruthy();
-        expect(isValidDate(toDate(invalidDateString))).toBeFalsy();
-        expect(isValidDate(toDate(validTimestamp))).toBeTruthy();
-        expect(isValidDate(toDate(invalidTimestamp))).toBeFalsy();
-        expect(isValidDate(toDate(validDate))).toBeTruthy();
-        expect(isValidDate(toDate(invalidDate))).toBeFalsy();
-    });
-
-    it('isValidDateFormat should return true if date string is formatted as yyyy-mm-dd', () => {
-        expect(isValidDateFormat(validDateString)).toBeTruthy();
-        expect(isValidDateFormat(invalidDateString)).toBeTruthy(); // Date is invalid, but format is still valid
-        expect(isValidDateFormat(invalidDateStringFormat)).toBeFalsy();
-    });
-
     it('formatDate should return a formatted date string if valid', () => {
-        expect(isValidDateFormat(formatDate(validDate))).toBeTruthy();
-        expect(isValidDateFormat(formatDate(invalidDate))).toBeFalsy();
+        expect(isValidDateString(formatDate(validDateString))).toBeTruthy();
+        expect(isValidDateString(formatDate(invalidDateString))).toBeFalsy();
+        expect(isValidDateString(formatDate(validTimestamp))).toBeTruthy();
+        expect(isValidDateString(formatDate(invalidTimestamp))).toBeFalsy();
+        expect(isValidDateString(formatDate(validDateArray))).toBeTruthy();
+        expect(isValidDateString(formatDate(invalidDateArray))).toBeFalsy();
     });
 
     // Node only support a limited set of locales by default:
@@ -50,13 +43,21 @@ describe('time utils', () => {
 
     // Node only support a limited set of locales by default:
     // https://stackoverflow.com/questions/49052731/jest-test-intl-datetimeformat
-    it('ormatStartEndDate should format date range according to locale', () => {
-        expect(formatStartEndDate('2018-12-17', '2018-12-18', 'en')).toEqual(
-            'Dec 17, 2018 - Dec 18, 2018'
-        );
+    it('formatStartEndDate should format date range according to locale', () => {
+        expect(
+            formatStartEndDate([2018, 11, 17], [2018, 11, 18], 'en')
+        ).toEqual('Dec 17, 2018 - Dec 18, 2018');
+
+        expect(
+            formatStartEndDate(
+                '2018-12-17T12:00:00',
+                '2018-12-18T12:00:00',
+                'en'
+            )
+        ).toEqual('Dec 17, 2018 - Dec 18, 2018');
     });
 
-    it('formatLocaleDate should format date string according to locale', () => {
+    it('getStartEndDateError should report errors correctly', () => {
         expect(getStartEndDateError('2018-12-17', '2018-12-18')).toBeNull();
         expect(getStartEndDateError('2018-12-17', '2018-12-16')).toEqual(
             'End date cannot be earlier than start date'
@@ -74,5 +75,9 @@ describe('time utils', () => {
         expect(getYear(validDateString)).toEqual(2018);
         expect(getYear(validTimestamp)).toEqual(2018);
         expect(getYear(validDate)).toEqual(2018);
+    });
+
+    it('getDateArray returns array from date string', () => {
+        expect(getDateArray('2018-12-17')).toEqual([2018, 11, 17]);
     });
 });

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -11,7 +11,12 @@ export const dateLocale = locale =>
  * @param {String|Number|Date} date
  * @returns {String}
  */
-export const toDate = date => new Date(date);
+const toDate = date => {
+    if (Array.isArray(date)) {
+        return new Date(date[0], date[1], date[2]);
+    }
+    return new Date(date);
+};
 
 // Simple check if the date part is correctly formatted
 const shortDateRegexp = /^\d{4}-\d{2}-\d{2}$/;
@@ -87,18 +92,30 @@ export const formatStartEndDate = (startDate, endDate, locale, showYear) => {
     )}`;
 };
 
+export const getDateArray = dateString => {
+    const year = parseInt(dateString.substring(0, 4));
+    const month = parseInt(dateString.substring(5, 7)) - 1;
+    const day = parseInt(dateString.substring(8, 10));
+    return [year, month, day];
+};
+
 /**
  * Checks for errors for start and end date strings or timestamps
  * @param {String} startDate
  * @param {String} endDate
  * @returns {String|null}
  */
-export const getStartEndDateError = (startDate, endDate) => {
-    if (!isValidDateFormat(startDate)) {
+export const getStartEndDateError = (startDateStr, endDateStr) => {
+    if (!isValidDateFormat(startDateStr)) {
         return i18n.t('Start date is invalid');
-    } else if (!isValidDateFormat(endDate)) {
+    } else if (!isValidDateFormat(endDateStr)) {
         return i18n.t('End date is invalid');
-    } else if (toDate(endDate) < toDate(startDate)) {
+    }
+
+    const startDateArr = getDateArray(startDateStr);
+    const endDateArr = getDateArray(endDateStr);
+
+    if (toDate(endDateArr) < toDate(startDateArr)) {
         return i18n.t('End date cannot be earlier than start date');
     }
     return null;

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -8,7 +8,7 @@ const dateLocale = locale =>
 
 /**
  * Converts a date string or timestamp to a date object
- * @param {String|Number|Date} date
+ * @param {String|Number|Array|Date} date
  * @returns {String}
  */
 const toDate = date => {
@@ -31,7 +31,7 @@ const isValidDateFormat = dateString =>
 
 /**
  * Formats a date string, timestamp or date array into format used by DHIS2 and <input> date
- * @param {String|Number|Date} date
+ * @param {String|Number|Array|Date} date
  * @returns {String}
  */
 export const formatDate = date => {
@@ -77,8 +77,8 @@ export const formatLocaleDate = (dateString, locale, showYear = true) =>
 
 /**
  * Formats a date range
- * @param {String|Number} startDate
- * @param {String|Number} endDate
+ * @param {String|Array|Number} startDate
+ * @param {String|Array|Number} endDate
  * @param {String} locale
  * @param {Boolean} showYear
  * @returns {String}
@@ -92,6 +92,10 @@ export const formatStartEndDate = (startDate, endDate, locale, showYear) => {
     )}`;
 };
 
+/**
+ * @param {String} dateString
+ * @returns {Array}
+ */
 export const getDateArray = dateString => {
     const year = parseInt(dateString.substring(0, 4));
     const month = parseInt(dateString.substring(5, 7)) - 1;
@@ -101,8 +105,8 @@ export const getDateArray = dateString => {
 
 /**
  * Checks for errors for start and end date strings or timestamps
- * @param {String} startDate
- * @param {String} endDate
+ * @param {String} startDateStr
+ * @param {String} endDateStr
  * @returns {String|null}
  */
 export const getStartEndDateError = (startDateStr, endDateStr) => {
@@ -123,7 +127,7 @@ export const getStartEndDateError = (startDateStr, endDateStr) => {
 
 /**
  * Returns the year of the date, or the current year of no date is passed
- * @param {String|Number|Date} startDate
+ * @param {String|Number|Array|Date} startDate
  * @returns {Number}
  */
 export const getYear = date => toDate(date || new Date()).getFullYear();

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -3,7 +3,7 @@ import i18n from '@dhis2/d2-i18n';
 const DEFAULT_LOCALE = 'en';
 
 // BCP 47 locale format
-export const dateLocale = locale =>
+const dateLocale = locale =>
     locale && locale.includes('_') ? locale.replace('_', '-') : locale;
 
 /**
@@ -26,11 +26,11 @@ const shortDateRegexp = /^\d{4}-\d{2}-\d{2}$/;
  * @param {String} dateString
  * @returns {String}
  */
-export const isValidDateFormat = dateString =>
+const isValidDateFormat = dateString =>
     shortDateRegexp.test(dateString.substr(0, 10));
 
 /**
- * Formats a date string or timestamp into format used by DHIS2 and <input> date
+ * Formats a date string, timestamp or date array into format used by DHIS2 and <input> date
  * @param {String|Number|Date} date
  * @returns {String}
  */
@@ -53,7 +53,7 @@ const fallbackDateFormat = dateString => dateString.substr(0, 10);
  * Returns true if the Internationalization API is supported
  * @returns {Boolean}
  */
-export const hasIntlSupport =
+const hasIntlSupport =
     typeof global.Intl !== 'undefined' && Intl.DateTimeFormat;
 
 /**


### PR DESCRIPTION
fixes: https://jira.dhis2.org/browse/DHIS2-12169

If a string with this format "2018-10-01" is passed to javascript Date, the assumed time is "00:00" and the returned date will be according to the user's timezone. So if you are in <= GMT-1, then the resulting date will actually be the previous day. To avoid this, the date string is converted to an array, and Date converts this correctly.

The screenshot shows the Layer card with the incorrect date shown (note that the analytics request uses the correct date)

![image](https://user-images.githubusercontent.com/6113918/142909755-25bb0b87-7250-4bfa-8855-b51773bcb316.png
Fixed:

https://user-images.githubusercontent.com/6113918/142910473-5506abaa-ddb2-48e4-bbaa-6e996497e007.mov



