### PR TITLE
fix: improved facility symbol handling (DHIS2-14438)

### DIFF
--- a/src/components/map/layers/Alert.js
+++ b/src/components/map/layers/Alert.js
@@ -3,9 +3,14 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './styles/Alert.module.css'
 
-const Alert = ({ message, onHidden }) => (
+const Alert = ({ message, critical, warning, onHidden }) => (
     <div className={styles.alert}>
-        <AlertBar critical={true} duration={10000} onHidden={onHidden}>
+        <AlertBar
+            critical={critical}
+            warning={warning}
+            duration={10000}
+            onHidden={onHidden}
+        >
             {message}
         </AlertBar>
     </div>
@@ -14,6 +19,8 @@ const Alert = ({ message, onHidden }) => (
 Alert.propTypes = {
     message: PropTypes.string.isRequired,
     onHidden: PropTypes.func.isRequired,
+    critical: PropTypes.string.boolean,
+    warning: PropTypes.string.boolean,
 }
 
 export default Alert

--- a/src/components/map/layers/FacilityLayer.js
+++ b/src/components/map/layers/FacilityLayer.js
@@ -10,6 +10,7 @@ import { getContrastColor } from '../../../util/colors.js'
 import { filterData } from '../../../util/filter.js'
 import { getLabelStyle } from '../../../util/labels.js'
 import Popup from '../Popup.js'
+import Alert from './Alert.js'
 import Layer from './Layer.js'
 
 class FacilityLayer extends Layer {
@@ -60,6 +61,7 @@ class FacilityLayer extends Layer {
             },
             onClick: this.onFeatureClick.bind(this),
             onRightClick: this.onFeatureRightClick.bind(this),
+            onError: this.onError.bind(this),
         }
 
         // Labels and label style
@@ -92,7 +94,7 @@ class FacilityLayer extends Layer {
         // Create and add facility layer based on config object
         group.addLayer(config)
         this.layer = group
-        map.addLayer(this.layer)
+        map.addLayer(this.layer).catch(this.onError)
 
         // Fit map to layer bounds once (when first created)
         this.fitBoundsOnce()
@@ -132,7 +134,20 @@ class FacilityLayer extends Layer {
     }
 
     render() {
-        return this.state.popup ? this.getPopup() : null
+        const { popup, error } = this.state
+
+        return (
+            <>
+                {popup && this.getPopup()}
+                {error && (
+                    <Alert
+                        warning={true}
+                        message={error}
+                        onHidden={this.onErrorHidden.bind(this)}
+                    />
+                )}
+            </>
+        )
     }
 
     onFeatureClick(evt) {

--- a/src/components/map/layers/FacilityLayer.js
+++ b/src/components/map/layers/FacilityLayer.js
@@ -94,7 +94,7 @@ class FacilityLayer extends Layer {
         // Create and add facility layer based on config object
         group.addLayer(config)
         this.layer = group
-        map.addLayer(this.layer).catch(this.onError)
+        map.addLayer(this.layer).catch(this.onError.bind(this))
 
         // Fit map to layer bounds once (when first created)
         this.fitBoundsOnce()

--- a/src/components/map/layers/Layer.js
+++ b/src/components/map/layers/Layer.js
@@ -1,3 +1,4 @@
+import log from 'loglevel'
 import PropTypes from 'prop-types'
 import { PureComponent } from 'react'
 import { RENDERING_STRATEGY_SPLIT_BY_PERIOD } from '../../../constants/layers.js'
@@ -198,6 +199,22 @@ class Layer extends PureComponent {
     // Called when a map popup is closed
     onPopupClose = () => {
         this.setState({ popup: null })
+    }
+
+    onError(error) {
+        const message = error.message || error
+        console.log('onError', message)
+
+        if (!this.context.isPlugin) {
+            this.setState({ error: message })
+        } else {
+            log.error(message)
+        }
+    }
+
+    onErrorHidden() {
+        console.log('onErrorHidden')
+        this.setState({ error: null })
     }
 }
 

--- a/src/components/map/layers/Layer.js
+++ b/src/components/map/layers/Layer.js
@@ -203,7 +203,6 @@ class Layer extends PureComponent {
 
     onError(error) {
         const message = error.message || error
-        console.log('onError', message)
 
         if (!this.context.isPlugin) {
             this.setState({ error: message })
@@ -213,7 +212,6 @@ class Layer extends PureComponent {
     }
 
     onErrorHidden() {
-        console.log('onErrorHidden')
         this.setState({ error: null })
     }
 }

--- a/src/components/map/layers/earthEngine/EarthEngineLayer.js
+++ b/src/components/map/layers/earthEngine/EarthEngineLayer.js
@@ -210,6 +210,7 @@ export default class EarthEngineLayer extends Layer {
                 {isLoading && <MapLoadingMask />}
                 {error && (
                     <Alert
+                        critical={true}
                         message={error}
                         onHidden={() => this.setState({ error: null })}
                     />

--- a/src/util/orgUnits.js
+++ b/src/util/orgUnits.js
@@ -140,7 +140,11 @@ export const getStyledOrgUnits = (
         if (useColor && color) {
             properties.color = hasAdditionalGeometry ? ORG_UNIT_COLOR : color
         } else if (symbol) {
-            properties.iconUrl = `${contextPath}/images/orgunitgroup/${symbol}`
+            // properties.iconUrl = `${contextPath}/images/orgunitgroup/${symbol}`
+            properties.iconUrl = `${contextPath.replace(
+                '8080',
+                '8082'
+            )}/images/orgunitgroup/${symbol}`
         }
 
         if (properties.level && levelWeight) {

--- a/src/util/orgUnits.js
+++ b/src/util/orgUnits.js
@@ -140,11 +140,7 @@ export const getStyledOrgUnits = (
         if (useColor && color) {
             properties.color = hasAdditionalGeometry ? ORG_UNIT_COLOR : color
         } else if (symbol) {
-            // properties.iconUrl = `${contextPath}/images/orgunitgroup/${symbol}`
-            properties.iconUrl = `${contextPath.replace(
-                '8080',
-                '8082'
-            )}/images/orgunitgroup/${symbol}`
+            properties.iconUrl = `${contextPath}/images/orgunitgroup/${symbol}`
         }
 
         if (properties.level && levelWeight) {


### PR DESCRIPTION
This PR will add support for SVG symbols for facility layer, and improve the symbol error handling. 

Fixes: https://dhis2.atlassian.net/browse/DHIS2-14440 (in https://github.com/dhis2/maps-gl/pull/517)
Fixes: https://dhis2.atlassian.net/browse/DHIS2-14438

If one or more symbols are missing, we will still show the remaining symbols on the map. A warning message about the first symbol missing is shown to the user.

The same error handling as we have for Earth Engine layers was reused. Added support for both critical and warning errors. 

Two new methods was added to the Layer class: 
- onError -> if plugin (dashboard) the error will only be in the console, if not it will be handled by the specific layer
- onErrorHidden -> Should be called when the error message is not showing anymore

After this PR: 
![Screenshot 2023-01-09 at 13 51 09](https://user-images.githubusercontent.com/548708/211316570-bb55f3e1-457d-442f-b275-a5eca88f7a56.png)
