### PR TITLE
fix: disable data table dragging after handle is released (DHIS2-12483, 2.36 backport)

### DIFF
--- a/src/components/datatable/ResizeHandle.js
+++ b/src/components/datatable/ResizeHandle.js
@@ -35,6 +35,8 @@ const ResizeHandle = ({ onResize, onResizeEnd, minHeight, maxHeight }) => {
         if (height && onResizeEnd) {
             onResizeEnd(height);
         }
+
+        document.ondragover = null;
     };
 
     const getHeight = evt => {


### PR DESCRIPTION
Partly fixes: https://jira.dhis2.org/browse/DHIS2-12483

2.36 backport of #2012