### PR TITLE
fix: white background for download maps (DHIS2-14291 - 2.36 backport)

### DIFF
--- a/src/components/map/styles/MapContainer.module.css
+++ b/src/components/map/styles/MapContainer.module.css
@@ -5,6 +5,10 @@
     overflow: hidden;
 }
 
+.download {
+    background-color: white;
+}
+
 .download :global(.dhis2-map-timeline) {
     display: none;
 }


### PR DESCRIPTION
2.36 backport of https://github.com/dhis2/maps-app/pull/2404