### PR TITLE
fix: allow popups for buildings layer while showing an error

### DIFF
--- a/cypress/elements/layer.js
+++ b/cypress/elements/layer.js
@@ -24,6 +24,7 @@ export class Layer {
     selectOu(ouName) {
         cy.get('.tree-view.orgunit')
             .contains(ouName)
+            .scrollIntoView()
             .click();
 
         return this;

--- a/cypress/integration/layers/orgunitlayer.cy.js
+++ b/cypress/integration/layers/orgunitlayer.cy.js
@@ -12,7 +12,9 @@ context('Org Unit Layers', () => {
 
         Layer.validateDialogClosed(false);
 
-        cy.contains('No organisation units are selected').should('be.visible');
+        cy.contains('No organisation units are selected')
+            .scrollIntoView()
+            .should('be.visible');
     });
 
     it('adds a org unit layer', () => {

--- a/src/components/map/layers/earthEngine/EarthEngineLayer.js
+++ b/src/components/map/layers/earthEngine/EarthEngineLayer.js
@@ -203,6 +203,7 @@ export default class EarthEngineLayer extends Layer {
         const { legend, aggregationType } = this.props;
         const { isLoading, popup, aggregations, error } = this.state;
 
+        /*
         if (error) {
             return (
                 <Alert
@@ -225,6 +226,28 @@ export default class EarthEngineLayer extends Layer {
                 {...popup}
             />
         ) : null;
+        */
+
+        return (
+            <>
+                {isLoading && <MapLoadingMask />}
+                {error && (
+                    <Alert
+                        message={error}
+                        onHidden={() => this.setState({ error: null })}
+                    />
+                )}
+                {popup && (
+                    <EarthEnginePopup
+                        data={aggregations || {}}
+                        legend={legend}
+                        valueType={aggregationType}
+                        onClose={this.onPopupClose}
+                        {...popup}
+                    />
+                )}
+            </>
+        );
     }
 
     onFeatureClick(evt) {
@@ -247,6 +270,10 @@ export default class EarthEngineLayer extends Layer {
             message = this.props.error;
         }
 
-        this.setState({ error: message, isLoading: false });
+        this.setState({
+            error: message,
+            isLoading: false,
+            aggregations: 'error',
+        });
     }
 }

--- a/src/components/map/layers/earthEngine/EarthEngineLayer.js
+++ b/src/components/map/layers/earthEngine/EarthEngineLayer.js
@@ -203,31 +203,6 @@ export default class EarthEngineLayer extends Layer {
         const { legend, aggregationType } = this.props;
         const { isLoading, popup, aggregations, error } = this.state;
 
-        /*
-        if (error) {
-            return (
-                <Alert
-                    message={error}
-                    onHidden={() => this.setState({ error: null })}
-                />
-            );
-        }
-
-        if (isLoading) {
-            return <MapLoadingMask />;
-        }
-
-        return popup ? (
-            <EarthEnginePopup
-                data={aggregations || {}}
-                legend={legend}
-                valueType={aggregationType}
-                onClose={this.onPopupClose}
-                {...popup}
-            />
-        ) : null;
-        */
-
         return (
             <>
                 {isLoading && <MapLoadingMask />}


### PR DESCRIPTION
This PR fixes two issues for the new buildings layer:
1. While we show an error from the Earth Engine API the map can still be clicked. 
2. The popup loading spinner is removed if we get an error, as data will never arrive. 

After this PR: 
![buildings-error](https://user-images.githubusercontent.com/548708/158017075-49b5aeac-4dcf-4359-9a21-cfddf6e8043d.gif)

