### PR TITLE
fix: component OrgUnitData should not setItems with value undefined [v37]

### DIFF
--- a/src/components/orgunits/OrgUnitData.js
+++ b/src/components/orgunits/OrgUnitData.js
@@ -20,12 +20,12 @@ const OrgUnitData = ({ id, periodType, defaultPeriod, data }) => {
             setItems(data);
         } else {
             setIsLoading(true);
-            apiFetch(`/organisationUnitProfile/${id}/data?period=${period.id}`)
-                .then(({ dataItems }) => {
-                    setItems(dataItems);
-                    setIsLoading(false);
-                })
-                .then(setItems);
+            apiFetch(
+                `/organisationUnitProfile/${id}/data?period=${period.id}`
+            ).then(({ dataItems }) => {
+                setItems(dataItems);
+                setIsLoading(false);
+            });
         }
     }, [id, period, defaultPeriod, data]);
 


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-14496
There was an extra call to setItems which set the items to undefined so that the data never displays.

Before (year 2021):
<img width="1009" alt="image" src="https://user-images.githubusercontent.com/6113918/212296966-a6f8ceb0-c3dc-4e4c-b184-9b0802140649.png">


After (year 2021):
<img width="873" alt="image" src="https://user-images.githubusercontent.com/6113918/212296855-e6058395-ac7e-4360-834e-820b8f93e81c.png">
