### PR TITLE
fix: use EE Web Worker in DHIS2 Maps 2.36 (DHIS2-12013)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-10-19T10:03:29.943Z\n"
-"PO-Revision-Date: 2021-10-19T10:03:29.943Z\n"
+"POT-Creation-Date: 2022-01-26T16:52:39.743Z\n"
+"PO-Revision-Date: 2022-01-26T16:52:39.743Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -586,6 +586,9 @@ msgid "Loading layer data"
 msgstr ""
 
 msgid "Last updated"
+msgstr ""
+
+msgid "no value"
 msgstr ""
 
 msgid "acres"
@@ -1238,9 +1241,6 @@ msgstr ""
 msgid ""
 "This layer requires a Google Earth Engine account. Check the DHIS2 "
 "documentation for more information."
-msgstr ""
-
-msgid "Cannot connect to Google Earth Engine."
 msgstr ""
 
 msgid "Start date is invalid"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "36.0.3",
+    "version": "36.0.4",
     "description": "DHIS2 Maps",
     "main": "src/app.js",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@dhis2/d2-ui-interpretations": "^7.3.3",
         "@dhis2/d2-ui-org-unit-dialog": "^7.3.3",
         "@dhis2/d2-ui-org-unit-tree": "^7.3.3",
-        "@dhis2/maps-gl": "^2.2.4",
+        "@dhis2/maps-gl": "^3.0.4",
         "@dhis2/ui": "^6.25.2",
         "abortcontroller-polyfill": "^1.5.0",
         "array-move": "^3.0.1",

--- a/src/components/map/MapApi.js
+++ b/src/components/map/MapApi.js
@@ -1,7 +1,7 @@
 import MapApi, {
     layerTypes,
     controlTypes,
-    loadEarthEngineApi,
+    loadEarthEngineWorker,
     poleOfInaccessibility,
 } from '@dhis2/maps-gl';
 import getMapLocale from './mapLocale';
@@ -23,6 +23,11 @@ const map = options => {
     });
 };
 
-export { layerTypes, controlTypes, loadEarthEngineApi, poleOfInaccessibility };
+export {
+    layerTypes,
+    controlTypes,
+    loadEarthEngineWorker,
+    poleOfInaccessibility,
+};
 
 export default map;

--- a/src/components/map/layers/earthEngine/EarthEngineLayer.js
+++ b/src/components/map/layers/earthEngine/EarthEngineLayer.js
@@ -127,7 +127,7 @@ export default class EarthEngineLayer extends Layer {
             this.onError(error);
         }
 
-        this.getAggregation();
+        this.getAggregations();
 
         this.fitBoundsOnce();
     }

--- a/src/components/map/layers/earthEngine/EarthEnginePopup.js
+++ b/src/components/map/layers/earthEngine/EarthEnginePopup.js
@@ -73,19 +73,21 @@ const EarthEnginePopup = props => {
                 </caption>
             );
 
-            rows = types.map(type => {
-                const precision = getPrecision(
-                    Object.values(data).map(d => d[type])
-                );
-                const valueFormat = numberPrecision(precision);
+            rows = types
+                .filter(type => getEarthEngineAggregationType(type))
+                .map(type => {
+                    const precision = getPrecision(
+                        Object.values(data).map(d => d[type])
+                    );
+                    const valueFormat = numberPrecision(precision);
 
-                return (
-                    <tr key={type}>
-                        <th>{getEarthEngineAggregationType(type)}:</th>
-                        <td>{valueFormat(values[type])}</td>
-                    </tr>
-                );
-            });
+                    return (
+                        <tr key={type}>
+                            <th>{getEarthEngineAggregationType(type)}:</th>
+                            <td>{valueFormat(values[type])}</td>
+                        </tr>
+                    );
+                });
         }
     }
 

--- a/src/util/earthEngine.js
+++ b/src/util/earthEngine.js
@@ -1,6 +1,6 @@
 import i18n from '@dhis2/d2-i18n';
 import { formatStartEndDate } from './time';
-import { loadEarthEngineApi } from '../components/map/MapApi';
+import { loadEarthEngineWorker } from '../components/map/MapApi';
 import { apiFetch } from './api';
 import { getEarthEngineLayer } from '../constants/earthEngine';
 
@@ -44,64 +44,51 @@ export const getPeriodNameFromFilter = filter => {
     return `${name}${showYear ? ` ${year}` : ''}`;
 };
 
-const setAuthToken = ({ client_id, access_token, expires_in }) =>
-    new Promise((resolve, reject) => {
-        ee.data.setAuthToken(client_id, 'Bearer', access_token, expires_in);
-        ee.initialize(null, null, resolve, reject);
-    });
-
-// Set token and load api
-const connectEarthEngine = () =>
+// Returns auth token for EE API as a promise
+export const getAuthToken = () =>
     new Promise(async (resolve, reject) => {
         const token = await apiFetch('/tokens/google').catch(() =>
-            reject({
-                type: 'engine',
-                error: true,
-                message: i18n.t(
-                    'Cannot get authorization token for Google Earth Engine.'
-                ),
-            })
+            reject(
+                new Error(
+                    i18n.t(
+                        'Cannot get authorization token for Google Earth Engine.'
+                    )
+                )
+            )
         );
 
         if (token && token.status === 'ERROR') {
-            reject({
-                type: 'engine',
-                warning: true,
-                message: i18n.t(
-                    'This layer requires a Google Earth Engine account. Check the DHIS2 documentation for more information.'
-                ),
-            });
+            reject(
+                new Error(
+                    i18n.t(
+                        'This layer requires a Google Earth Engine account. Check the DHIS2 documentation for more information.'
+                    )
+                )
+            );
         }
 
-        if (!window.ee && loadEarthEngineApi) {
-            await loadEarthEngineApi();
-        }
-
-        try {
-            await setAuthToken(token);
-        } catch (e) {
-            reject({
-                type: 'engine',
-                error: true,
-                message: i18n.t('Cannot connect to Google Earth Engine.'),
-            });
-        }
-
-        resolve(window.ee);
+        resolve({
+            token_type: 'Bearer',
+            ...token,
+        });
     });
+
+let workerPromise;
+
+// Load EE worker and set token
+const getWorkerInstance = async () => {
+    workerPromise =
+        workerPromise ||
+        (async () => {
+            const EarthEngineWorker = await loadEarthEngineWorker(getAuthToken);
+            return await new EarthEngineWorker();
+        })();
+
+    return workerPromise;
+};
 
 export const getPeriods = async eeId => {
     const { periodType } = getEarthEngineLayer(eeId);
-    const ee = await connectEarthEngine();
-
-    const imageCollection = ee
-        .ImageCollection(eeId)
-        .distinct('system:time_start')
-        .sort('system:time_start', false);
-
-    const featureCollection = ee
-        .FeatureCollection(imageCollection)
-        .select(['system:time_start', 'system:time_end'], null, false);
 
     const getPeriod = ({ id, properties }) => {
         const year = new Date(properties['system:time_start']).getFullYear();
@@ -118,11 +105,10 @@ export const getPeriods = async eeId => {
         return { id, name, year };
     };
 
-    return new Promise(resolve =>
-        featureCollection.getInfo(({ features }) =>
-            resolve(features.map(getPeriod))
-        )
-    );
+    const eeWorker = await getWorkerInstance();
+
+    const { features } = await eeWorker.getPeriods(eeId);
+    return features.map(getPeriod);
 };
 
 export const defaultFilters = ({ id, name, year }) => [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2042,10 +2042,10 @@
     react-select "^2.0.0"
     rxjs "^5.5.7"
 
-"@dhis2/maps-gl@^2.2.4":
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-2.2.4.tgz#8c6efb5e241abda65f20a568531597dde646ccf9"
-  integrity sha512-WEXPpt5CmMcPvHUFM8NlQamIny3ddQkg+P+gbkupGi5FhlypI+aIAP2utWIQIOdmrA1tPRtd/J7qQb/ZQUxk7g==
+"@dhis2/maps-gl@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-3.0.4.tgz#4fef1a717676d63866c838aba438af54be7ab76b"
+  integrity sha512-Jpw4vO1IFrTVJv4KbuEPL+Wg6PIo2fc+e6vX7LDyfIVEJkcAL88VSEdM1Xj/nyPXu+LqqhtO5tZ81lty1O9T6g==
   dependencies:
     "@mapbox/sphericalmercator" "^1.1.0"
     "@turf/area" "^6.3.0"
@@ -2054,8 +2054,9 @@
     "@turf/center-of-mass" "^6.3.0"
     "@turf/circle" "^6.3.0"
     "@turf/length" "^6.3.0"
+    comlink "^4.3.1"
     fetch-jsonp "^1.1.3"
-    lodash.throttle "^4.1.1"
+    lodash "^4.17.21"
     maplibre-gl "^1.15.2"
     polylabel "^1.1.0"
     suggestions "^1.7.1"
@@ -6022,6 +6023,11 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+comlink@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/comlink/-/comlink-4.3.1.tgz#0c6b9d69bcd293715c907c33fe8fc45aecad13c5"
+  integrity sha512-+YbhUdNrpBZggBAHWcgQMLPLH1KDF3wJpeqrCKieWQ8RL7atmgsgTQko1XEBK6PsecfopWNntopJ+ByYG1lRaA==
 
 commander@2.15.1:
   version "2.15.1"


### PR DESCRIPTION
Fixes for Maps 2.36: https://jira.dhis2.org/browse/DHIS2-12013

With this PR we use the new Earth Engine web worker for DHIS2 Maps 2.36.
It is a minimal backport of #1931

The PR also includes a backport of:
https://jira.dhis2.org/browse/DHIS2-12506

EE layer loaded with through the web worker in Maps 2.36:
![Screenshot 2022-01-26 at 17 58 12](https://user-images.githubusercontent.com/548708/151210142-e06ec63f-c159-4129-8680-eddec6d0f9df.png)
