### PR TITLE
fix: catchment areas fixes (DHIS2-11969)

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -12,7 +12,7 @@ import EarthEngineColumns from './EarthEngineColumns';
 import { setOrgUnitProfile } from '../../actions/orgUnits';
 import { highlightFeature } from '../../actions/feature';
 import { loadLayer } from '../../actions/layers';
-import { filterData, removeDuplicateIds } from '../../util/filter';
+import { filterData } from '../../util/filter';
 import { formatTime } from '../../util/helpers';
 import {
     EVENT_LAYER,
@@ -96,7 +96,9 @@ class DataTable extends Component {
     filter() {
         const { layer, aggregations = {} } = this.props;
         const { dataFilters } = layer;
-        const data = layer.data;
+        const data = layer.data.filter(
+            d => !d.properties.hasAdditionalGeometry
+        );
 
         return filterData(
             data.map((d, index) => ({
@@ -110,7 +112,7 @@ class DataTable extends Component {
 
     // TODO: Make sure sorting works across different locales - use lib method
     sort(data, sortBy, sortDirection) {
-        return removeDuplicateIds(data).sort((a, b) => {
+        return data.sort((a, b) => {
             a = a[sortBy];
             b = b[sortBy];
 

--- a/src/components/edit/FacilityDialog.js
+++ b/src/components/edit/FacilityDialog.js
@@ -19,6 +19,7 @@ import {
     STYLE_TYPE_SYMBOL,
     MIN_RADIUS,
     MAX_RADIUS,
+    NONE,
 } from '../../constants/layers';
 import styles from './styles/LayerDialog.module.css';
 
@@ -134,7 +135,7 @@ class FacilityDialog extends Component {
         const selectedUserOrgUnits = getUserOrgUnitsFromRows(rows);
         const hasUserOrgUnits = !!selectedUserOrgUnits.length;
         const hasGeometryAttribute =
-            geometryAttribute && geometryAttribute.id !== 'none';
+            geometryAttribute && geometryAttribute.id !== NONE;
 
         return (
             <div data-test="facilitydialog">

--- a/src/components/orgunits/OrgUnitGeometryAttributeSelect.js
+++ b/src/components/orgunits/OrgUnitGeometryAttributeSelect.js
@@ -5,6 +5,7 @@ import i18n from '@dhis2/d2-i18n';
 import { SelectField } from '../core';
 import { fetchOrgUnitGeometryAttributes } from '../../util/orgUnits';
 import { setOrganisationUnitGeometryAttribute } from '../../actions/layerEdit';
+import { NONE } from '../../constants/layers';
 
 export const OrgUnitGeometryAttributeSelect = ({
     geometryAttribute,
@@ -23,7 +24,7 @@ export const OrgUnitGeometryAttributeSelect = ({
     return (
         <SelectField
             label={i18n.t('Use associated geometry')}
-            items={[{ id: 'none', name: i18n.t('None') }, ...attributes]}
+            items={[{ id: NONE, name: i18n.t('None') }, ...attributes]}
             value={geometryAttribute ? geometryAttribute.id : null}
             onChange={setOrganisationUnitGeometryAttribute}
             data-test="orgunitgeometryattributeselect"

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -7,7 +7,7 @@ import { getOrgUnitsFromRows } from '../util/analytics';
 import { getDisplayProperty } from '../util/helpers';
 import { numberPrecision } from '../util/numbers';
 import { toGeoJson } from '../util/map';
-import { getCoordinateField } from '../util/orgUnits';
+import { getCoordinateField, setAdditionalGeometry } from '../util/orgUnits';
 
 // Returns a promise
 const earthEngineLoader = async config => {
@@ -39,6 +39,7 @@ const earthEngineLoader = async config => {
                     .then(toGeoJson);
 
                 features = features.concat(associatedGeometries);
+                setAdditionalGeometry(features);
             }
         } catch (error) {
             alerts = [

--- a/src/loaders/orgUnitLoader.js
+++ b/src/loaders/orgUnitLoader.js
@@ -1,7 +1,7 @@
 import i18n from '@dhis2/d2-i18n';
 import { getInstance as getD2 } from 'd2';
 import { toGeoJson } from '../util/map';
-import { fetchOrgUnitGroupSet } from '../util/orgUnits';
+import { fetchOrgUnitGroupSet, setAdditionalGeometry } from '../util/orgUnits';
 import { getOrgUnitsFromRows } from '../util/analytics';
 import { getDisplayProperty } from '../util/helpers';
 import {
@@ -59,6 +59,8 @@ const orgUnitLoader = async config => {
     }
 
     features = mainFeatures.concat(associatedGeometries);
+
+    setAdditionalGeometry(features);
 
     const { styledFeatures, legend } = getStyledOrgUnits(
         features,

--- a/src/reducers/layerEdit.js
+++ b/src/reducers/layerEdit.js
@@ -17,6 +17,7 @@ import {
     CLASSIFICATION_EQUAL_COUNTS,
     CLASSIFICATION_PREDEFINED,
     THEMATIC_CHOROPLETH,
+    NONE,
 } from '../constants/layers';
 import { START_END_DATES } from '../constants/periods';
 
@@ -422,7 +423,7 @@ const layerEdit = (state = null, action) => {
             return {
                 ...state,
                 geometryAttribute: action.geometryAttribute,
-                ...(action.geometryAttribute !== 'none' && {
+                ...(action.geometryAttribute !== NONE && {
                     areaRadius: null,
                 }),
             };

--- a/src/util/filter.js
+++ b/src/util/filter.js
@@ -31,11 +31,6 @@ export const stringFilter = (string, filter) => {
     return ('' + string).toLowerCase().includes(filter.toLowerCase());
 };
 
-// Only keep the last feature with the same id
-// Used for data table when having associated geometries
-export const removeDuplicateIds = data =>
-    data.filter((d, i) => i > data.findIndex(f => f.id === d.id && f !== d));
-
 // Numeric filter supporting AND, OR, GREATER THAN, LESS THAN or equal number
 export const numericFilter = (value, filter) => {
     // TODO: Syntax error handling

--- a/src/util/orgUnits.js
+++ b/src/util/orgUnits.js
@@ -7,6 +7,7 @@ import { qualitativeColors } from '../constants/colors';
 import {
     ORG_UNIT_COLOR,
     ORG_UNIT_RADIUS,
+    ORG_UNIT_RADIUS_SMALL,
     STYLE_TYPE_COLOR,
     STYLE_TYPE_SYMBOL,
     NONE,
@@ -117,24 +118,24 @@ export const getStyledOrgUnits = (
 
     let styledFeatures = features.map(f => {
         const isPoint = f.geometry.type === 'Point';
-        const hasAssociatedGeometry =
-            isPoint &&
-            !!features.find(
-                ({ id, geometry }) => id === f.id && geometry.type !== 'Point'
-            );
-
+        const { hasAdditionalGeometry } = f.properties;
         const { color, symbol } = getOrgUnitStyle(
             f.properties.dimensions,
             groupSet
         );
-        const radius = isPoint ? radiusLow : undefined;
+        let radius;
+
+        if (isPoint) {
+            radius = hasAdditionalGeometry ? ORG_UNIT_RADIUS_SMALL : radiusLow;
+        }
+
         const properties = {
             ...f.properties,
             radius,
         };
 
         if (useColor && color) {
-            properties.color = hasAssociatedGeometry ? ORG_UNIT_COLOR : color;
+            properties.color = hasAdditionalGeometry ? ORG_UNIT_COLOR : color;
         } else if (symbol) {
             properties.iconUrl = `${contextPath}/images/orgunitgroup/${symbol}`;
         }


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-11969

This PR contains some code improvements:
- Org units having additional geometry (catchment area) are marked, and this property is used to exclude them from the data table. 
- 'none' is now a constant. 
- Facilities having additional geometry displayed get a smaller radius for the point showing the location (ORG_UNIT_RADIUS_SMALL). 