### PR TITLE
fix: layer scope, data table filter and open as chart base url (DHIS2-12462)

### DIFF
--- a/src/components/layers/overlays/OverlayCard.js
+++ b/src/components/layers/overlays/OverlayCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
+import { useConfig } from '@dhis2/app-runtime';
 import LayerCard from '../LayerCard';
 import Legend from '../../legend/Legend';
 import {
@@ -35,6 +36,8 @@ const OverlayCard = ({
     openDataDownloadDialog,
     setAlert,
 }) => {
+    const { baseUrl } = useConfig();
+
     const {
         id,
         name,
@@ -81,7 +84,8 @@ const OverlayCard = ({
             }
             openAs={
                 canOpenAs
-                    ? type => setAnalyticalObjectAndSwitchApp(layer, type)
+                    ? type =>
+                          setAnalyticalObjectAndSwitchApp(layer, type, baseUrl)
                     : undefined
             }
         >

--- a/src/components/map/layers/Layer.js
+++ b/src/components/map/layers/Layer.js
@@ -105,11 +105,11 @@ class Layer extends PureComponent {
         await map.addLayer(this.layer);
     }
 
-    async updateLayer() {
+    updateLayer = async () => {
         await this.removeLayer();
         await this.createLayer(true);
         this.setLayerOrder();
-    }
+    };
 
     // Override in subclass if needed
     setPeriod(callback) {

--- a/src/components/map/layers/Layer.js
+++ b/src/components/map/layers/Layer.js
@@ -62,7 +62,7 @@ class Layer extends PureComponent {
         ) {
             // Reset period if edited
             if (isEdited) {
-                this.setPeriod(this.updateLayer);
+                this.setPeriod(this.updateLayer.bind(this));
             } else {
                 this.updateLayer(dataFilters !== prevProps.dataFilters);
             }
@@ -105,11 +105,11 @@ class Layer extends PureComponent {
         await map.addLayer(this.layer);
     }
 
-    updateLayer = async () => {
+    async updateLayer() {
         await this.removeLayer();
         await this.createLayer(true);
         this.setLayerOrder();
-    };
+    }
 
     // Override in subclass if needed
     setPeriod(callback) {

--- a/src/components/map/layers/OrgUnitLayer.js
+++ b/src/components/map/layers/OrgUnitLayer.js
@@ -93,9 +93,4 @@ export default class OrgUnitLayer extends Layer {
     onFeatureClick(evt) {
         this.setState({ popup: evt });
     }
-
-    removeLayer() {
-        this.layer.off('click', this.onFeatureClick, this);
-        super.removeLayer();
-    }
 }

--- a/src/util/analyticalObject.js
+++ b/src/util/analyticalObject.js
@@ -124,10 +124,14 @@ export const setCurrentAnalyticalObject = async ao => {
 };
 
 // Sets analytical object to open it in another app
-export const setAnalyticalObjectAndSwitchApp = async (layer, openAs) => {
+export const setAnalyticalObjectAndSwitchApp = async (
+    layer,
+    openAs,
+    baseUrl
+) => {
     const ao = getAnalyticalObjectFromThematicLayer(layer);
 
-    const url = `${process.env.DHIS2_BASE_URL}/${APP_URLS[openAs]}/#/currentAnalyticalObject`;
+    const url = `${baseUrl}/${APP_URLS[openAs]}/#/currentAnalyticalObject`;
 
     await setCurrentAnalyticalObject(ao);
 

--- a/src/util/analyticalObject.js
+++ b/src/util/analyticalObject.js
@@ -1,4 +1,4 @@
-import { config, getInstance as getD2 } from 'd2';
+import { getInstance as getD2 } from 'd2';
 import { getPeriodNameFromId, getDimensionsFromFilters } from './analytics';
 import { loadDataItemLegendSet } from './legend';
 import { cleanDimension } from './favorites';
@@ -126,7 +126,8 @@ export const setCurrentAnalyticalObject = async ao => {
 // Sets analytical object to open it in another app
 export const setAnalyticalObjectAndSwitchApp = async (layer, openAs) => {
     const ao = getAnalyticalObjectFromThematicLayer(layer);
-    const url = `${config.appUrl}/${APP_URLS[openAs]}/#/currentAnalyticalObject`;
+
+    const url = `${process.env.DHIS2_BASE_URL}/${APP_URLS[openAs]}/#/currentAnalyticalObject`;
 
     await setCurrentAnalyticalObject(ao);
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12462

This PR fixes 3 issues only present in master: 
- Run updateLayer method in the layer scope
- Remove "removeLayer" method of org unit layer (we don't use the click event anymore)
- Set the correct base url when open as chart
