### PR TITLE
fix: check for program name for TEI layers

### DIFF
--- a/src/loaders/trackedEntityLoader.js
+++ b/src/loaders/trackedEntityLoader.js
@@ -65,7 +65,7 @@ const trackedEntityLoader = async config => {
         relationshipLineColor,
     } = config;
 
-    const name = program ? program.name : i18n.t('Tracked entity');
+    const name = program?.name ? program.name : i18n.t('Tracked entity');
 
     const legend = {
         title: name,


### PR DESCRIPTION
Fixes issue where fallback title "Tracked entity" is not showing in legend for tracked entity layers on Dashboard. 