### PR TITLE
fix: polygon legend item (DHIS2-11969)

### DIFF
--- a/src/components/legend/LegendItem.js
+++ b/src/components/legend/LegendItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import LineSymbol from './LineSymbol';
-import OutlineSymbol from './OutlineSymbol';
+import PolygonSymbol from './PolygonSymbol';
 import LegendItemRange from './LegendItemRange';
 import styles from './styles/LegendItem.module.css';
 
@@ -12,6 +12,7 @@ const LegendItem = ({
     image,
     color,
     strokeColor,
+    fillColor,
     radius,
     weight,
     name,
@@ -47,7 +48,11 @@ const LegendItem = ({
                     type === 'LineString' ? (
                         <LineSymbol color={color} weight={weight} />
                     ) : (
-                        <OutlineSymbol color={color} weight={weight} />
+                        <PolygonSymbol
+                            color={strokeColor || color}
+                            fill={fillColor}
+                            weight={weight}
+                        />
                     )
                 ) : (
                     <span style={symbol} />
@@ -68,6 +73,7 @@ LegendItem.propTypes = {
     image: PropTypes.string,
     color: PropTypes.string,
     strokeColor: PropTypes.string,
+    fillColor: PropTypes.string,
     radius: PropTypes.number,
     weight: PropTypes.number,
     name: PropTypes.string,

--- a/src/components/legend/PolygonSymbol.js
+++ b/src/components/legend/PolygonSymbol.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const OutlineSymbol = ({ color, weight }) => (
+const PolygonSymbol = ({ color, fill = 'none', weight }) => (
     <svg viewBox="0 0 24 24" style={{ width: 24, height: 24 }}>
         <path
-            fill="none"
+            fill={fill}
             stroke={color}
             strokeWidth={weight}
             strokeLinecap="round"
@@ -14,9 +14,10 @@ const OutlineSymbol = ({ color, weight }) => (
     </svg>
 );
 
-OutlineSymbol.propTypes = {
+PolygonSymbol.propTypes = {
     color: PropTypes.string,
+    fill: PropTypes.string,
     weight: PropTypes.number,
 };
 
-export default OutlineSymbol;
+export default PolygonSymbol;


### PR DESCRIPTION
This PR will make it possible to show a filled polygon in the map legend. 

Partly fixes: https://jira.dhis2.org/browse/DHIS2-11969

The "OutlineSymbol" component has been renamed to "PolygonSymbol" and a new fill property was added. 

It is backward compatible so it still shows as a boundary outline for org unit layers: 
![Screenshot 2022-02-24 at 11 39 22](https://user-images.githubusercontent.com/548708/155509781-19839134-c168-425c-b693-f04f0ee94271.png)

It will allow us to apply a fill color for the upcoming catchement area support: 
![Screenshot 2022-02-24 at 11 40 32](https://user-images.githubusercontent.com/548708/155509848-1e5d8ee5-8f93-419c-bec7-20306b221ef0.png)
