### PR TITLE
fix: filter out invalid geojson

### DIFF
--- a/src/util/map.js
+++ b/src/util/map.js
@@ -65,7 +65,8 @@ export const toGeoJson = organisationUnits =>
         .filter(
             ({ geometry }) =>
                 Array.isArray(geometry.coordinates) &&
-                geometry.coordinates.length
+                geometry.coordinates.length &&
+                geometry.coordinates.flat().length
         );
 
 export const drillUpDown = (layerConfig, parentId, parentGraph, level) => ({


### PR DESCRIPTION
This PR will filter out GeoJSON polygons that have no coordinates `[[]]`. 

After this PR no error shows when selecting catchment areas in Kailahun:
<img width="896" alt="Screenshot 2022-03-11 at 22 31 48" src="https://user-images.githubusercontent.com/548708/157973293-3b6fe1ef-8cfb-4f5f-877d-ab91d52bb45a.png">
