### PR TITLE
fix: remove duplicate org units from data table (DHIS2-11969)

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -12,7 +12,7 @@ import EarthEngineColumns from './EarthEngineColumns';
 import { setOrgUnitProfile } from '../../actions/orgUnits';
 import { highlightFeature } from '../../actions/feature';
 import { loadLayer } from '../../actions/layers';
-import { filterData } from '../../util/filter';
+import { filterData, removeDuplicateIds } from '../../util/filter';
 import { formatTime } from '../../util/helpers';
 import {
     EVENT_LAYER,
@@ -110,7 +110,7 @@ class DataTable extends Component {
 
     // TODO: Make sure sorting works across different locales - use lib method
     sort(data, sortBy, sortDirection) {
-        return data.sort((a, b) => {
+        return removeDuplicateIds(data).sort((a, b) => {
             a = a[sortBy];
             b = b[sortBy];
 

--- a/src/util/filter.js
+++ b/src/util/filter.js
@@ -31,6 +31,11 @@ export const stringFilter = (string, filter) => {
     return ('' + string).toLowerCase().includes(filter.toLowerCase());
 };
 
+// Only keep the last feature with the same id
+// Used for data table when having associated geometries
+export const removeDuplicateIds = data =>
+    data.filter((d, i) => i > data.findIndex(f => f.id === d.id && f !== d));
+
 // Numeric filter supporting AND, OR, GREATER THAN, LESS THAN or equal number
 export const numericFilter = (value, filter) => {
     // TODO: Syntax error handling


### PR DESCRIPTION
This PR will make sure that an org unit only is displayed once in the data table. 

Partly fixes: https://jira.dhis2.org/browse/DHIS2-11969

When we introduce catchment areas we the same org unit will be represented by to features - one having the original org unit geometry, and the other having an associated geometry (catchment area, polygon). 

Do avoid duplicate rows in the data table (except the geometry) we will only show one of the features. When the user is hovering an org unit in the data table - we will highlight both features in the map through https://github.com/dhis2/maps-gl/pull/447

With this PR org units will not be duplicated in the data table: 
![Screenshot 2022-02-24 at 12 40 14](https://user-images.githubusercontent.com/548708/155517900-bc042c3d-c641-488c-8684-e84dd49fae4f.png)

Without this fix org units would show like this: 
![Screenshot 2022-02-24 at 12 42 51](https://user-images.githubusercontent.com/548708/155518009-725eee8d-2c9a-450f-b118-3a5ece2cfd95.png)