### PR TITLE
fix: component OrgUnitData should not setItems with value undefined [v39]

### DIFF
--- a/src/components/orgunits/OrgUnitData.js
+++ b/src/components/orgunits/OrgUnitData.js
@@ -20,12 +20,12 @@ const OrgUnitData = ({ id, periodType, defaultPeriod, data }) => {
             setItems(data);
         } else {
             setIsLoading(true);
-            apiFetch(`/organisationUnitProfile/${id}/data?period=${period.id}`)
-                .then(({ dataItems }) => {
-                    setItems(dataItems);
-                    setIsLoading(false);
-                })
-                .then(setItems);
+            apiFetch(
+                `/organisationUnitProfile/${id}/data?period=${period.id}`
+            ).then(({ dataItems }) => {
+                setItems(dataItems);
+                setIsLoading(false);
+            });
         }
     }, [id, period, defaultPeriod, data]);
 


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-14496
There was an extra call to setItems which set the items to undefined so that the data never displays.