### PR TITLE
fix: uncheck completed events only checkbox if value type don't support events

### DIFF
--- a/src/components/edit/thematic/CompletedOnlyCheckbox.js
+++ b/src/components/edit/thematic/CompletedOnlyCheckbox.js
@@ -1,16 +1,35 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import i18n from '@dhis2/d2-i18n';
 import { connect } from 'react-redux';
 import { Checkbox } from '../../core';
 import { setEventStatus } from '../../../actions/layerEdit';
+import { dimConf } from '../../../constants/dimension';
 import {
     EVENT_STATUS_ALL,
     EVENT_STATUS_COMPLETED,
 } from '../../../constants/eventStatuses';
 
-export const CompletedOnlyCheckbox = ({ completedOnly, setEventStatus }) => {
-    return (
+const eventDataTypes = [
+    dimConf.indicator.objectName,
+    dimConf.programIndicator.objectName,
+    dimConf.eventDataItem.objectName,
+];
+
+export const CompletedOnlyCheckbox = ({
+    valueType,
+    completedOnly,
+    setEventStatus,
+}) => {
+    const hasEventData = eventDataTypes.includes(valueType);
+
+    useEffect(() => {
+        if (completedOnly && !hasEventData) {
+            setEventStatus(EVENT_STATUS_ALL);
+        }
+    }, [completedOnly, hasEventData, setEventStatus]);
+
+    return hasEventData ? (
         <Checkbox
             label={i18n.t('Only show completed events')}
             checked={completedOnly}
@@ -20,10 +39,11 @@ export const CompletedOnlyCheckbox = ({ completedOnly, setEventStatus }) => {
                 )
             }
         />
-    );
+    ) : null;
 };
 
 CompletedOnlyCheckbox.propTypes = {
+    valueType: PropTypes.string,
     completedOnly: PropTypes.bool,
     setEventStatus: PropTypes.func.isRequired,
 };

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -280,11 +280,6 @@ export class ThematicDialog extends Component {
         const dataItem = getDataItemFromColumns(columns);
         const dimensions = getDimensionsFromFilters(filters);
         const hasUserOrgUnits = !!selectedUserOrgUnits.length;
-        const hasEventData = [
-            dimConf.indicator.objectName,
-            dimConf.programIndicator.objectName,
-            dimConf.eventDataItem.objectName,
-        ].includes(valueType);
 
         return (
             <div className={styles.content} data-test="thematicdialog">
@@ -428,7 +423,7 @@ export class ThematicDialog extends Component {
                                 ),
                             ]}
                             <AggregationTypeSelect className={styles.select} />
-                            {hasEventData && <CompletedOnlyCheckbox />}
+                            <CompletedOnlyCheckbox valueType={valueType} />
                         </div>
                     )}
                     {tab === 'period' && (


### PR DESCRIPTION
Improves: https://jira.dhis2.org/browse/DHIS2-13095

If the user selects "Data element" or "Reporting rates" as value type for a thematic layer, this PR will make sure that we reset the eventStatus param and the checkbox will be unchecked. If the user switches between value types that supports event data, the value will still be kept. 

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/548708/181251920-dd95fec6-aee8-445d-9014-f5a91e995778.gif)

