### PR TITLE
fix: show explanation when buffer is disabled

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-03-01T16:07:11.327Z\n"
-"PO-Revision-Date: 2022-03-01T16:07:11.327Z\n"
+"POT-Creation-Date: 2022-03-12T16:34:26.614Z\n"
+"PO-Revision-Date: 2022-03-12T16:34:26.614Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -304,6 +304,9 @@ msgid "Buffer"
 msgstr ""
 
 msgid "Radius in meters"
+msgstr ""
+
+msgid "Buffer can't be combined with associated geometry."
 msgstr ""
 
 msgid "Labels"

--- a/src/components/edit/FacilityDialog.js
+++ b/src/components/edit/FacilityDialog.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import i18n from '@dhis2/d2-i18n';
-import cx from 'classnames';
 import { Tab, Tabs, NumberField, ColorPicker } from '../core';
 import OrgUnitTree from '../orgunits/OrgUnitTree';
 import OrgUnitGroupSelect from '../orgunits/OrgUnitGroupSelect';
@@ -186,11 +185,11 @@ class FacilityDialog extends Component {
                             className={styles.flexColumnFlow}
                             data-test="facilitydialog-styletab"
                         >
-                            <div className={cx(styles.flexColumn)}>
+                            <div className={styles.flexColumn}>
                                 <Labels />
                                 <BufferRadius
                                     defaultRadius={FACILITY_BUFFER}
-                                    disabled={hasOrgUnitField}
+                                    hasOrgUnitField={hasOrgUnitField}
                                 />
                             </div>
                             <div className={styles.flexColumn}>

--- a/src/components/edit/earthEngine/StyleTab.js
+++ b/src/components/edit/earthEngine/StyleTab.js
@@ -12,7 +12,7 @@ const StyleTab = ({ unit, params, hasOrgUnitField }) => (
             {params && <StyleSelect unit={unit} params={params} />}
             <BufferRadius
                 defaultRadius={EE_BUFFER}
-                disabled={hasOrgUnitField}
+                hasOrgUnitField={hasOrgUnitField}
             />
         </div>
         {params && <LegendPreview params={params} />}

--- a/src/components/edit/shared/BufferRadius.js
+++ b/src/components/edit/shared/BufferRadius.js
@@ -16,18 +16,20 @@ import styles from './styles/BufferRadius.module.css';
 const BufferRadius = ({
     radius,
     defaultRadius = 1000,
+    hasOrgUnitField,
     disabled,
     className,
     setBufferRadius,
 }) => {
     const showBuffer = radius !== undefined && radius !== null;
+    const isDisabled = disabled || hasOrgUnitField;
 
     return (
         <div className={cx(styles.buffer, className)}>
             <Checkbox
                 label={i18n.t('Buffer')}
                 checked={showBuffer}
-                disabled={disabled}
+                disabled={isDisabled}
                 onChange={isChecked =>
                     setBufferRadius(isChecked ? radius || defaultRadius : null)
                 }
@@ -36,13 +38,20 @@ const BufferRadius = ({
                 <NumberField
                     label={i18n.t('Radius in meters')}
                     value={Number.isInteger(radius) ? radius : ''}
-                    disabled={disabled}
+                    disabled={isDisabled}
                     onChange={value =>
                         setBufferRadius(value !== '' ? parseInt(value, 10) : '')
                     }
                     min={0}
                     className={styles.numberField}
                 />
+            )}
+            {hasOrgUnitField && (
+                <div className={styles.info}>
+                    {i18n.t(
+                        "Buffer can't be combined with associated geometry."
+                    )}
+                </div>
             )}
         </div>
     );
@@ -51,6 +60,7 @@ const BufferRadius = ({
 BufferRadius.propTypes = {
     radius: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     defaultRadius: PropTypes.number,
+    hasOrgUnitField: PropTypes.bool,
     disabled: PropTypes.bool,
     className: PropTypes.string,
     setBufferRadius: PropTypes.func.isRequired,

--- a/src/components/edit/shared/styles/BufferRadius.module.css
+++ b/src/components/edit/shared/styles/BufferRadius.module.css
@@ -12,3 +12,10 @@
 .numberField {
     padding-left: 23px;
 }
+
+.info {
+    padding-left: 23px;
+    line-height: 20px;
+    color: rgb(110, 122, 138);
+    font-style: italic;
+}


### PR DESCRIPTION
With this PR we will show an explanation when buffer is disabled due to associated geometry:

![Screenshot 2022-03-12 at 17 33 53](https://user-images.githubusercontent.com/548708/158026531-fc57756d-b43c-4478-a692-5626ce40bd28.png)

![Screenshot 2022-03-12 at 17 34 10](https://user-images.githubusercontent.com/548708/158026558-8e250bdf-63bc-4219-942c-320d90b41da5.png)


