### PR TITLE
fix: store geometry attribute as orgUnitField

### DIFF
--- a/src/actions/layerEdit.js
+++ b/src/actions/layerEdit.js
@@ -174,9 +174,9 @@ export const setOrganisationUnitColor = color => ({
     color,
 });
 
-export const setOrganisationUnitGeometryAttribute = geometryAttribute => ({
+export const setOrganisationUnitGeometryAttribute = payload => ({
     type: types.LAYER_EDIT_ORGANISATION_UNIT_GEOMETRY_ATTRIBUTE_SET,
-    geometryAttribute,
+    payload,
 });
 
 // Set period label (earth engine)

--- a/src/components/edit/FacilityDialog.js
+++ b/src/components/edit/FacilityDialog.js
@@ -50,7 +50,7 @@ class FacilityDialog extends Component {
         radiusLow: PropTypes.number,
         organisationUnitColor: PropTypes.string,
         organisationUnitGroupSet: PropTypes.object,
-        geometryAttribute: PropTypes.shape({
+        orgUnitField: PropTypes.shape({
             id: PropTypes.string.isRequired,
         }),
         setOrgUnitLevels: PropTypes.func.isRequired,
@@ -120,7 +120,7 @@ class FacilityDialog extends Component {
             radiusLow,
             organisationUnitColor,
             organisationUnitGroupSet,
-            geometryAttribute,
+            orgUnitField,
             setOrgUnitLevels,
             setOrgUnitGroups,
             setUserOrgUnits,
@@ -134,8 +134,7 @@ class FacilityDialog extends Component {
         const orgUnits = getOrgUnitsFromRows(rows);
         const selectedUserOrgUnits = getUserOrgUnitsFromRows(rows);
         const hasUserOrgUnits = !!selectedUserOrgUnits.length;
-        const hasGeometryAttribute =
-            geometryAttribute && geometryAttribute.id !== NONE;
+        const hasGeometryAttribute = orgUnitField && orgUnitField.id !== NONE;
 
         return (
             <div data-test="facilitydialog">

--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -35,7 +35,7 @@ const EarthEngineDialog = props => {
         params,
         filter,
         areaRadius,
-        geometryAttribute,
+        orgUnitField,
         setFilter,
         setOrgUnitLevels,
         setBufferRadius,
@@ -220,7 +220,7 @@ const EarthEngineDialog = props => {
                     <StyleTab
                         unit={unit}
                         params={params}
-                        geometryAttribute={geometryAttribute}
+                        geometryAttribute={orgUnitField}
                     />
                 )}
             </div>
@@ -239,7 +239,7 @@ EarthEngineDialog.propTypes = {
         palette: PropTypes.string.isRequired,
     }),
     areaRadius: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    geometryAttribute: PropTypes.shape({
+    orgUnitField: PropTypes.shape({
         id: PropTypes.string.isRequired,
     }),
     legend: PropTypes.object,

--- a/src/components/map/layers/FacilityLayer.js
+++ b/src/components/map/layers/FacilityLayer.js
@@ -27,7 +27,7 @@ class FacilityLayer extends Layer {
             dataFilters,
             labels,
             areaRadius,
-            geometryAttribute,
+            orgUnitField,
             associatedGeometries,
             organisationUnitColor: color = ORG_UNIT_COLOR,
             organisationUnitGroupSet,
@@ -79,7 +79,7 @@ class FacilityLayer extends Layer {
             group.addLayer({
                 type: GEOJSON_LAYER,
                 data: associatedGeometries,
-                hoverLabel: `{name}: ${geometryAttribute.name}`,
+                hoverLabel: `{name}: ${orgUnitField.name}`,
                 style: {
                     color: 'rgb(149, 200, 251)',
                     opacityFactor: 0.5,
@@ -101,7 +101,7 @@ class FacilityLayer extends Layer {
     getPopup() {
         const { coordinates, feature } = this.state.popup;
         const { id, name, dimensions, pn } = feature.properties;
-        const { geometryAttribute } = this.props;
+        const { orgUnitField } = this.props;
 
         return (
             <Popup
@@ -112,7 +112,7 @@ class FacilityLayer extends Layer {
             >
                 <em>{name}</em>
                 {this.state.isAssociatedGeometry && (
-                    <div>{geometryAttribute.name}</div>
+                    <div>{orgUnitField.name}</div>
                 )}
                 {isPlainObject(dimensions) && (
                     <div>

--- a/src/components/orgunits/OrgUnitGeometryAttributeSelect.js
+++ b/src/components/orgunits/OrgUnitGeometryAttributeSelect.js
@@ -41,7 +41,7 @@ OrgUnitGeometryAttributeSelect.propTypes = {
 
 export default connect(
     ({ layerEdit }) => ({
-        geometryAttribute: layerEdit.geometryAttribute,
+        geometryAttribute: layerEdit.orgUnitField,
     }),
     { setOrganisationUnitGeometryAttribute }
 )(OrgUnitGeometryAttributeSelect);

--- a/src/reducers/layerEdit.js
+++ b/src/reducers/layerEdit.js
@@ -422,8 +422,8 @@ const layerEdit = (state = null, action) => {
         case types.LAYER_EDIT_ORGANISATION_UNIT_GEOMETRY_ATTRIBUTE_SET:
             return {
                 ...state,
-                geometryAttribute: action.geometryAttribute,
-                ...(action.geometryAttribute !== NONE && {
+                orgUnitField: action.payload,
+                ...(action.payload !== NONE && {
                     areaRadius: null,
                 }),
             };

--- a/src/util/favorites.js
+++ b/src/util/favorites.js
@@ -54,6 +54,7 @@ const validLayerProperties = [
     'organisationUnitColor',
     'organisationUnitGroupSet',
     'organisationUnitSelectionMode',
+    'orgUnitField',
     'params',
     'periodName',
     'periodType',

--- a/src/util/orgUnits.js
+++ b/src/util/orgUnits.js
@@ -213,10 +213,8 @@ export const fetchFacilityConfigurations = async () => {
 };
 
 // Returns coordinate field from layer config
-export const getCoordinateField = ({ geometryAttribute }) =>
-    geometryAttribute && geometryAttribute.id !== NONE
-        ? geometryAttribute
-        : null;
+export const getCoordinateField = ({ orgUnitField }) =>
+    orgUnitField && orgUnitField.id !== NONE ? orgUnitField : null;
 
 // Set hasAddiditionalGeometry property if exist
 export const setAdditionalGeometry = features =>


### PR DESCRIPTION
This PR will allow maps showing catchment areas to be saved and added to the dashboard. 

The PR depends on https://github.com/dhis2/dhis2-core/pull/9934

The mapView parameter will be named `orgUnitField` which required some changes in our code to support it. 