### PR TITLE
fix: backward compability for EE layers (DHIS2-11749, 2.35 backport)

### DIFF
--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -232,7 +232,7 @@ const earthEngineLoader = async config => {
 
     layer.legend = {
         title: layer.name,
-        period: layer.periodName,
+        period: layer.periodName || layer.image,
         ...layer.legend,
     };
 


### PR DESCRIPTION
2.35 backport of #1848

This PR makes sure that we show the period for EE layers saved with a different format.

After this PR: 
![Screenshot 2021-12-08 at 21 11 28](https://user-images.githubusercontent.com/548708/145277896-7eb1b9d5-e0c3-46c1-86da-d18e596a7bea.png)

Before: 
![Screenshot 2021-12-08 at 21 12 07](https://user-images.githubusercontent.com/548708/145277882-7bdac462-6ad3-4e9e-8684-5109036952a5.png)
