### PR TITLE
fix: DHIS2_BASE_URL should not be set globally

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -10,6 +10,7 @@ env:
     GIT_COMMITTER_NAME: '@dhis2-bot'
     GIT_COMMITTER_EMAIL: 'apps@dhis2.org'
     GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
+    DHIS2_BASE_URL: ${{ secrets.CYPRESS_DHIS2_BASE_URL_37 }}
     CI: true
 
 jobs:
@@ -141,7 +142,7 @@ jobs:
                   COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
                   SERVER_START_CMD: 'yarn start:nobrowser'
                   SERVER_URL: 'http://localhost:8082'
-                  DHIS2_BASE_URL: ${{ secrets.CYPRESS_DHIS2_BASE_URL_37 }}
+                  # DHIS2_BASE_URL: ${{ secrets.CYPRESS_DHIS2_BASE_URL_37 }}
                   CYPRESS_dhis2BaseUrl: ${{ secrets.CYPRESS_DHIS2_BASE_URL_37 }}
                   CYPRESS_dhis2ApiVersion: 38
                   CYPRESS_networkMode: 'live'

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -10,7 +10,6 @@ env:
     GIT_COMMITTER_NAME: '@dhis2-bot'
     GIT_COMMITTER_EMAIL: 'apps@dhis2.org'
     GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
-    DHIS2_BASE_URL: ${{ secrets.CYPRESS_DHIS2_BASE_URL_37 }}
     CI: true
 
 jobs:
@@ -142,7 +141,7 @@ jobs:
                   COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
                   SERVER_START_CMD: 'yarn start:nobrowser'
                   SERVER_URL: 'http://localhost:8082'
-                  # DHIS2_BASE_URL: ${{ secrets.CYPRESS_DHIS2_BASE_URL_37 }}
+                  DHIS2_BASE_URL: ${{ secrets.CYPRESS_DHIS2_BASE_URL_37 }}
                   CYPRESS_dhis2BaseUrl: ${{ secrets.CYPRESS_DHIS2_BASE_URL_37 }}
                   CYPRESS_dhis2ApiVersion: 38
                   CYPRESS_networkMode: 'live'

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -10,7 +10,6 @@ env:
     GIT_COMMITTER_NAME: '@dhis2-bot'
     GIT_COMMITTER_EMAIL: 'apps@dhis2.org'
     GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
-    DHIS2_BASE_URL: ${{ secrets.CYPRESS_DHIS2_BASE_URL_37 }}
     CI: true
 
 jobs:
@@ -142,6 +141,7 @@ jobs:
                   COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
                   SERVER_START_CMD: 'yarn start:nobrowser'
                   SERVER_URL: 'http://localhost:8082'
+                  DHIS2_BASE_URL: ${{ secrets.CYPRESS_DHIS2_BASE_URL_37 }}
                   CYPRESS_dhis2BaseUrl: ${{ secrets.CYPRESS_DHIS2_BASE_URL_37 }}
                   CYPRESS_dhis2ApiVersion: 38
                   CYPRESS_networkMode: 'live'


### PR DESCRIPTION
Setting DHIS2_BASE_URL globally causes the value from the repository secret to override the value from the instance environment, causing the app to crash. The value from the repository secret DHIS2_BASE_URL was being coded into the build file app.js (e.g. `test.e2e.dhis2.org/analytics-2.37`)
