### PR TITLE
fix: bump web api version to 39 (v39 backport)

### DIFF
--- a/src/constants/settings.js
+++ b/src/constants/settings.js
@@ -1,6 +1,6 @@
 import { FALLBACK_BASEMAP_ID } from './basemaps';
 
-export const apiVersion = 38;
+export const apiVersion = 39;
 
 export const DEFAULT_SYSTEM_SETTINGS = {
     keyDefaultBaseMap: FALLBACK_BASEMAP_ID,


### PR DESCRIPTION
This PR will update the Web API version to 2.39.1

v39 backport of https://github.com/dhis2/maps-app/pull/2306