### PR TITLE
fix: disable data table and download if no aggregations (DHIS2-12475)

### DIFF
--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -140,17 +140,16 @@ LayerToolbarMoreMenu.propTypes = {
     downloadData: PropTypes.func,
     dataTableOpen: PropTypes.string,
     hasOrgUnitData: PropTypes.bool,
-    hasAggregations: PropTypes.bool,
     isLoading: PropTypes.bool,
 };
 
 export default connect(
     ({ dataTable: dataTableOpen, aggregations }, { layer = {} }) => {
-        const hasOrgUnitData = !!layer.data;
+        const isEarthEngine = layer.layer === 'earthEngine';
+        const hasOrgUnitData =
+            layer.data && (!isEarthEngine || layer.aggregationType?.length > 0);
         const isLoading =
-            hasOrgUnitData &&
-            layer.aggregationType?.length > 0 &&
-            !aggregations[layer.id];
+            isEarthEngine && hasOrgUnitData && !aggregations[layer.id];
 
         return { dataTableOpen, hasOrgUnitData, isLoading };
     }

--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -15,6 +15,8 @@ import {
     IconDelete16,
 } from '@dhis2/ui';
 import { IconButton } from '../../core';
+import { EARTH_ENGINE_LAYER } from '../../../constants/layers';
+
 import styles from './styles/LayerToolbarMore.module.css';
 
 export const LayerToolbarMoreMenu = ({
@@ -145,7 +147,7 @@ LayerToolbarMoreMenu.propTypes = {
 
 export default connect(
     ({ dataTable: dataTableOpen, aggregations }, { layer = {} }) => {
-        const isEarthEngine = layer.layer === 'earthEngine';
+        const isEarthEngine = layer.layer === EARTH_ENGINE_LAYER;
         const hasOrgUnitData =
             layer.data && (!isEarthEngine || layer.aggregationType?.length > 0);
         const isLoading =


### PR DESCRIPTION
Fixes: https://jira.dhis2.org/browse/DHIS2-12475

This PR will disable data table option from the layer menu if: 
1. There are no org units selected, and
2. It is not an earth engine layer OR the earth engine layer has no aggregated data

The download option will be disabled if: 
1. Same conditions as above, OR
2. The earth engine aggregated data is still loading

After this PR for EE layers: 

Aggregations and org units are selected:
<img width="282" alt="Screenshot 2022-03-22 at 20 39 19" src="https://user-images.githubusercontent.com/548708/159562342-bdebc14d-cffb-4924-9131-fbf98c82df69.png">

No aggregations are selected: 
<img width="251" alt="Screenshot 2022-03-22 at 20 40 28" src="https://user-images.githubusercontent.com/548708/159562420-83669907-195a-4484-b44a-2d8b1e4784ef.png">

No org units are selected: 
<img width="226" alt="Screenshot 2022-03-22 at 20 41 17" src="https://user-images.githubusercontent.com/548708/159562530-97acf5d8-5fbd-4526-8441-5b70dd06c96b.png">

Aggregated data is stil loading:
<img width="222" alt="Screenshot 2022-03-22 at 20 41 55" src="https://user-images.githubusercontent.com/548708/159562638-329bef26-b40a-4681-8a90-9bf195173b4f.png">

