### PR TITLE
fix: use tileScale to avoid EE aggregation timeout

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-08-30T15:44:20.557Z\n"
-"PO-Revision-Date: 2022-08-30T15:44:20.557Z\n"
+"POT-Creation-Date: 2022-08-30T15:47:38.891Z\n"
+"PO-Revision-Date: 2022-08-30T15:47:38.891Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -189,9 +189,6 @@ msgid "Add layer"
 msgstr ""
 
 msgid "Aggregation method"
-msgstr ""
-
-msgid "Choosing many groups takes a long time to calculate and display."
 msgstr ""
 
 msgid "Groups"

--- a/src/components/edit/earthEngine/BandSelect.js
+++ b/src/components/edit/earthEngine/BandSelect.js
@@ -5,30 +5,16 @@ import { connect } from 'react-redux';
 import { SelectField } from '../../core';
 import { setBand } from '../../../actions/layerEdit';
 
-const WARNING_BANDS = 10;
-
-const BandSelect = ({ band = [], bands, setBand, errorText }) => {
-    let warning;
-
-    // Show time warning if more than 10 bands/groups are selected
-    if (band.length > WARNING_BANDS) {
-        warning = i18n.t(
-            'Choosing many groups takes a long time to calculate and display.'
-        );
-    }
-
-    return (
-        <SelectField
-            label={i18n.t('Groups')}
-            items={bands}
-            multiple={true}
-            value={band}
-            onChange={setBand}
-            warning={warning}
-            errorText={errorText}
-        />
-    );
-};
+const BandSelect = ({ band = [], bands, setBand, errorText }) => (
+    <SelectField
+        label={i18n.t('Groups')}
+        items={bands}
+        multiple={true}
+        value={band}
+        onChange={setBand}
+        errorText={errorText}
+    />
+);
 
 BandSelect.propTypes = {
     band: PropTypes.array,

--- a/src/components/map/layers/earthEngine/EarthEngineLayer.js
+++ b/src/components/map/layers/earthEngine/EarthEngineLayer.js
@@ -73,6 +73,7 @@ export default class EarthEngineLayer extends Layer {
             data,
             aggregationType,
             areaRadius,
+            tileScale,
         } = this.props;
 
         const { map, isPlugin } = this.context;
@@ -100,6 +101,7 @@ export default class EarthEngineLayer extends Layer {
             projection,
             data,
             aggregationType,
+            tileScale,
             preload: !isPlugin && this.hasAggregations(),
             onClick: this.onFeatureClick.bind(this),
             onRightClick: this.onFeatureRightClick.bind(this),

--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -207,6 +207,7 @@ export const earthEngineLayers = () => [
             palette: '#fee5d9,#fcbba1,#fc9272,#fb6a4a,#de2d26,#a50f15', // Reds
         },
         opacity: 0.9,
+        tileScale: 4,
     },
     {
         layer: EARTH_ENGINE_LAYER,


### PR DESCRIPTION
Depends on: https://github.com/dhis2/maps-gl/pull/490

This PR will add a tileScale value to EE Population age groups layer which will solve the timeout issue when multiple age groups are selected. 

The PR also removes the warning when selecting more than 10 age groups, as this is no longer a limitation. 