### PR TITLE
fix: minor fixes

### DIFF
--- a/src/components/map/MapContainer.js
+++ b/src/components/map/MapContainer.js
@@ -50,7 +50,7 @@ const MapContainer = props => {
 
     // Trigger map resize when panels are expanded, collapsed or dragged
     useEffect(() => {
-        setResizeCount(resizeCount + 1);
+        setResizeCount(count => count + 1);
     }, [layersPanelOpen, rightPanelOpen, dataTableOpen, dataTableHeight]);
 
     return (

--- a/src/components/map/MapView.js
+++ b/src/components/map/MapView.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { ComponentCover, CenteredContent, CircularLoader } from '@dhis2/ui';
 import Map from './Map';
@@ -25,7 +25,10 @@ const MapView = props => {
 
     const splitViewLayer = getSplitViewLayer(layers);
     const isSplitView = !!splitViewLayer;
-    const mapControls = getMapControls(isPlugin, isSplitView, controls);
+    const mapControls = useMemo(
+        () => getMapControls(isPlugin, isSplitView, controls),
+        [isPlugin, isSplitView, controls]
+    );
 
     return (
         <>

--- a/src/constants/mapControls.js
+++ b/src/constants/mapControls.js
@@ -11,7 +11,6 @@ export const splitViewControls = [
     { type: 'zoom' },
     { type: 'fullscreen' },
     { type: 'fitBounds' },
-    { type: 'search' },
     { type: 'attribution', prefix: false },
 ];
 

--- a/src/reducers/interpretation.js
+++ b/src/reducers/interpretation.js
@@ -1,6 +1,6 @@
 import * as types from '../constants/actionTypes';
 
-const programs = (state = {}, action) => {
+const interpretation = (state = {}, action) => {
     switch (action.type) {
         case types.INTERPRETATION_SET:
             return { ...state, id: action.payload };
@@ -10,4 +10,4 @@ const programs = (state = {}, action) => {
     }
 };
 
-export default programs;
+export default interpretation;


### PR DESCRIPTION
This PR contains the following fixes: 
1. resizeCount in MapContainer.js uses current state to increment the counter
2. mapControls in MapView.js is wrapped in a useMemo to avoid triggering a redraw on every render. 
3. Search control is removed from split view maps as it was not working well for multiple synced maps (and it is not important in this context)
4. interpretation.js renames "programs" to "interpretation" which is only cosmetic. 