### PR TITLE
fix: no buffer if catchment area

### DIFF
--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -109,10 +109,10 @@ const EarthEngineDialog = props => {
     }, [rows, setOrgUnitLevels]);
 
     useEffect(() => {
-        if (areaRadius === undefined) {
+        if (!hasOrgUnitField && areaRadius === undefined) {
             setBufferRadius(EE_BUFFER);
         }
-    }, [areaRadius, setBufferRadius]);
+    }, [hasOrgUnitField, areaRadius, setBufferRadius]);
 
     useEffect(() => {
         if (validateLayer) {


### PR DESCRIPTION
Only set default buffer radius if no associated geometry (catchment area) is selected. We don't allow associated geometry and buffers to be combined. 