### PR TITLE
fix: show error when org unit selection is invalid for org unit layer (DHIS2-12504)

### DIFF
--- a/src/loaders/orgUnitLoader.js
+++ b/src/loaders/orgUnitLoader.js
@@ -26,6 +26,7 @@ const orgUnitLoader = async config => {
     const featuresRequest = d2.geoFeatures
         .byOrgUnit(orgUnitParams)
         .displayProperty(displayProperty);
+
     let features;
     let associatedGeometries = [];
 


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12504

This PR avoids and infinitive loading spinner when the backend api reports an invalid org unit selection.

After this PR we will show the error message from the backend and the user is able to change the layer settings:

![Screenshot 2022-03-17 at 15 50 30](https://user-images.githubusercontent.com/548708/158855559-569621bc-c40a-40ad-a2fc-0ab9c9bf4ff6.png)
