### PR TITLE
fix: switch back to default image tiles basemap

### DIFF
--- a/src/constants/basemaps.js
+++ b/src/constants/basemaps.js
@@ -1,10 +1,5 @@
 import i18n from '@dhis2/d2-i18n';
-import {
-    VECTOR_STYLE,
-    TILE_LAYER,
-    GOOGLE_LAYER,
-    BING_LAYER,
-} from '../constants/layers';
+import { TILE_LAYER, GOOGLE_LAYER, BING_LAYER } from '../constants/layers';
 
 export const FALLBACK_BASEMAP_ID = 'osmLight';
 
@@ -18,9 +13,9 @@ export const defaultBasemaps = () => [
         name: i18n.t('OSM Light'),
         img: 'images/osmlight.png',
         config: {
-            type: VECTOR_STYLE,
-            url: '//basemaps.cartocdn.com/gl/positron-gl-style/style.json',
-            // beforeId: 'watername_ocean', //TODO - this may become a configurable property
+            type: 'tileLayer',
+            url:
+                '//cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
             attribution:
                 '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
         },

--- a/src/constants/basemaps.js
+++ b/src/constants/basemaps.js
@@ -13,7 +13,7 @@ export const defaultBasemaps = () => [
         name: i18n.t('OSM Light'),
         img: 'images/osmlight.png',
         config: {
-            type: 'tileLayer',
+            type: TILE_LAYER,
             url:
                 '//cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
             attribution:


### PR DESCRIPTION
This PR will switch back to the OSM Light basemap using image tiles. We will only support vector tiles as external layer in this release. There are not enough benefits for the switch, and less performant when we need to redraw all map layers if the user is switching to/from a vector style. 

With this PR the default basemap is OSM Light image tiles: 

<img width="1069" alt="Screenshot 2022-03-07 at 19 55 06" src="https://user-images.githubusercontent.com/548708/157099384-ddb6c3fc-406a-4c71-9548-cc4704b7efe9.png">
