### PR TITLE
fix: display api error when org unit selection is invalid (DHIS2-12504)

### DIFF
--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -37,7 +37,7 @@ const earthEngineLoader = async config => {
             ];
         }
 
-        if (!features.length) {
+        if (Array.isArray(features) && !features.length) {
             alerts = [
                 {
                     warning: true,


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12504

This PR will make sure the API error message is displayed when the org unit selection is invalid: 

![Screenshot 2022-01-24 at 16 47 20](https://user-images.githubusercontent.com/548708/150816423-480cbcb6-eabf-4457-a63f-2a553a215866.png)
