### PR TITLE
feat: improved handling of earth engine layers

### DIFF
--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -25,6 +25,7 @@ export const LayerToolbarMoreMenu = ({
     openAs,
     downloadData,
     dataTableOpen,
+    isLoading,
 }) => {
     const [isOpen, setIsOpen] = useState(false);
     const anchorRef = useRef();
@@ -95,6 +96,7 @@ export const LayerToolbarMoreMenu = ({
                                         setIsOpen(false);
                                         downloadData();
                                     }}
+                                    disabled={isLoading}
                                 />
                             )}
                             {showDivider && <Divider />}
@@ -135,8 +137,10 @@ LayerToolbarMoreMenu.propTypes = {
     openAs: PropTypes.func,
     downloadData: PropTypes.func,
     dataTableOpen: PropTypes.string,
+    isLoading: PropTypes.bool,
 };
 
-export default connect(({ dataTable }) => ({
+export default connect(({ dataTable, aggregations }, { layer }) => ({
     dataTableOpen: dataTable,
+    isLoading: layer?.layer === 'earthEngine' && !aggregations[layer.id],
 }))(LayerToolbarMoreMenu);

--- a/src/components/legend/Legend.js
+++ b/src/components/legend/Legend.js
@@ -22,7 +22,7 @@ const Legend = ({
         {description && <div className={styles.description}>{description}</div>}
         {groups && (
             <div className={styles.group}>
-                {groups.length > 1 ? i18n.t('Groups') : i18n.t('Group')}:
+                {groups.length > 1 ? i18n.t('Groups') : i18n.t('Group')}
                 {groups.map(({ id, name }) => (
                     <div key={id}>{name}</div>
                 ))}

--- a/src/components/map/MapLoadingMask.js
+++ b/src/components/map/MapLoadingMask.js
@@ -3,7 +3,7 @@ import { ComponentCover, CenteredContent, CircularLoader } from '@dhis2/ui';
 import styles from './styles/MapLoadingMask.module.css';
 
 const MapLoadingMask = () => (
-    <ComponentCover className={styles.cover}>
+    <ComponentCover translucent className={styles.cover}>
         <CenteredContent>
             <CircularLoader />
         </CenteredContent>

--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -219,7 +219,7 @@ export const earthEngineLayers = () => [
             'https://explorer.earthengine.google.com/#detail/USGS%2FSRTMGL1_003',
         img: 'images/elevation.png',
         aggregations: ['min', 'max', 'mean', 'median', 'stdDev', 'variance'],
-        defaultAggregations: ['min', 'max', 'mean'],
+        defaultAggregations: ['mean', 'min', 'max'],
         band: 'elevation',
         params: {
             min: 0,
@@ -242,7 +242,7 @@ export const earthEngineLayers = () => [
         periodType: 'Custom',
         band: 'precipitation',
         aggregations: ['min', 'max', 'mean', 'median', 'stdDev', 'variance'],
-        defaultAggregations: ['min', 'max', 'mean'],
+        defaultAggregations: ['mean', 'min', 'max'],
         mask: true,
         img: 'images/precipitation.png',
         params: {
@@ -265,7 +265,7 @@ export const earthEngineLayers = () => [
             'https://explorer.earthengine.google.com/#detail/MODIS%2FMOD11A2',
         img: 'images/temperature.png',
         aggregations: ['min', 'max', 'mean', 'median', 'stdDev', 'variance'],
-        defaultAggregations: ['min', 'max', 'mean'],
+        defaultAggregations: ['mean', 'min', 'max'],
         periodType: 'Custom',
         band: 'LST_Day_1km',
         mask: true,

--- a/src/reducers/aggregations.js
+++ b/src/reducers/aggregations.js
@@ -1,6 +1,8 @@
 import * as types from '../constants/actionTypes';
 
 const dataTable = (state = {}, action) => {
+    let layerId;
+
     switch (action.type) {
         case types.AGGREGATIONS_SET:
             return {
@@ -13,10 +15,13 @@ const dataTable = (state = {}, action) => {
             return {};
 
         case types.LAYER_REMOVE:
-            return state[action.id]
+        case types.LAYER_UPDATE:
+            layerId = action.id || action.payload?.id;
+
+            return layerId && state[layerId]
                 ? {
                       ...state,
-                      [action.id]: null,
+                      [layerId]: undefined,
                   }
                 : state;
 


### PR DESCRIPTION
Implements: https://jira.dhis2.org/browse/DHIS2-12464

Included in this PR:
- Disable "Download data" from layer toolbar until aggregated values are returned (screenshot below). 
- Clear current aggregation data when an EE layer is updated. Will trigger a loading spinner in the data table (see screen recording below).
- Add translucent mask while Earth Engine layers are loading. I tried to remove the mask to allow user interactions, but it had some side effects: If the users navigates a map there will be a sudden change of view when the layer is loaded. Better to keep the mask for now, and make it visible. 
- Remove ":" after "Group" in legend
- Order default aggregations so the mose useful one is shown first

![Screenshot 2022-01-19 at 13 40 58](https://user-images.githubusercontent.com/548708/150132908-6c3a751f-8522-46a6-9c7b-9215a1b658d8.png)

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/548708/150148356-ddb7b2f3-a0fa-4d47-89fe-c1c36a83ddab.gif)
