### PR TITLE
fix: white background for download maps (DHIS2-14291)

### DIFF
--- a/src/components/map/styles/MapContainer.module.css
+++ b/src/components/map/styles/MapContainer.module.css
@@ -5,6 +5,10 @@
     overflow: hidden;
 }
 
+.download {
+    background-color: white;
+}
+
 .download :global(.dhis2-map-timeline) {
     display: none;
 }


### PR DESCRIPTION
This PR adds a white background to the canvas when maps are downloaded.

Fixes: https://dhis2.atlassian.net/browse/DHIS2-14291

After this PR: 

![map-wmygz](https://user-images.githubusercontent.com/548708/206535773-77faba87-34ee-4f4f-8263-4a110486f7ed.png)

![map-d50kd](https://user-images.githubusercontent.com/548708/206535821-d1d65ffe-d220-4a32-a7b2-91d71b8f7601.png)
