### PR TITLE
fix: disable data table if no org units are selected (DHIS2-12800)

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -193,7 +193,8 @@ class DataTable extends Component {
         const isOrgUnit = layerType === ORG_UNIT_LAYER;
         const isEvent = layerType === EVENT_LAYER;
         const isEarthEngine = layerType === EARTH_ENGINE_LAYER;
-        const isLoading = isEarthEngine && aggregationType && !aggregations;
+        const isLoading =
+            isEarthEngine && aggregationType?.length && !aggregations;
 
         return !serverCluster ? (
             <>

--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -25,7 +25,8 @@ export const LayerToolbarMoreMenu = ({
     openAs,
     downloadData,
     dataTableOpen,
-    downloadDisabled,
+    hasOrgUnitData,
+    isLoading,
 }) => {
     const [isOpen, setIsOpen] = useState(false);
     const anchorRef = useRef();
@@ -76,6 +77,7 @@ export const LayerToolbarMoreMenu = ({
                                         setIsOpen(false);
                                         toggleDataTable();
                                     }}
+                                    disabled={!hasOrgUnitData}
                                 />
                             )}
                             {openAs && (
@@ -96,7 +98,7 @@ export const LayerToolbarMoreMenu = ({
                                         setIsOpen(false);
                                         downloadData();
                                     }}
-                                    disabled={downloadDisabled}
+                                    disabled={!hasOrgUnitData || isLoading}
                                 />
                             )}
                             {showDivider && <Divider />}
@@ -137,13 +139,19 @@ LayerToolbarMoreMenu.propTypes = {
     openAs: PropTypes.func,
     downloadData: PropTypes.func,
     dataTableOpen: PropTypes.string,
-    downloadDisabled: PropTypes.bool,
+    hasOrgUnitData: PropTypes.bool,
+    hasAggregations: PropTypes.bool,
+    isLoading: PropTypes.bool,
 };
 
-export default connect(({ dataTable, aggregations }, { layer }) => ({
-    dataTableOpen: dataTable,
-    // Disable EE download if no org units or no aggregations are available
-    downloadDisabled:
-        layer?.layer === 'earthEngine' &&
-        (!layer.data || !aggregations[layer.id]),
-}))(LayerToolbarMoreMenu);
+export default connect(
+    ({ dataTable: dataTableOpen, aggregations }, { layer = {} }) => {
+        const hasOrgUnitData = !!layer.data;
+        const isLoading =
+            hasOrgUnitData &&
+            layer.aggregationType?.length > 0 &&
+            !aggregations[layer.id];
+
+        return { dataTableOpen, hasOrgUnitData, isLoading };
+    }
+)(LayerToolbarMoreMenu);

--- a/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbarMoreMenu.spec.js.snap
+++ b/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbarMoreMenu.spec.js.snap
@@ -37,12 +37,14 @@ exports[`LayerToolbarMoreMenu Should match snapshot 1`] = `
       >
         <MenuItem
           dataTest="dhis2-uicore-menuitem"
+          disabled={true}
           icon={<SvgTable16 />}
           label="Hide data table"
           onClick={[Function]}
         />
         <MenuItem
           dataTest="dhis2-uicore-menuitem"
+          disabled={true}
           icon={<SvgDownload16 />}
           label="Download data"
           onClick={[Function]}


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12800

This PR will disable data table and download options from the layer menu if no org units are selected. The download data option will only be enabled if the layer is finished loading. 

After this PR if no org units are selected for an EE layer: 
![Screenshot 2022-03-11 at 10 28 29](https://user-images.githubusercontent.com/548708/157840014-a35f3fd3-35e7-4170-9d84-2ac4a674daaf.png)

