### PR TITLE
fix: improved map download style (DHIS2-12861, DHIS2-12862) 

### DIFF
--- a/src/components/download/DownloadDialog.js
+++ b/src/components/download/DownloadDialog.js
@@ -128,7 +128,7 @@ export class DownloadDialog extends Component {
         const skipElements = el =>
             !el.classList ||
             el.classList.contains('maplibregl-ctrl-scale') ||
-            el.classList.contains('mapboxgl-ctrl-attrib') ||
+            el.classList.contains('maplibregl-ctrl-attrib') ||
             !(
                 el.classList.contains('maplibregl-ctrl') ||
                 el.classList.contains('maplibregl-ctrl-attrib-button') ||

--- a/src/components/download/DownloadDialog.js
+++ b/src/components/download/DownloadDialog.js
@@ -150,7 +150,7 @@ export class DownloadDialog extends Component {
                 .getComputedStyle(titleEl, null)
                 .getPropertyValue('width');
 
-            titleEl.style.width = parseFloat(width) + 2 + 'px';
+            titleEl.style.width = `${parseFloat(width) + 2}px`;
         }
 
         convertToPng(mapEl, options)

--- a/src/components/download/DownloadDialog.js
+++ b/src/components/download/DownloadDialog.js
@@ -128,9 +128,10 @@ export class DownloadDialog extends Component {
         const skipElements = el =>
             !el.classList ||
             el.classList.contains('maplibregl-ctrl-scale') ||
-            el.classList.contains('maplibregl-ctrl-attrib-button') ||
+            el.classList.contains('mapboxgl-ctrl-attrib') ||
             !(
                 el.classList.contains('maplibregl-ctrl') ||
+                el.classList.contains('maplibregl-ctrl-attrib-button') ||
                 el.classList.contains('dhis2-map-bing-logo')
             );
 
@@ -140,7 +141,7 @@ export class DownloadDialog extends Component {
             filter: skipElements,
         };
 
-        // Adding 1 to the computed width of the title element avoids text
+        // Adding 2 px to the computed width of the title element avoids text
         // wrapping outside the box in the generated image
         const titleEl = mapEl.getElementsByClassName('dhis2-maps-title')[0];
 
@@ -149,7 +150,7 @@ export class DownloadDialog extends Component {
                 .getComputedStyle(titleEl, null)
                 .getPropertyValue('width');
 
-            titleEl.style.width = parseFloat(width) + 1 + 'px';
+            titleEl.style.width = parseFloat(width) + 2 + 'px';
         }
 
         convertToPng(mapEl, options)

--- a/src/components/legend/styles/LegendItem.module.css
+++ b/src/components/legend/styles/LegendItem.module.css
@@ -7,6 +7,7 @@
     height: var(--spacers-dp24);
     padding: 0;
     vertical-align: middle;
+    line-height: 0;
 }
 
 .legendItem th span {


### PR DESCRIPTION
Fixes: 
https://jira.dhis2.org/browse/DHIS2-12861
https://jira.dhis2.org/browse/DHIS2-12862

This PR fixes issue with the map download style: 
1. Remove padding below legend items to avoid overflow
2. Add 2 px width to map name to avoid text wrap
3. Don't hide map attribution

These style issues are related to limitations of the dom-to-image dependency: https://github.com/tsayen/dom-to-image

After this PR: 
![map-d72ji](https://user-images.githubusercontent.com/548708/161564635-b7e89123-b0ac-42e2-8f22-7d0a1b4f1b6a.png)

Before: 
![map-xja84](https://user-images.githubusercontent.com/548708/161564858-a8f3d8cf-bc6a-4f3b-ab6c-df16db2fb5ed.png)