### PR TITLE
fix: use native input instead of dhis2/ui input in order to correctly validate manually entered dates [v36] 

### DIFF
--- a/src/components/core/DatePicker.js
+++ b/src/components/core/DatePicker.js
@@ -1,29 +1,44 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { InputField } from '@dhis2/ui';
 import cx from 'classnames';
-import { formatDate } from '../../util/time';
 import styles from './styles/DatePicker.module.css';
 
-// DatePicker not yet supported in @dhis2/ui
-// Fallback on browser native
-const DatePicker = ({ label, value, dense = true, onChange, className }) => (
-    <div className={cx(styles.datePicker, className)}>
-        <InputField
-            dense={dense}
-            type="date"
-            label={label}
-            value={formatDate(value)}
-            onChange={({ value }) => onChange(value)}
-        />
-    </div>
-);
+// Fallback on browser native until full DatePicker support in @dhis2/ui
+const DatePicker = ({ label, name, defaultVal, onBlur, className }) => {
+    const inputEl = useRef(null);
+
+    useEffect(() => {
+        if (inputEl.current) {
+            inputEl.current.defaultValue = defaultVal;
+        }
+    }, [defaultVal]);
+
+    return (
+        <div className={cx(styles.datePicker, className)}>
+            <label className={styles.label}>{label}</label>
+            <div className={styles.content}>
+                <div className={styles.box}>
+                    <div className={styles.inputDiv}>
+                        <input
+                            className={styles.input}
+                            ref={inputEl}
+                            type="date"
+                            name={name}
+                            onBlur={e => onBlur(e.target.value)}
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
 
 DatePicker.propTypes = {
     label: PropTypes.string.isRequired,
-    value: PropTypes.string,
+    defaultVal: PropTypes.string,
     dense: PropTypes.bool,
-    onChange: PropTypes.func.isRequired,
+    name: PropTypes.string,
+    onBlur: PropTypes.func.isRequired,
     className: PropTypes.string,
 };
 

--- a/src/components/core/styles/DatePicker.module.css
+++ b/src/components/core/styles/DatePicker.module.css
@@ -1,3 +1,47 @@
 .datePicker {
     margin: var(--spacers-dp8) 0;
 }
+
+.label {
+    display: block;
+    box-sizing: border-box;
+    font-size: 14px;
+    line-height: 24px;
+    padding: 0px;
+}
+
+.content {
+    margin-top: var(--spacers-dp4);
+}
+
+.box {
+    min-width: 72px;
+    margin-right: var(--spacers-dp8);
+}
+
+.inputDiv {
+    display: flex;
+    -webkit-box-align: center;
+    align-items: center;
+}
+
+.input {
+    padding: 8px 11px 6px;
+    width: 100%;
+    box-sizing: border-box;
+    font-size: 14px;
+    line-height: 16px;
+    user-select: text;
+    color: var(--colors-grey900);
+    background-color: var(--colors-white);
+    outline: 0;
+    border: 1px solid var(--colors-grey500);
+    border-radius: 3px;
+    box-shadow: inset 0 1px 2px 0 rgba(48, 54, 60, 0.1);
+    text-overflow: ellipsis;
+}
+
+.input:focus {
+    outline: none;
+    border-color: var(--colors-teal400);
+}

--- a/src/components/periods/StartEndDates.js
+++ b/src/components/periods/StartEndDates.js
@@ -29,14 +29,14 @@ const StartEndDates = props => {
         <Fragment>
             <DatePicker
                 label={i18n.t('Start date')}
-                value={startDate}
-                onChange={setStartDate}
+                defaultVal={startDate}
+                onBlur={setStartDate}
                 className={className || styles.select}
             />
             <DatePicker
                 label={i18n.t('End date')}
-                value={endDate}
-                onChange={setEndDate}
+                defaultVal={endDate}
+                onBlur={setEndDate}
                 className={className || styles.select}
             />
             {errorText && (


### PR DESCRIPTION
Backport of #1925

Fixes https://jira.dhis2.org/browse/DHIS2-11934

Controlled input type date components are problematic because of the way date validation is handled by the native element.

Use an uncontrolled input component, pass in a default value, and use onBlur instead of onChange to set the date value in the redux store.

Styles are copied from dhis2/ui input.