### PR TITLE
chore: allow core app override 2.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,9 @@
         "icons": {
             "48": "icon.png"
         },
+        "appType": "APP",
+        "core_app": true,
+        "short_name": "maps",
         "developer": {
             "url": "",
             "name": "Bjørn Sandvik"


### PR DESCRIPTION
2.36 backport of https://github.com/dhis2/maps-app/pull/1956