### PR TITLE
fix: special characters in map name

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,13 +5,13 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-12-14T09:49:25.172Z\n"
-"PO-Revision-Date: 2022-12-14T09:49:25.172Z\n"
+"POT-Creation-Date: 2023-01-09T14:49:29.260Z\n"
+"PO-Revision-Date: 2023-01-09T14:49:29.260Z\n"
 
 msgid "Maps"
 msgstr ""
 
-msgid "Map \"{{name}}\" is saved."
+msgid "Map \"{{- name}}\" is saved."
 msgstr ""
 
 msgid "Failed to save map: {{message}}"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "analyze-bundle": "webpack --profile --json --progress > .webpack-profile.json && webpack-bundle-analyzer .webpack-profile.json"
     },
     "dependencies": {
-        "@dhis2/analytics": "^24.0.8",
+        "@dhis2/analytics": "^24.4.0",
         "@dhis2/app-runtime": "^3.4.4",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-alerts": "^3.6.2",

--- a/src/components/app/FileMenu.js
+++ b/src/components/app/FileMenu.js
@@ -34,7 +34,7 @@ const saveAsNewMapMutation = {
     data: ({ data }) => data,
 }
 
-const getSavedMessage = (name) => i18n.t('Map "{{name}}" is saved.', { name })
+const getSavedMessage = (name) => i18n.t('Map "{{- name}}" is saved.', { name })
 
 const getSaveFailureMessage = (message) =>
     i18n.t('Failed to save map: {{message}}', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4354,10 +4354,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^24.0.8":
-  version "24.0.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.0.8.tgz#a463bef8ea1f10b8581d202583fa3da5e474c9bf"
-  integrity sha512-Jkh23yiEkUz4SYgGItEkM1z4nXqsLUs9aqUl7oihwQmut2iIMHLo2355QsuELcQGP8DFf4Qgu9MT1mrOZADIFA==
+"@dhis2/analytics@^24.4.0":
+  version "24.4.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-24.4.0.tgz#99a4cc0c8d846edb9792e489db3f93357f71d8be"
+  integrity sha512-0tSECJLMhEvn96OLYQhfdbNoEaLN2EkXp0zc8FfjEfM7HtVjNeiops9SaQH1Fzu2/XkkY9H1lcX5PHGo4Ail9g==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.0"
     classnames "^2.3.1"


### PR DESCRIPTION
This PR fixes an issue with the "/" character in map names. 

Partly fixes: https://dhis2.atlassian.net/browse/DHIS2-14436

The fix is similar to: https://github.com/dhis2/analytics/pull/1405 

After this PR: 

![Screenshot 2023-01-09 at 15 53 05](https://user-images.githubusercontent.com/548708/211336960-e4058d5e-78de-4820-9c3c-d0efa4f099be.png)

![Screenshot 2023-01-09 at 15 53 35](https://user-images.githubusercontent.com/548708/211337051-cdf5058c-aa20-472d-819c-34d22a17b904.png)

Before: 

![Screenshot 2023-01-09 at 15 54 44](https://user-images.githubusercontent.com/548708/211337367-8eaf2ce0-e3b1-4d06-82ea-b4212dc6c87b.png)

![Screenshot 2023-01-09 at 15 55 59](https://user-images.githubusercontent.com/548708/211337604-2e994dcc-6aa8-4acb-b1fb-b5438cd4fbbc.png)

The error message shown when a map is saved without a name is not solved in this PR. This should be solved by:
1. Improve the error message returned from the API (which we currently show), or
2. Make name required for FileMenu in @dhis2/analytics (at least for maps).