### PR TITLE
fix: use male/female instead of men/women

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-01-24T17:17:35.040Z\n"
-"PO-Revision-Date: 2022-01-24T17:17:35.040Z\n"
+"POT-Creation-Date: 2022-01-31T14:54:01.715Z\n"
+"PO-Revision-Date: 2022-01-31T14:54:01.715Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -922,112 +922,112 @@ msgstr ""
 msgid "Estimated number of people living in an area, grouped by age and gender."
 msgstr ""
 
-msgid "Men 0 - 1 years"
+msgid "Male 0 - 1 years"
 msgstr ""
 
-msgid "Men 1 - 4 years"
+msgid "Male 1 - 4 years"
 msgstr ""
 
-msgid "Men 5 - 9 years"
+msgid "Male 5 - 9 years"
 msgstr ""
 
-msgid "Men 10 - 14 years"
+msgid "Male 10 - 14 years"
 msgstr ""
 
-msgid "Men 15 - 19 years"
+msgid "Male 15 - 19 years"
 msgstr ""
 
-msgid "Men 20 - 24 years"
+msgid "Male 20 - 24 years"
 msgstr ""
 
-msgid "Men 25 - 29 years"
+msgid "Male 25 - 29 years"
 msgstr ""
 
-msgid "Men 30 - 34 years"
+msgid "Male 30 - 34 years"
 msgstr ""
 
-msgid "Men 35 - 39 years"
+msgid "Male 35 - 39 years"
 msgstr ""
 
-msgid "Men 40 - 44 years"
+msgid "Male 40 - 44 years"
 msgstr ""
 
-msgid "Men 45 - 49 years"
+msgid "Male 45 - 49 years"
 msgstr ""
 
-msgid "Men 50 - 54 years"
+msgid "Male 50 - 54 years"
 msgstr ""
 
-msgid "Men 55 - 59 years"
+msgid "Male 55 - 59 years"
 msgstr ""
 
-msgid "Men 60 - 64 years"
+msgid "Male 60 - 64 years"
 msgstr ""
 
-msgid "Men 65 - 69 years"
+msgid "Male 65 - 69 years"
 msgstr ""
 
-msgid "Men 70 - 74 years"
+msgid "Male 70 - 74 years"
 msgstr ""
 
-msgid "Men 75 - 79 years"
+msgid "Male 75 - 79 years"
 msgstr ""
 
-msgid "Men 80 years and above"
+msgid "Male 80 years and above"
 msgstr ""
 
-msgid "Women 0 - 1 years"
+msgid "Female 0 - 1 years"
 msgstr ""
 
-msgid "Women 1 - 4 years"
+msgid "Female 1 - 4 years"
 msgstr ""
 
-msgid "Women 5 - 9 years"
+msgid "Female 5 - 9 years"
 msgstr ""
 
-msgid "Women 10 - 14 years"
+msgid "Female 10 - 14 years"
 msgstr ""
 
-msgid "Women 15 - 19 years"
+msgid "Female 15 - 19 years"
 msgstr ""
 
-msgid "Women 20 - 24 years"
+msgid "Female 20 - 24 years"
 msgstr ""
 
-msgid "Women 25 - 29 years"
+msgid "Female 25 - 29 years"
 msgstr ""
 
-msgid "Women 30 - 34 years"
+msgid "Female 30 - 34 years"
 msgstr ""
 
-msgid "Women 35 - 39 years"
+msgid "Female 35 - 39 years"
 msgstr ""
 
-msgid "Women 40 - 44 years"
+msgid "Female 40 - 44 years"
 msgstr ""
 
-msgid "Women 45 - 49 years"
+msgid "Female 45 - 49 years"
 msgstr ""
 
-msgid "Women 50 - 54 years"
+msgid "Female 50 - 54 years"
 msgstr ""
 
-msgid "Women 55 - 59 years"
+msgid "Female 55 - 59 years"
 msgstr ""
 
-msgid "Women 60 - 64 years"
+msgid "Female 60 - 64 years"
 msgstr ""
 
-msgid "Women 65 - 69 years"
+msgid "Female 65 - 69 years"
 msgstr ""
 
-msgid "Women 70 - 74 years"
+msgid "Female 70 - 74 years"
 msgstr ""
 
-msgid "Women 75 - 79 years"
+msgid "Female 75 - 79 years"
 msgstr ""
 
-msgid "Women 80 years and above"
+msgid "Female 80 years and above"
 msgstr ""
 
 msgid "Elevation"

--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -48,148 +48,148 @@ export const earthEngineLayers = () => [
         bands: [
             {
                 id: 'M_0',
-                name: i18n.t('Men 0 - 1 years'),
+                name: i18n.t('Male 0 - 1 years'),
             },
             {
                 id: 'M_1',
-                name: i18n.t('Men 1 - 4 years'),
+                name: i18n.t('Male 1 - 4 years'),
             },
             {
                 id: 'M_5',
-                name: i18n.t('Men 5 - 9 years'),
+                name: i18n.t('Male 5 - 9 years'),
             },
             {
                 id: 'M_10',
-                name: i18n.t('Men 10 - 14 years'),
+                name: i18n.t('Male 10 - 14 years'),
             },
             {
                 id: 'M_15',
-                name: i18n.t('Men 15 - 19 years'),
+                name: i18n.t('Male 15 - 19 years'),
             },
             {
                 id: 'M_20',
-                name: i18n.t('Men 20 - 24 years'),
+                name: i18n.t('Male 20 - 24 years'),
             },
             {
                 id: 'M_25',
-                name: i18n.t('Men 25 - 29 years'),
+                name: i18n.t('Male 25 - 29 years'),
             },
             {
                 id: 'M_30',
-                name: i18n.t('Men 30 - 34 years'),
+                name: i18n.t('Male 30 - 34 years'),
             },
             {
                 id: 'M_35',
-                name: i18n.t('Men 35 - 39 years'),
+                name: i18n.t('Male 35 - 39 years'),
             },
             {
                 id: 'M_40',
-                name: i18n.t('Men 40 - 44 years'),
+                name: i18n.t('Male 40 - 44 years'),
             },
             {
                 id: 'M_45',
-                name: i18n.t('Men 45 - 49 years'),
+                name: i18n.t('Male 45 - 49 years'),
             },
             {
                 id: 'M_50',
-                name: i18n.t('Men 50 - 54 years'),
+                name: i18n.t('Male 50 - 54 years'),
             },
             {
                 id: 'M_55',
-                name: i18n.t('Men 55 - 59 years'),
+                name: i18n.t('Male 55 - 59 years'),
             },
             {
                 id: 'M_60',
-                name: i18n.t('Men 60 - 64 years'),
+                name: i18n.t('Male 60 - 64 years'),
             },
             {
                 id: 'M_65',
-                name: i18n.t('Men 65 - 69 years'),
+                name: i18n.t('Male 65 - 69 years'),
             },
             {
                 id: 'M_70',
-                name: i18n.t('Men 70 - 74 years'),
+                name: i18n.t('Male 70 - 74 years'),
             },
             {
                 id: 'M_75',
-                name: i18n.t('Men 75 - 79 years'),
+                name: i18n.t('Male 75 - 79 years'),
             },
             {
                 id: 'M_80',
-                name: i18n.t('Men 80 years and above'),
+                name: i18n.t('Male 80 years and above'),
             },
             {
                 id: 'F_0',
-                name: i18n.t('Women 0 - 1 years'),
+                name: i18n.t('Female 0 - 1 years'),
             },
             {
                 id: 'F_1',
-                name: i18n.t('Women 1 - 4 years'),
+                name: i18n.t('Female 1 - 4 years'),
             },
             {
                 id: 'F_5',
-                name: i18n.t('Women 5 - 9 years'),
+                name: i18n.t('Female 5 - 9 years'),
             },
             {
                 id: 'F_10',
-                name: i18n.t('Women 10 - 14 years'),
+                name: i18n.t('Female 10 - 14 years'),
             },
             {
                 id: 'F_15',
-                name: i18n.t('Women 15 - 19 years'),
+                name: i18n.t('Female 15 - 19 years'),
             },
             {
                 id: 'F_20',
-                name: i18n.t('Women 20 - 24 years'),
+                name: i18n.t('Female 20 - 24 years'),
             },
             {
                 id: 'F_25',
-                name: i18n.t('Women 25 - 29 years'),
+                name: i18n.t('Female 25 - 29 years'),
             },
             {
                 id: 'F_30',
-                name: i18n.t('Women 30 - 34 years'),
+                name: i18n.t('Female 30 - 34 years'),
             },
             {
                 id: 'F_35',
-                name: i18n.t('Women 35 - 39 years'),
+                name: i18n.t('Female 35 - 39 years'),
             },
             {
                 id: 'F_40',
-                name: i18n.t('Women 40 - 44 years'),
+                name: i18n.t('Female 40 - 44 years'),
             },
             {
                 id: 'F_45',
-                name: i18n.t('Women 45 - 49 years'),
+                name: i18n.t('Female 45 - 49 years'),
             },
             {
                 id: 'F_50',
-                name: i18n.t('Women 50 - 54 years'),
+                name: i18n.t('Female 50 - 54 years'),
             },
             {
                 id: 'F_55',
-                name: i18n.t('Women 55 - 59 years'),
+                name: i18n.t('Female 55 - 59 years'),
             },
             {
                 id: 'F_60',
-                name: i18n.t('Women 60 - 64 years'),
+                name: i18n.t('Female 60 - 64 years'),
             },
             {
                 id: 'F_65',
-                name: i18n.t('Women 65 - 69 years'),
+                name: i18n.t('Female 65 - 69 years'),
             },
             {
                 id: 'F_70',
-                name: i18n.t('Women 70 - 74 years'),
+                name: i18n.t('Female 70 - 74 years'),
                 multiple: true,
             },
             {
                 id: 'F_75',
-                name: i18n.t('Women 75 - 79 years'),
+                name: i18n.t('Female 75 - 79 years'),
             },
             {
                 id: 'F_80',
-                name: i18n.t('Women 80 years and above'),
+                name: i18n.t('Female 80 years and above'),
             },
         ],
         filters: ({ id, name, year }) => [


### PR DESCRIPTION
This PR will use male/female instead of men/women for the population age group layer. Male/female is more commonly used as category options in DHIS2. 

After this PR: 
<img width="562" alt="Screenshot 2022-01-31 at 16 03 09" src="https://user-images.githubusercontent.com/548708/151817529-82f7243b-d432-4fc1-a814-aa074610cf16.png">
