### PR TITLE
fix: error format for earth engine layers

### DIFF
--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -63,15 +63,13 @@ const earthEngineLoader = async config => {
                 });
             }
         } catch (error) {
-            alerts.push([
-                {
-                    critical: true,
-                    message: i18n.t('Error: {{message}}', {
-                        message: error.message,
-                        nsSeparator: ';',
-                    }),
-                },
-            ]);
+            alerts.push({
+                critical: true,
+                message: i18n.t('Error: {{message}}', {
+                    message: error.message,
+                    nsSeparator: ';',
+                }),
+            });
         }
     }
 


### PR DESCRIPTION
This PR will fix the error format for earth engine layers. The error should not be wrapped in array brackets. 

After this PR the error will show: 

<img width="568" alt="Screenshot 2022-03-12 at 18 33 12" src="https://user-images.githubusercontent.com/548708/158028437-33c8eb83-dc1a-4b05-84ba-1b4faae6aac4.png">

Before: 
<img width="402" alt="Screenshot 2022-03-11 at 12 16 47" src="https://user-images.githubusercontent.com/548708/158028501-3bc6bf84-f3fa-40f8-aba9-6a2b3f109012.png">
