### PR TITLE
fix: handle no aggregation types or no org units for Earth Engine layers (DHIS2-12475)

### DIFF
--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -25,7 +25,7 @@ export const LayerToolbarMoreMenu = ({
     openAs,
     downloadData,
     dataTableOpen,
-    isLoading,
+    downloadDisabled,
 }) => {
     const [isOpen, setIsOpen] = useState(false);
     const anchorRef = useRef();
@@ -96,7 +96,7 @@ export const LayerToolbarMoreMenu = ({
                                         setIsOpen(false);
                                         downloadData();
                                     }}
-                                    disabled={isLoading}
+                                    disabled={downloadDisabled}
                                 />
                             )}
                             {showDivider && <Divider />}
@@ -137,10 +137,13 @@ LayerToolbarMoreMenu.propTypes = {
     openAs: PropTypes.func,
     downloadData: PropTypes.func,
     dataTableOpen: PropTypes.string,
-    isLoading: PropTypes.bool,
+    downloadDisabled: PropTypes.bool,
 };
 
 export default connect(({ dataTable, aggregations }, { layer }) => ({
     dataTableOpen: dataTable,
-    isLoading: layer?.layer === 'earthEngine' && !aggregations[layer.id],
+    // Disable EE download if no org units or no aggregations are available
+    downloadDisabled:
+        layer?.layer === 'earthEngine' &&
+        (!layer.data || !aggregations[layer.id]),
 }))(LayerToolbarMoreMenu);

--- a/src/components/map/layers/earthEngine/EarthEngineLayer.js
+++ b/src/components/map/layers/earthEngine/EarthEngineLayer.js
@@ -95,7 +95,7 @@ export default class EarthEngineLayer extends Layer {
             projection,
             data,
             aggregationType,
-            preload: !isPlugin,
+            preload: !isPlugin && this.hasAggregations(),
             onClick: this.onFeatureClick.bind(this),
             onRightClick: this.onFeatureRightClick.bind(this),
             onLoad: this.onLoad.bind(this),
@@ -130,7 +130,12 @@ export default class EarthEngineLayer extends Layer {
     }
 
     hasAggregations() {
-        return this.props.data && this.props.aggregationType;
+        const { data, aggregationType } = this.props;
+        return (
+            data &&
+            (typeof aggregationType === 'string' ||
+                (Array.isArray(aggregationType) && aggregationType.length))
+        );
     }
 
     getAggregations() {


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12475

This PR fixes two issues: 
- When no aggregation types are selected (empty array) we will no longer show an error, but show a map without aggregating for each org unit. 
- When no org units are selected, "Download data" will be disabled in the layer more menu. 

Download is disabled when no aggregation types are selected: 
![Screenshot 2022-01-25 at 15 24 53](https://user-images.githubusercontent.com/548708/150995007-f05c0f05-b9a0-4800-8bb5-7cc3bb775cb6.png)

Download is disabled when no org units are selected: 
![Screenshot 2022-01-25 at 15 26 02](https://user-images.githubusercontent.com/548708/150995211-d3d2dfd4-c1e8-4e0f-8787-9ece68443048.png)

Download is disabled when the layer is loading: 
![Screenshot 2022-01-25 at 15 27 58](https://user-images.githubusercontent.com/548708/150995471-b2524a4f-db3b-45a5-9047-06a293b394d6.png)

Download is enabled when aggregations and org units are selected + the layer has loaded:
![Screenshot 2022-01-25 at 15 28 51](https://user-images.githubusercontent.com/548708/150995699-17ec2ae4-aab0-4ac0-b22f-72b996153c8d.png)


