### PR TITLE
fix: remove unused event statuses

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-03-01T16:07:11.327Z\n"
-"PO-Revision-Date: 2022-03-01T16:07:11.327Z\n"
+"POT-Creation-Date: 2022-03-11T20:46:39.429Z\n"
+"PO-Revision-Date: 2022-03-11T20:46:39.429Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -1169,15 +1169,6 @@ msgid "Active"
 msgstr ""
 
 msgid "Completed"
-msgstr ""
-
-msgid "Schedule"
-msgstr ""
-
-msgid "Overdue"
-msgstr ""
-
-msgid "Skipped"
 msgstr ""
 
 msgid "Choropleth"

--- a/src/constants/eventStatuses.js
+++ b/src/constants/eventStatuses.js
@@ -13,16 +13,4 @@ export const getEventStatuses = () => [
         id: 'COMPLETED',
         name: i18n.t('Completed'),
     },
-    {
-        id: 'SCHEDULE',
-        name: i18n.t('Schedule'),
-    },
-    {
-        id: 'OVERDUE',
-        name: i18n.t('Overdue'),
-    },
-    {
-        id: 'SKIPPED',
-        name: i18n.t('Skipped'),
-    },
 ];


### PR DESCRIPTION
This PR will remove event statuses that are not supported in analytics tables:
- Schedule
- Overdue
- Skipped

After this PR:
<img width="364" alt="Screenshot 2022-03-11 at 21 52 17" src="https://user-images.githubusercontent.com/548708/157963080-da11623c-5232-4b9d-bc00-aa98f5ce6868.png">
