### PR TITLE
Show aggregate values for each age group (DHIS2-11039)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-12-08T15:04:35.136Z\n"
-"PO-Revision-Date: 2021-12-08T15:04:35.136Z\n"
+"POT-Creation-Date: 2021-12-08T15:23:58.705Z\n"
+"PO-Revision-Date: 2021-12-08T15:23:58.705Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -180,6 +180,9 @@ msgid "Add layer"
 msgstr ""
 
 msgid "Aggregation method"
+msgstr ""
+
+msgid "Maximum number of groups are {{maxBands}}"
 msgstr ""
 
 msgid "Groups"
@@ -1304,8 +1307,4 @@ msgid "End date is invalid"
 msgstr ""
 
 msgid "End date cannot be earlier than start date"
-msgstr ""
-
-msgctxt "BANDS}}"
-msgid "Maximum number of groups are {{MAX"
 msgstr ""

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-12-10T16:33:24.098Z\n"
-"PO-Revision-Date: 2021-12-10T16:33:24.098Z\n"
+"POT-Creation-Date: 2021-12-13T12:22:02.535Z\n"
+"PO-Revision-Date: 2021-12-13T12:22:02.535Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -180,6 +180,9 @@ msgid "Add layer"
 msgstr ""
 
 msgid "Aggregation method"
+msgstr ""
+
+msgid "Choosing many groups takes a long time to calculate and display."
 msgstr ""
 
 msgid "Groups"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-11-16T09:45:00.428Z\n"
-"PO-Revision-Date: 2021-11-16T09:45:00.428Z\n"
+"POT-Creation-Date: 2021-12-08T15:04:35.136Z\n"
+"PO-Revision-Date: 2021-12-08T15:04:35.136Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -594,6 +594,9 @@ msgstr ""
 msgid "Last updated"
 msgstr ""
 
+msgid "All groups"
+msgstr ""
+
 msgid "Loading data"
 msgstr ""
 
@@ -860,6 +863,9 @@ msgid "Mean"
 msgstr ""
 
 msgid "Median"
+msgstr ""
+
+msgid "Std dev"
 msgstr ""
 
 msgid "OSM Light"
@@ -1298,4 +1304,8 @@ msgid "End date is invalid"
 msgstr ""
 
 msgid "End date cannot be earlier than start date"
+msgstr ""
+
+msgctxt "BANDS}}"
+msgid "Maximum number of groups are {{MAX"
 msgstr ""

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-12-08T15:23:58.705Z\n"
-"PO-Revision-Date: 2021-12-08T15:23:58.705Z\n"
+"POT-Creation-Date: 2021-12-10T16:33:24.098Z\n"
+"PO-Revision-Date: 2021-12-10T16:33:24.098Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -180,9 +180,6 @@ msgid "Add layer"
 msgstr ""
 
 msgid "Aggregation method"
-msgstr ""
-
-msgid "Maximum number of groups are {{maxBands}}"
 msgstr ""
 
 msgid "Groups"

--- a/src/components/core/SelectField.js
+++ b/src/components/core/SelectField.js
@@ -19,6 +19,7 @@ export const SelectField = props => {
         dense = true,
         errorText,
         helpText,
+        warning,
         items,
         label,
         loading,
@@ -65,7 +66,8 @@ export const SelectField = props => {
                 disabled={disabled}
                 loading={isLoading}
                 error={!!errorText}
-                validationText={errorText}
+                warning={!!warning}
+                validationText={warning ? warning : errorText}
                 helpText={helpText}
                 onChange={onSelectChange}
                 dataTest={dataTest}
@@ -104,6 +106,11 @@ SelectField.propTypes = {
      * If set, shows the error message below the SelectField
      */
     errorText: PropTypes.string,
+
+    /**
+     * If set, shows the warning message below the SelectField
+     */
+    warning: PropTypes.string,
 
     /**
      * The select field items (rendered as MenuItems)

--- a/src/components/edit/earthEngine/BandSelect.js
+++ b/src/components/edit/earthEngine/BandSelect.js
@@ -5,12 +5,13 @@ import { connect } from 'react-redux';
 import { SelectField } from '../../core';
 import { setBand } from '../../../actions/layerEdit';
 
-const MAX_BANDS = 10;
+const WARNING_BANDS = 10;
 
 const BandSelect = ({ band = [], bands, setBand, errorText }) => {
     let warning;
 
-    if (band.length > MAX_BANDS) {
+    // Show time warning if more than 10 bands/groups are selected
+    if (band.length > WARNING_BANDS) {
         warning = i18n.t(
             'Choosing many groups takes a long time to calculate and display.'
         );

--- a/src/components/edit/earthEngine/BandSelect.js
+++ b/src/components/edit/earthEngine/BandSelect.js
@@ -1,29 +1,22 @@
-import React, { useState, useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import { connect } from 'react-redux';
 import { SelectField } from '../../core';
 import { setBand } from '../../../actions/layerEdit';
 
-const MAX_BANDS = 10;
+export const MAX_BANDS = 10;
 
 const BandSelect = ({ band = [], bands, setBand, errorText }) => {
-    const [hasMaxBands, setHasMaxBands] = useState(band.length > MAX_BANDS);
+    let error;
 
-    const onBandChange = useCallback(band => {
-        if (band.length > MAX_BANDS) {
-            setHasMaxBands(true);
-        } else {
-            setBand(band);
-            setHasMaxBands(false);
-        }
-    }, []);
-
-    const error = hasMaxBands
-        ? i18n.t('Maximum number of groups are {{MAX_BANDS}}', { MAX_BANDS })
-        : !band.length && errorText
-        ? errorText
-        : null;
+    if (band.length > MAX_BANDS) {
+        error = i18n.t('Maximum number of groups are {{MAX_BANDS}}', {
+            MAX_BANDS,
+        });
+    } else if (errorText && !band.length) {
+        error = errorText;
+    }
 
     return (
         <SelectField
@@ -31,7 +24,7 @@ const BandSelect = ({ band = [], bands, setBand, errorText }) => {
             items={bands}
             multiple={true}
             value={band}
-            onChange={onBandChange}
+            onChange={setBand}
             errorText={error}
         />
     );

--- a/src/components/edit/earthEngine/BandSelect.js
+++ b/src/components/edit/earthEngine/BandSelect.js
@@ -11,8 +11,8 @@ const BandSelect = ({ band = [], bands, setBand, errorText }) => {
     let error;
 
     if (band.length > MAX_BANDS) {
-        error = i18n.t('Maximum number of groups are {{MAX_BANDS}}', {
-            MAX_BANDS,
+        error = i18n.t('Maximum number of groups are {{maxBands}}', {
+            maxBands: MAX_BANDS,
         });
     } else if (errorText && !band.length) {
         error = errorText;

--- a/src/components/edit/earthEngine/BandSelect.js
+++ b/src/components/edit/earthEngine/BandSelect.js
@@ -12,7 +12,7 @@ const BandSelect = ({ band = [], bands, setBand, errorText }) => {
 
     if (band.length > MAX_BANDS) {
         warning = i18n.t(
-            'Warning: It takes longer time to calculate data for many groups.'
+            'Choosing many groups takes a long time to calculate and display.'
         );
     }
 

--- a/src/components/edit/earthEngine/BandSelect.js
+++ b/src/components/edit/earthEngine/BandSelect.js
@@ -5,17 +5,14 @@ import { connect } from 'react-redux';
 import { SelectField } from '../../core';
 import { setBand } from '../../../actions/layerEdit';
 
-const MAX_BANDS = 3;
+const MAX_BANDS = 10;
 
 const BandSelect = ({ band = [], bands, setBand, errorText }) => {
     let warning;
 
     if (band.length > MAX_BANDS) {
         warning = i18n.t(
-            'Warning: It takes longer time to calculate data for many groups.',
-            {
-                maxBands: MAX_BANDS,
-            }
+            'Warning: It takes longer time to calculate data for many groups.'
         );
     }
 

--- a/src/components/edit/earthEngine/BandSelect.js
+++ b/src/components/edit/earthEngine/BandSelect.js
@@ -1,20 +1,41 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import { connect } from 'react-redux';
 import { SelectField } from '../../core';
 import { setBand } from '../../../actions/layerEdit';
 
-const BandSelect = ({ band = [], bands, setBand, errorText }) => (
-    <SelectField
-        label={i18n.t('Groups')}
-        items={bands}
-        multiple={true}
-        value={band}
-        onChange={setBand}
-        errorText={!band.length && errorText ? errorText : null}
-    />
-);
+const MAX_BANDS = 10;
+
+const BandSelect = ({ band = [], bands, setBand, errorText }) => {
+    const [hasMaxBands, setHasMaxBands] = useState(band.length > MAX_BANDS);
+
+    const onBandChange = useCallback(band => {
+        if (band.length > MAX_BANDS) {
+            setHasMaxBands(true);
+        } else {
+            setBand(band);
+            setHasMaxBands(false);
+        }
+    }, []);
+
+    const error = hasMaxBands
+        ? i18n.t('Maximum number of groups are {{MAX_BANDS}}', { MAX_BANDS })
+        : !band.length && errorText
+        ? errorText
+        : null;
+
+    return (
+        <SelectField
+            label={i18n.t('Groups')}
+            items={bands}
+            multiple={true}
+            value={band}
+            onChange={onBandChange}
+            errorText={error}
+        />
+    );
+};
 
 BandSelect.propTypes = {
     band: PropTypes.array,

--- a/src/components/edit/earthEngine/BandSelect.js
+++ b/src/components/edit/earthEngine/BandSelect.js
@@ -5,17 +5,18 @@ import { connect } from 'react-redux';
 import { SelectField } from '../../core';
 import { setBand } from '../../../actions/layerEdit';
 
-export const MAX_BANDS = 10;
+const MAX_BANDS = 3;
 
 const BandSelect = ({ band = [], bands, setBand, errorText }) => {
-    let error;
+    let warning;
 
     if (band.length > MAX_BANDS) {
-        error = i18n.t('Maximum number of groups are {{maxBands}}', {
-            maxBands: MAX_BANDS,
-        });
-    } else if (errorText && !band.length) {
-        error = errorText;
+        warning = i18n.t(
+            'Warning: It takes longer time to calculate data for many groups.',
+            {
+                maxBands: MAX_BANDS,
+            }
+        );
     }
 
     return (
@@ -25,7 +26,8 @@ const BandSelect = ({ band = [], bands, setBand, errorText }) => {
             multiple={true}
             value={band}
             onChange={setBand}
-            errorText={error}
+            warning={warning}
+            errorText={errorText}
         />
     );
 };

--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -5,7 +5,7 @@ import i18n from '@dhis2/d2-i18n';
 import { NoticeBox } from '@dhis2/ui';
 import { Help, Tab, Tabs } from '../../core';
 import AggregationSelect from './AggregationSelect';
-import BandSelect from './BandSelect';
+import BandSelect, { MAX_BANDS } from './BandSelect';
 import PeriodSelect from './PeriodSelect';
 import OrgUnitsSelect from './OrgUnitsSelect';
 import StyleSelect from './StyleSelect';
@@ -59,6 +59,7 @@ const EarthEngineDialog = props => {
     const setPeriod = period => setFilter(period ? filters(period) : null);
 
     const noBandSelected = Array.isArray(bands) && (!band || !band.length);
+    const hasMaxBands = Array.isArray(bands) && band && band.length > MAX_BANDS;
 
     // Load all available periods
     useEffect(() => {
@@ -97,7 +98,8 @@ const EarthEngineDialog = props => {
 
     useEffect(() => {
         if (validateLayer) {
-            const isValid = !noBandSelected && (!periodType || period);
+            const isValid =
+                !noBandSelected && !hasMaxBands && (!periodType || period);
 
             if (!isValid) {
                 if (noBandSelected) {
@@ -106,6 +108,8 @@ const EarthEngineDialog = props => {
                         message: i18n.t('This field is required'),
                     });
                     setTab('data');
+                } else if (hasMaxBands) {
+                    setTab('data'); // Error message is already showing
                 } else {
                     setError({
                         type: 'period',

--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -59,7 +59,8 @@ const EarthEngineDialog = props => {
     const setPeriod = period => setFilter(period ? filters(period) : null);
 
     const noBandSelected = Array.isArray(bands) && (!band || !band.length);
-    const hasMaxBands = Array.isArray(bands) && band && band.length > MAX_BANDS;
+    const aboveMaxBands =
+        Array.isArray(bands) && band && band.length > MAX_BANDS;
 
     // Load all available periods
     useEffect(() => {
@@ -99,7 +100,7 @@ const EarthEngineDialog = props => {
     useEffect(() => {
         if (validateLayer) {
             const isValid =
-                !noBandSelected && !hasMaxBands && (!periodType || period);
+                !noBandSelected && !aboveMaxBands && (!periodType || period);
 
             if (!isValid) {
                 if (noBandSelected) {
@@ -108,7 +109,7 @@ const EarthEngineDialog = props => {
                         message: i18n.t('This field is required'),
                     });
                     setTab('data');
-                } else if (hasMaxBands) {
+                } else if (aboveMaxBands) {
                     setTab('data'); // Error message is already showing
                 } else {
                     setError({

--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -5,7 +5,7 @@ import i18n from '@dhis2/d2-i18n';
 import { NoticeBox } from '@dhis2/ui';
 import { Help, Tab, Tabs } from '../../core';
 import AggregationSelect from './AggregationSelect';
-import BandSelect, { MAX_BANDS } from './BandSelect';
+import BandSelect from './BandSelect';
 import PeriodSelect from './PeriodSelect';
 import OrgUnitsSelect from './OrgUnitsSelect';
 import StyleSelect from './StyleSelect';
@@ -59,8 +59,6 @@ const EarthEngineDialog = props => {
     const setPeriod = period => setFilter(period ? filters(period) : null);
 
     const noBandSelected = Array.isArray(bands) && (!band || !band.length);
-    const aboveMaxBands =
-        Array.isArray(bands) && band && band.length > MAX_BANDS;
 
     // Load all available periods
     useEffect(() => {
@@ -99,8 +97,7 @@ const EarthEngineDialog = props => {
 
     useEffect(() => {
         if (validateLayer) {
-            const isValid =
-                !noBandSelected && !aboveMaxBands && (!periodType || period);
+            const isValid = !noBandSelected && (!periodType || period);
 
             if (!isValid) {
                 if (noBandSelected) {
@@ -109,8 +106,6 @@ const EarthEngineDialog = props => {
                         message: i18n.t('This field is required'),
                     });
                     setTab('data');
-                } else if (aboveMaxBands) {
-                    setTab('data'); // Error message is already showing
                 } else {
                     setError({
                         type: 'period',

--- a/src/components/legend/Legend.js
+++ b/src/components/legend/Legend.js
@@ -23,8 +23,8 @@ const Legend = ({
         {groups && (
             <div className={styles.group}>
                 {groups.length > 1 ? i18n.t('Groups') : i18n.t('Group')}:
-                {groups.map(group => (
-                    <div key={group}>{group}</div>
+                {groups.map(({ id, name }) => (
+                    <div key={id}>{name}</div>
                 ))}
             </div>
         )}

--- a/src/components/map/layers/earthEngine/EarthEnginePopup.js
+++ b/src/components/map/layers/earthEngine/EarthEnginePopup.js
@@ -21,7 +21,15 @@ const EarthEnginePopup = props => {
     let header = null;
 
     if (values) {
-        const types = valueType;
+        const onlySum = valueType.length === 1 && valueType[0] === 'sum';
+
+        // Returns the value
+        const getValueProp = (type, group) =>
+            groups.length === 1
+                ? type
+                : valueType.length === 1
+                ? group
+                : `${group}_${type}`;
 
         const getValueFormat = type =>
             numberPrecision(
@@ -40,8 +48,6 @@ const EarthEnginePopup = props => {
             types[type] = getValueFormat(type);
             return types;
         }, {});
-
-        const onlySum = types.length === 1 && types[0] === 'sum';
 
         if (classes) {
             const valueFormat = numberPrecision(isPercentage ? 2 : 0);
@@ -91,7 +97,7 @@ const EarthEnginePopup = props => {
                         <thead>
                             <tr>
                                 <th>Group</th>
-                                {types.map(type => (
+                                {valueType.map(type => (
                                     <th key={type}>
                                         {getEarthEngineAggregationType(type)}
                                     </th>
@@ -102,31 +108,35 @@ const EarthEnginePopup = props => {
                             {groups.map(({ id, name }) => (
                                 <tr key={id}>
                                     <th>{name}</th>
-                                    {types.map(type => (
+                                    {valueType.map(type => (
                                         <td key={type}>
                                             {typeValueFormat[type](
-                                                values[`${id}_${type}`]
+                                                values[getValueProp(type, id)]
                                             )}
                                         </td>
                                     ))}
                                 </tr>
                             ))}
                         </tbody>
-                        <tfoot>
-                            <tr>
-                                <th>{i18n.t('All groups')}</th>
-                                {types.map(type => (
-                                    <td key={type}>
-                                        {typeValueFormat[type](values[type])}
-                                    </td>
-                                ))}
-                            </tr>
-                        </tfoot>
+                        {groups.length > 1 && (
+                            <tfoot>
+                                <tr>
+                                    <th>{i18n.t('All groups')}</th>
+                                    {valueType.map(type => (
+                                        <td key={type}>
+                                            {typeValueFormat[type](
+                                                values[type]
+                                            )}
+                                        </td>
+                                    ))}
+                                </tr>
+                            </tfoot>
+                        )}
                     </table>
                 );
             }
 
-            rows = types.map(type => {
+            rows = valueType.map(type => {
                 const precision = getPrecision(
                     Object.values(data).map(d => d[type])
                 );

--- a/src/components/map/layers/earthEngine/EarthEnginePopup.js
+++ b/src/components/map/layers/earthEngine/EarthEnginePopup.js
@@ -164,14 +164,16 @@ const EarthEnginePopup = props => {
             onClose={onClose}
             className="dhis2-map-popup-orgunit"
         >
-            <div className={styles.title}>{name}</div>
-            {table}
-            {isLoading && (
-                <div className={styles.loading}>
-                    <CircularLoader small />
-                    {i18n.t('Loading data')}
-                </div>
-            )}
+            <div className={styles.popup}>
+                <div className={styles.title}>{name}</div>
+                {table}
+                {isLoading && (
+                    <div className={styles.loading}>
+                        <CircularLoader small />
+                        {i18n.t('Loading data')}
+                    </div>
+                )}
+            </div>
         </Popup>
     );
 };

--- a/src/components/map/layers/earthEngine/EarthEnginePopup.js
+++ b/src/components/map/layers/earthEngine/EarthEnginePopup.js
@@ -19,8 +19,6 @@ const EarthEnginePopup = props => {
     let table = null;
 
     if (values) {
-        const onlySum = valueType.length === 1 && valueType[0] === 'sum';
-
         if (classes) {
             const valueFormat = numberPrecision(isPercentage ? 2 : 0);
 
@@ -56,13 +54,17 @@ const EarthEnginePopup = props => {
                 </table>
             );
         } else {
-            const getValueProp = (type, group) =>
+            const onlySum = valueType.length === 1 && valueType[0] === 'sum';
+
+            // Returns the value key for a type/group
+            const getValueKey = (type, group) =>
                 groups.length === 1
                     ? type
                     : valueType.length === 1
                     ? group
                     : `${group}_${type}`;
 
+            // Returns the value format (precision) for an aggregation type
             const getValueFormat = type =>
                 numberPrecision(
                     getPrecision(
@@ -76,6 +78,7 @@ const EarthEnginePopup = props => {
                     )
                 );
 
+            // Create value format function for each aggregation type
             const typeValueFormat = valueType.reduce((types, type) => {
                 types[type] = getValueFormat(type);
                 return types;
@@ -109,7 +112,7 @@ const EarthEnginePopup = props => {
                                     {valueType.map(type => (
                                         <td key={type}>
                                             {typeValueFormat[type](
-                                                values[getValueProp(type, id)]
+                                                values[getValueKey(type, id)]
                                             )}
                                         </td>
                                     ))}

--- a/src/components/map/layers/earthEngine/styles/EarthEnginePopup.module.css
+++ b/src/components/map/layers/earthEngine/styles/EarthEnginePopup.module.css
@@ -66,6 +66,14 @@
     padding-left: var(--spacers-dp12);
 }
 
+.classes th:first-child {
+    width: 20px;
+}
+
+.classes th:nth-child(2) {
+    padding-left: var(--spacers-dp8);
+}
+
 .loading {
     display: flex;
     align-items: center;

--- a/src/components/map/layers/earthEngine/styles/EarthEnginePopup.module.css
+++ b/src/components/map/layers/earthEngine/styles/EarthEnginePopup.module.css
@@ -61,6 +61,7 @@
     font-weight: bold;
 }
 
+.table thead th:not(:first-child),
 .table td {
     padding-left: var(--spacers-dp12);
 }

--- a/src/components/map/layers/earthEngine/styles/EarthEnginePopup.module.css
+++ b/src/components/map/layers/earthEngine/styles/EarthEnginePopup.module.css
@@ -8,6 +8,8 @@
     width: 100%;
     border-collapse: collapse;
     font-size: 14px;
+    line-height: 22px;
+    margin-bottom: var(--spacers-dp16);
 }
 
 .table caption {
@@ -30,36 +32,37 @@
     font-weight: normal;
 }
 
-.table thead th {
-    text-align: left;
-    padding-bottom: var(--spacers-dp4);
+.table thead {
+    border-bottom: 1px solid #eee;
 }
 
-.table thead th:last-child {
+.table tfoot {
+    border-top: 1px solid #eee;
+}
+
+.table tfoot {
+    border-top: 1px solid #eee;
+}
+
+.table th,
+.table td {
     text-align: right;
-}
-
-.table tbody th {
-    text-align: left;
     font-weight: normal;
-    padding-right: var(--spacers-dp8);
 }
 
-.table tbody td {
+.table thead th:first-child,
+.table tbody th,
+.table tfoot th {
     text-align: left;
 }
 
-.table tbody td:last-child {
-    text-align: right;
+.table thead th,
+.table tfoot th {
+    font-weight: bold;
 }
 
-td.color {
-    width: 20px;
-}
-
-td.name {
-    padding-left: var(--spacers-dp8);
-    padding-right: var(--spacers-dp8);
+.table td {
+    padding-left: var(--spacers-dp12);
 }
 
 .loading {

--- a/src/components/map/layers/earthEngine/styles/EarthEnginePopup.module.css
+++ b/src/components/map/layers/earthEngine/styles/EarthEnginePopup.module.css
@@ -1,3 +1,10 @@
+.popup {
+    color: var(--colors-grey900);
+    max-height: 240px;
+    overflow-y: auto;
+    padding-right: var(--spacers-dp8);
+}
+
 .title {
     font-weight: bold;
     font-size: 16px;
@@ -7,7 +14,7 @@
 .table {
     width: 100%;
     border-collapse: collapse;
-    font-size: 14px;
+    font-size: 13px;
     line-height: 22px;
     margin-bottom: var(--spacers-dp16);
 }
@@ -33,15 +40,13 @@
 }
 
 .table thead {
-    border-bottom: 1px solid #eee;
+    color: var(--colors-grey600);
+    font-weight: 500;
+    border-bottom: 1px solid var(--colors-grey300);
 }
 
 .table tfoot {
-    border-top: 1px solid #eee;
-}
-
-.table tfoot {
-    border-top: 1px solid #eee;
+    border-top: 1px solid var(--colors-grey300);
 }
 
 .table th,
@@ -58,7 +63,7 @@
 
 .table thead th,
 .table tfoot th {
-    font-weight: bold;
+    font-weight: 500;
 }
 
 .table thead th:not(:first-child),

--- a/src/constants/aggregationTypes.js
+++ b/src/constants/aggregationTypes.js
@@ -27,7 +27,11 @@ export const getEarthEngineAggregationTypes = filter => {
         { id: 'mean', name: i18n.t('Mean') },
         { id: 'median', name: i18n.t('Median') },
         { id: 'sum', name: i18n.t('Sum') },
-        { id: 'stdDev', name: i18n.t('Standard deviation') },
+        {
+            id: 'stdDev',
+            name: i18n.t('Standard deviation'),
+            shortName: i18n.t('Std dev'),
+        },
         { id: 'variance', name: i18n.t('Variance') },
     ];
 
@@ -37,5 +41,8 @@ export const getEarthEngineAggregationTypes = filter => {
 export const getEarthEngineStatisticType = id =>
     (getEarthEngineStatisticTypes().find(t => t.id === id) || {}).name;
 
-export const getEarthEngineAggregationType = id =>
-    (getEarthEngineAggregationTypes().find(t => t.id === id) || {}).name;
+export const getEarthEngineAggregationType = id => {
+    const { name, shortName } =
+        getEarthEngineAggregationTypes().find(t => t.id === id) || {};
+    return shortName || name;
+};

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -106,14 +106,12 @@ const earthEngineLoader = async config => {
     const period = getPeriodNameFromFilter(filter);
     const data =
         Array.isArray(features) && features.length ? features : undefined;
+    const hasBand = b =>
+        Array.isArray(band) ? band.includes(b.id) : band === b.id;
 
     const groups =
         band && Array.isArray(bands) && bands.length
-            ? bands
-                  .filter(b =>
-                      Array.isArray(band) ? band.includes(b.id) : band === b.id
-                  )
-                  .map(b => b.name)
+            ? bands.filter(hasBand)
             : null;
 
     const legend = {


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11039

Depends on this PR in maps-gl: https://github.com/dhis2/maps-gl/pull/422
Will be merged to the EE web worker refactor PR in maps-app: https://github.com/dhis2/maps-app/pull/1931

This PR will show aggregation values for each age/gender groups for the population layer. Currently we only show the aggregated values for all age/gender groups combined.

After this PR:
![Screenshot 2021-12-08 at 17 55 09](https://user-images.githubusercontent.com/548708/145250051-3cd18c64-52b1-4329-924f-f137e7998565.png)

Before: 
![Screenshot 2021-12-08 at 17 56 11](https://user-images.githubusercontent.com/548708/145250229-8d7eb9c6-d9b6-4081-adc9-c8f14db2dbcb.png)

If only one group is selected after this PR:
![Screenshot 2021-12-08 at 18 02 43](https://user-images.githubusercontent.com/548708/145251312-ece08f39-9a0b-4f87-abda-4c7b84a43103.png)

Before: 
![Screenshot 2021-12-08 at 18 03 54](https://user-images.githubusercontent.com/548708/145251426-a7d99d14-8007-4c9e-93c3-ca69bf354057.png)

This PR also adds a restriction to select max 10 groups (selecting more will result in very long response time from EE API):
![Screenshot 2021-12-08 at 18 06 32](https://user-images.githubusercontent.com/548708/145252087-7a5431fc-bde5-4c80-bf99-f66870f04bd2.png)

Aggregated values for each age/gender group will not show in the data table, as there is no room with the current layout: 
![Screenshot 2021-12-08 at 18 22 39](https://user-images.githubusercontent.com/548708/145254850-ad4a0e1c-8b58-4417-9f99-c903fa40c5da.png)

Support can be added by having expandable rows - which is included in: https://jira.dhis2.org/browse/DHIS2-10655

All aggregation values are included when downloading data. 
