### PR TITLE
chore: allow core app override 2.37

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,9 @@
         "icons": {
             "48": "icon.png"
         },
+        "appType": "APP",
+        "core_app": true,
+        "short_name": "maps",
         "developer": {
             "url": "",
             "name": "Bjørn Sandvik"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2057,16 +2057,6 @@
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.5.10"
 
-"@dhis2/d2-ui-org-unit-tree@7.3.2":
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.3.2.tgz#557265b3960fc4815882eb220ac2a7f55bb39ca3"
-  integrity sha512-13Yk/sqZ4OkcnDyFKdECt6hIY9my1IZHdAheMIoeUkjDShUpLkAA9AtagcA910HeNj+x1AeZLjsdPc92bOlw+w==
-  dependencies:
-    "@dhis2/d2-ui-core" "7.3.2"
-    "@material-ui/core" "^3.3.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.5.10"
-
 "@dhis2/d2-ui-org-unit-tree@7.3.3", "@dhis2/d2-ui-org-unit-tree@^7.3.3":
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.3.3.tgz#86fe4c37468fa845b2a6fe893fef74e1efdfb889"


### PR DESCRIPTION
2.37 backport of https://github.com/dhis2/maps-app/pull/1956