### PR TITLE
fix: handle no aggregation types or no org units for Earth Engine layers (DHIS2-12475, 2.37 backport)

### DIFF
--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -25,6 +25,7 @@ export const LayerToolbarMoreMenu = ({
     openAs,
     downloadData,
     dataTableOpen,
+    downloadDisabled,
 }) => {
     const [isOpen, setIsOpen] = useState(false);
     const anchorRef = useRef();
@@ -95,6 +96,7 @@ export const LayerToolbarMoreMenu = ({
                                         setIsOpen(false);
                                         downloadData();
                                     }}
+                                    disabled={downloadDisabled}
                                 />
                             )}
                             {showDivider && <Divider />}
@@ -135,8 +137,13 @@ LayerToolbarMoreMenu.propTypes = {
     openAs: PropTypes.func,
     downloadData: PropTypes.func,
     dataTableOpen: PropTypes.string,
+    downloadDisabled: PropTypes.bool,
 };
 
-export default connect(({ dataTable }) => ({
+export default connect(({ dataTable, aggregations }, { layer }) => ({
     dataTableOpen: dataTable,
+    // Disable EE download if no org units or no aggregations are available
+    downloadDisabled:
+        layer?.layer === 'earthEngine' &&
+        (!layer.data || !aggregations[layer.id]),
 }))(LayerToolbarMoreMenu);

--- a/src/components/map/layers/earthEngine/EarthEngineLayer.js
+++ b/src/components/map/layers/earthEngine/EarthEngineLayer.js
@@ -97,7 +97,7 @@ export default class EarthEngineLayer extends Layer {
             projection,
             data,
             aggregationType,
-            preload: true,
+            preload: this.hasAggregations(),
             getAuthToken: getAuthToken,
             onClick: this.onFeatureClick.bind(this),
             onRightClick: this.onFeatureRightClick.bind(this),
@@ -133,7 +133,12 @@ export default class EarthEngineLayer extends Layer {
     }
 
     hasAggregations() {
-        return this.props.data && this.props.aggregationType;
+        const { data, aggregationType } = this.props;
+        return (
+            data &&
+            (typeof aggregationType === 'string' ||
+                (Array.isArray(aggregationType) && aggregationType.length))
+        );
     }
 
     getAggregations() {

--- a/src/components/map/layers/styles/LayerLoading.module.css
+++ b/src/components/map/layers/styles/LayerLoading.module.css
@@ -1,7 +1,7 @@
 .layerLoading {
     display: flex;
     align-items: center;
-    padding-right: var(--spacers-dp16);
+    padding: var(--spacers-dp16);
     box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
     border-radius: 4px;
     background: rgba(255, 255, 255, 0.9);

--- a/src/components/orgunits/styles/UserOrgUnitSelect.module.css
+++ b/src/components/orgunits/styles/UserOrgUnitSelect.module.css
@@ -8,7 +8,7 @@
     fill: none;
 }
 
-.userOrgUnits svg rect.filled {
+.userOrgUnits svg :global rect.filled {
     stroke: #555;
     fill: #555;
 }

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -37,7 +37,7 @@ const earthEngineLoader = async config => {
             ];
         }
 
-        if (!features.length) {
+        if (Array.isArray(features) && !features.length) {
             alerts = [
                 {
                     warning: true,


### PR DESCRIPTION
Fixes for DHIS2 Maps 2.37: 
https://jira.dhis2.org/browse/DHIS2-12475
https://jira.dhis2.org/browse/DHIS2-12504

2.37 backport of https://github.com/dhis2/maps-app/pull/2018 and https://github.com/dhis2/maps-app/pull/2016

This PR also fixes two smal style issues: 

Extra padding around "Loading layer data": 
<img width="303" alt="Screenshot 2022-01-31 at 12 47 43" src="https://user-images.githubusercontent.com/548708/151789480-be9c543a-398b-4ec6-b4f5-680802b2d5fc.png">

Before: 
<img width="251" alt="Screenshot 2022-01-31 at 12 48 19" src="https://user-images.githubusercontent.com/548708/151789503-fa8f037f-7a5c-45de-b8a5-4acfe310be33.png">

Filled style for user org unit levels: 

![Screenshot 2022-01-20 at 18 11 15](https://user-images.githubusercontent.com/548708/150387923-dfd3ba05-991a-4e03-b475-53ad69e69d97.png)

Before:

![Screenshot 2022-01-20 at 18 11 44](https://user-images.githubusercontent.com/548708/150387994-6946916b-1914-484f-9065-59985d210b65.png)
 
