### PR TITLE
chore: remove query variables for lazy query

### DIFF
--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -231,13 +231,15 @@ class EventDialog extends Component {
                                 errorText={programError}
                                 data-test="eventdialog-programselect"
                             />
-                            <ProgramStageSelect
-                                program={program}
-                                programStage={programStage}
-                                onChange={setProgramStage}
-                                className={styles.select}
-                                errorText={programStageError}
-                            />
+                            {program && (
+                                <ProgramStageSelect
+                                    program={program}
+                                    programStage={programStage}
+                                    onChange={setProgramStage}
+                                    className={styles.select}
+                                    errorText={programStageError}
+                                />
+                            )}
                             <CoordinateField
                                 program={program}
                                 programStage={programStage}

--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -231,15 +231,13 @@ class EventDialog extends Component {
                                 errorText={programError}
                                 data-test="eventdialog-programselect"
                             />
-                            {program && (
-                                <ProgramStageSelect
-                                    program={program}
-                                    programStage={programStage}
-                                    onChange={setProgramStage}
-                                    className={styles.select}
-                                    errorText={programStageError}
-                                />
-                            )}
+                            <ProgramStageSelect
+                                program={program}
+                                programStage={programStage}
+                                onChange={setProgramStage}
+                                className={styles.select}
+                                errorText={programStageError}
+                            />
                             <CoordinateField
                                 program={program}
                                 programStage={programStage}

--- a/src/components/program/ProgramStageSelect.js
+++ b/src/components/program/ProgramStageSelect.js
@@ -38,7 +38,6 @@ const ProgramStageSelect = ({
     const { loading, error, data, refetch } = useDataQuery(
         PROGRAM_STAGES_QUERY,
         {
-            variables: { id: program.id },
             onComplete: onProgramStagesLoad,
             lazy: true,
         }
@@ -46,8 +45,14 @@ const ProgramStageSelect = ({
 
     // Fetch program stages when program is changed
     useEffect(() => {
-        refetch({ id: program.id })
+        if (program) {
+            refetch({ id: program.id })
+        }
     }, [program, refetch])
+
+    if (!program) {
+        return null
+    }
 
     let items = data?.stages.programStages
 
@@ -74,12 +79,12 @@ const ProgramStageSelect = ({
 }
 
 ProgramStageSelect.propTypes = {
-    program: PropTypes.shape({
-        id: PropTypes.string.isRequired,
-    }).isRequired,
     onChange: PropTypes.func.isRequired,
     className: PropTypes.string,
     errorText: PropTypes.string,
+    program: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+    }),
     programStage: PropTypes.object,
 }
 

--- a/src/components/program/ProgramStageSelect.js
+++ b/src/components/program/ProgramStageSelect.js
@@ -45,14 +45,8 @@ const ProgramStageSelect = ({
 
     // Fetch program stages when program is changed
     useEffect(() => {
-        if (program) {
-            refetch({ id: program.id })
-        }
+        refetch({ id: program.id })
     }, [program, refetch])
-
-    if (!program) {
-        return null
-    }
 
     let items = data?.stages.programStages
 
@@ -79,12 +73,12 @@ const ProgramStageSelect = ({
 }
 
 ProgramStageSelect.propTypes = {
+    program: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+    }).isRequired,
     onChange: PropTypes.func.isRequired,
     className: PropTypes.string,
     errorText: PropTypes.string,
-    program: PropTypes.shape({
-        id: PropTypes.string.isRequired,
-    }),
     programStage: PropTypes.object,
 }
 


### PR DESCRIPTION
`variables` are not needed for lazy query as they are passed with `refetch` method.