### PR TITLE
fix: improved error handling for facility layers (DHIS2-12504)

### DIFF
--- a/src/loaders/facilityLoader.js
+++ b/src/loaders/facilityLoader.js
@@ -61,7 +61,7 @@ const facilityLoader = async config => {
         legend.explanation = [`${areaRadius} ${'m'} ${'buffer'}`];
     }
 
-    if (!styledFeatures.length) {
+    if (!styledFeatures.length && !alerts.length) {
         alerts.push({ warning: true, message: i18n.t('No facilities found') });
     }
 

--- a/src/util/orgUnits.js
+++ b/src/util/orgUnits.js
@@ -77,7 +77,7 @@ export const getOrgUnitGroupLegendItems = (
     );
 
 export const getStyledOrgUnits = (
-    features,
+    features = [],
     groupSet = {},
     { organisationUnitColor = ORG_UNIT_COLOR, radiusLow = ORG_UNIT_RADIUS },
     contextPath,


### PR DESCRIPTION
Fixes for facility layer: https://jira.dhis2.org/browse/DHIS2-12504

This PR avoids and infinitive loading spinner when the backend api reports an invalid org unit selection. 

After this PR we will show the error message from the backend and the user is able to change the layer settings: 

<img width="995" alt="Screenshot 2022-02-14 at 14 55 28" src="https://user-images.githubusercontent.com/548708/153877382-a8ca84d2-23bc-42dc-9ba7-e45e95b9c7b4.png">

Before this PR an infinite spinner was shown and it was not possible to change the layer settings: 

<img width="996" alt="Screenshot 2022-02-14 at 14 54 51" src="https://user-images.githubusercontent.com/548708/153877670-26a294c5-f2b3-42c1-bc3d-a2fed746f639.png">
