### PR TITLE
fix: basemap default opacity and isVisible needed since they are not stored in visualization

### DIFF
--- a/src/components/map/layers/BasemapLayer.js
+++ b/src/components/map/layers/BasemapLayer.js
@@ -73,4 +73,9 @@ BasemapLayer.propTypes = {
     opacity: PropTypes.number,
 };
 
+BasemapLayer.defaultProps = {
+    opacity: 1,
+    isVisible: true,
+};
+
 export default BasemapLayer;


### PR DESCRIPTION
The recent basemap layer refactor caused a bug in the plugin: basemap isn't visible since the opacity and isVisible properties are missing.


From debug/dev
![image](https://user-images.githubusercontent.com/6113918/206239426-846b3881-f0f4-4848-ad79-73425a404d7e.png)

Before: 
![Screenshot 2022-12-07 at 17 40 22](https://user-images.githubusercontent.com/6113918/206239074-b45884a5-ab98-4866-998c-7c1491bc134f.png)

After: 
![Screenshot 2022-12-07 at 17 42 02](https://user-images.githubusercontent.com/6113918/206239119-93a68de4-42b0-42db-9fff-7e6972c05cc7.png)
