### PR TITLE
fix: disable data table dragging after handle is released (DHIS2-12483)

### DIFF
--- a/src/components/datatable/ResizeHandle.js
+++ b/src/components/datatable/ResizeHandle.js
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import { IconDrag } from '../core/icons';
 import styles from './styles/ResizeHandle.module.css';
 
+// TODO: Remove globe cursor in chrome
+// https://stackoverflow.com/questions/6771196/stopping-chrome-from-changing-cursor-to-a-globe-while-dragging-a-link
+
 const ResizeHandle = ({ onResize, onResizeEnd, minHeight, maxHeight }) => {
     let dragHeight = 0;
 
@@ -35,6 +38,8 @@ const ResizeHandle = ({ onResize, onResizeEnd, minHeight, maxHeight }) => {
         if (height && onResizeEnd) {
             onResizeEnd(height);
         }
+
+        document.ondragover = null;
     };
 
     const getHeight = evt => {


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-12483

This PR makes sure that the table will not resize after dragging the handle stopped. 

I've not been able to find a solution to the globe cursor issue in chrome. As we have more pressing issues, I don't plan to spend more time on looking for a solution :-)