### PR TITLE
fix: untitled map name (DHIS2-14436)

### DIFF
--- a/src/components/app/FileMenu.js
+++ b/src/components/app/FileMenu.js
@@ -34,6 +34,16 @@ const saveAsNewMapMutation = {
     data: ({ data }) => data,
 }
 
+const getMapName = (name) =>
+    name ||
+    i18n.t('Untitled map, {{date}}', {
+        date: new Date().toLocaleDateString(undefined, {
+            year: 'numeric',
+            month: 'short',
+            day: '2-digit',
+        }),
+    })
+
 const getSavedMessage = (name) => i18n.t('Map "{{- name}}" is saved.', { name })
 
 const getSaveFailureMessage = (message) =>
@@ -111,7 +121,7 @@ const FileMenu = ({ map, newMap, tOpenMap, setMapProps }) => {
                 config: map,
                 defaultBasemapId: keyDefaultBaseMap,
             }),
-            name: name,
+            name: getMapName(name),
             description: description,
         }
 
@@ -144,6 +154,9 @@ const FileMenu = ({ map, newMap, tOpenMap, setMapProps }) => {
         }
     }
 
+    const onRename = ({ name, description }) =>
+        setMapProps({ name: getMapName(name), description })
+
     const onDelete = () => {
         newMap()
         deleteAlert.show()
@@ -158,7 +171,7 @@ const FileMenu = ({ map, newMap, tOpenMap, setMapProps }) => {
             onOpen={openMap}
             onSave={saveMap}
             onSaveAs={saveAsNewMap}
-            onRename={setMapProps}
+            onRename={onRename}
             onDelete={onDelete}
             onError={onFileMenuError}
         />


### PR DESCRIPTION
If map name is not set (undefined) when saving from file menu, it will be set to "Untitled map _date_". The same will happen if the map name is removed under File menu > Rename.  

Fixes: https://dhis2.atlassian.net/browse/DHIS2-14436

After this PR:
<img width="822" alt="Screenshot 2023-01-12 at 21 35 39" src="https://user-images.githubusercontent.com/548708/212175574-9b284ca6-e0d3-4c9b-981e-1d23fa2a5d92.png">
