### PR TITLE
fix: disable data table if no org units are selected (DHIS2-12800, 2.37 backport)

### DIFF
--- a/src/components/datatable/DataTable.js
+++ b/src/components/datatable/DataTable.js
@@ -94,8 +94,7 @@ class DataTable extends Component {
 
     filter() {
         const { layer, aggregations = {} } = this.props;
-        const { dataFilters } = layer;
-        const data = layer.data;
+        const { data = [], dataFilters } = layer;
 
         return filterData(
             data.map((d, index) => ({

--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -25,7 +25,8 @@ export const LayerToolbarMoreMenu = ({
     openAs,
     downloadData,
     dataTableOpen,
-    downloadDisabled,
+    hasOrgUnitData,
+    isLoading,
 }) => {
     const [isOpen, setIsOpen] = useState(false);
     const anchorRef = useRef();
@@ -76,6 +77,7 @@ export const LayerToolbarMoreMenu = ({
                                         setIsOpen(false);
                                         toggleDataTable();
                                     }}
+                                    disabled={!hasOrgUnitData}
                                 />
                             )}
                             {openAs && (
@@ -96,7 +98,7 @@ export const LayerToolbarMoreMenu = ({
                                         setIsOpen(false);
                                         downloadData();
                                     }}
-                                    disabled={downloadDisabled}
+                                    disabled={!hasOrgUnitData || isLoading}
                                 />
                             )}
                             {showDivider && <Divider />}
@@ -137,13 +139,18 @@ LayerToolbarMoreMenu.propTypes = {
     openAs: PropTypes.func,
     downloadData: PropTypes.func,
     dataTableOpen: PropTypes.string,
-    downloadDisabled: PropTypes.bool,
+    hasOrgUnitData: PropTypes.bool,
+    isLoading: PropTypes.bool,
 };
 
-export default connect(({ dataTable, aggregations }, { layer }) => ({
-    dataTableOpen: dataTable,
-    // Disable EE download if no org units or no aggregations are available
-    downloadDisabled:
-        layer?.layer === 'earthEngine' &&
-        (!layer.data || !aggregations[layer.id]),
-}))(LayerToolbarMoreMenu);
+export default connect(
+    ({ dataTable: dataTableOpen, aggregations }, { layer = {} }) => {
+        const hasOrgUnitData = !!layer.data;
+        const isLoading =
+            hasOrgUnitData &&
+            layer.aggregationType?.length > 0 &&
+            !aggregations[layer.id];
+
+        return { dataTableOpen, hasOrgUnitData, isLoading };
+    }
+)(LayerToolbarMoreMenu);

--- a/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbarMoreMenu.spec.js.snap
+++ b/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbarMoreMenu.spec.js.snap
@@ -37,12 +37,14 @@ exports[`LayerToolbarMoreMenu Should match snapshot 1`] = `
       >
         <MenuItem
           dataTest="dhis2-uicore-menuitem"
+          disabled={true}
           icon={<SvgTable16 />}
           label="Hide data table"
           onClick={[Function]}
         />
         <MenuItem
           dataTest="dhis2-uicore-menuitem"
+          disabled={true}
           icon={<SvgDownload16 />}
           label="Download data"
           onClick={[Function]}


### PR DESCRIPTION
Fixes for 2.37: https://jira.dhis2.org/browse/DHIS2-12800

2.37 backport of: https://github.com/dhis2/maps-app/pull/2075

This PR will disable data table and download options from the layer menu if no org units are selected. The download data option will only be enabled if the layer is finished loading.