### PR TITLE
fix: keep data filter when Earth Engine layer is redrawn (DHIS2-12502)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@dhis2/d2-ui-interpretations": "^7.3.3",
         "@dhis2/d2-ui-org-unit-dialog": "^7.3.3",
         "@dhis2/d2-ui-org-unit-tree": "^7.3.3",
-        "@dhis2/maps-gl": "^3.0.2",
+        "@dhis2/maps-gl": "^3.0.3",
         "@dhis2/ui": "^7.14.2",
         "abortcontroller-polyfill": "^1.7.3",
         "array-move": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2377,10 +2377,10 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-3.0.2.tgz#8c20886fb3f92802cd71e19284c26e7c32095dd5"
-  integrity sha512-vEe6VBuKU3penUAYNxCPa9YOsGKSUdXASwiOu1gDAUJWZqGCI3MS8EZDAHq9HMG1qCFIf9PatpyLeshlkxLOqQ==
+"@dhis2/maps-gl@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-3.0.3.tgz#a26ddb5b8b51271ffa96b56344f357e66507936f"
+  integrity sha512-iFFY2CyN3RMGtpQHTxu3NAraOd7k1qf3QrF3xpp/ZD1FJYf1H4mJZBDyu+KIkGWWy5igp6RTwf7k3ZKxai4lrw==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.3.0"
@@ -2391,7 +2391,7 @@
     "@turf/length" "^6.3.0"
     comlink "^4.3.1"
     fetch-jsonp "^1.1.3"
-    lodash.throttle "^4.1.1"
+    lodash "^4.17.21"
     maplibre-gl "^1.15.2"
     polylabel "^1.1.0"
     suggestions "^1.7.1"


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12502

Fixed in https://github.com/dhis2/maps-gl/pull/431