### PR TITLE
fix: show warning if no catchment areas for thematic layer

### DIFF
--- a/cypress/elements/layer.js
+++ b/cypress/elements/layer.js
@@ -24,6 +24,7 @@ export class Layer {
     selectOu(ouName) {
         cy.get('.tree-view.orgunit')
             .contains(ouName)
+            .scrollIntoView()
             .click();
 
         return this;

--- a/cypress/integration/layers/orgunitlayer.cy.js
+++ b/cypress/integration/layers/orgunitlayer.cy.js
@@ -12,7 +12,9 @@ context('Org Unit Layers', () => {
 
         Layer.validateDialogClosed(false);
 
-        cy.contains('No organisation units are selected').should('be.visible');
+        cy.contains('No organisation units are selected')
+            .scrollIntoView()
+            .should('be.visible');
     });
 
     it('adds a org unit layer', () => {

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -45,6 +45,7 @@ const thematicLoader = async config => {
     } = config;
 
     const dataItem = getDataItemFromColumns(columns);
+    const coordinateField = getCoordinateField(config);
 
     let error;
 
@@ -91,6 +92,7 @@ const thematicLoader = async config => {
     let minValue = orderedValues[0];
     let maxValue = orderedValues[orderedValues.length - 1];
     const name = names[dataItem.id];
+    const alerts = [];
 
     let legendSet = config.legendSet;
 
@@ -105,7 +107,6 @@ const thematicLoader = async config => {
     }
 
     let method = legendSet ? CLASSIFICATION_PREDEFINED : config.method; // Favorites often have wrong method
-    let alert;
 
     if (legendSet) {
         legendSet = await loadLegendSet(legendSet);
@@ -172,18 +173,28 @@ const thematicLoader = async config => {
         setAdditionalGeometry(valueFeatures);
     } else {
         if (!features.length) {
-            alert = {
+            alerts.push({
                 warning: true,
                 message: i18n.t('Selected org units: No coordinates found', {
                     nsSeparator: ';',
                 }),
-            };
+            });
         } else {
-            alert = {
+            alerts.push({
                 warning: true,
                 message: `${name}: ${i18n.t('No data found')}`,
-            };
+            });
         }
+    }
+
+    if (coordinateField && !associatedGeometries.length) {
+        alerts.push({
+            warning: true,
+            message: i18n.t('{{name}}: No coordinates found', {
+                name: coordinateField.name,
+                nsSeparator: ';',
+            }),
+        });
     }
 
     if (valuesByPeriod) {
@@ -245,7 +256,7 @@ const thematicLoader = async config => {
         name,
         legend,
         method,
-        alerts: alert ? [alert] : undefined,
+        alerts,
         isLoaded: true,
         isExpanded: true,
         isVisible: true,


### PR DESCRIPTION
With this PR we will show a warning if the user has selected to show "assoicated geometries", but there are no geometries found for selected org units. We also allow multiple warnings to be shown at the same time. 

![Screenshot 2022-03-12 at 13 42 23](https://user-images.githubusercontent.com/548708/158018394-0ff6dc34-da2e-4454-bc1f-010182948e90.png)

