### PR TITLE
chore: add shim to provide baseUrl to apiFetch

### DIFF
--- a/src/components/BaseUrlShim.js
+++ b/src/components/BaseUrlShim.js
@@ -1,0 +1,7 @@
+import { useConfig } from '@dhis2/app-runtime'
+
+export const BaseUrlShim = ({ children }) => {
+    const { baseUrl, apiVersion } = useConfig()
+
+    return children({ baseUrl: `${baseUrl}/api/${apiVersion}` })
+}

--- a/src/components/map/layers/TrackedEntityLayer.js
+++ b/src/components/map/layers/TrackedEntityLayer.js
@@ -7,8 +7,9 @@ import {
     TEI_RELATED_COLOR,
     TEI_RELATED_RADIUS,
 } from '../../../constants/layers.js'
-import { apiFetch } from '../../../util/api.js'
+import { apiFetchWithBaseUrl } from '../../../util/api.js'
 import { formatTime } from '../../../util/helpers.js'
+import { BaseUrlShim } from '../../BaseUrlShim.js'
 import Popup from '../Popup.js'
 import Layer from './Layer.js'
 
@@ -24,10 +25,11 @@ const getCentroid = (points) => {
     return [totals[0] / points.length, totals[1] / points.length]
 }
 
-const fetchTEI = async (id, fieldsString) => {
-    const data = await apiFetch(
-        `/trackedEntityInstances/${id}?fields=${fieldsString}`
-    )
+const fetchTEI = async (id, fieldsString, baseUrl) => {
+    const data = await apiFetchWithBaseUrl({
+        url: `/trackedEntityInstances/${id}?fields=${fieldsString}`,
+        baseUrl,
+    })
     return data
 }
 
@@ -189,11 +191,18 @@ class TrackedEntityLayer extends Layer {
 
         const data = await fetchTEI(
             feature.properties.id,
-            'lastUpdated,attributes[displayName~rename(name),value],relationships'
+            'lastUpdated,attributes[displayName~rename(name),value],relationships',
+            this.props.baseUrl
         )
 
         this.setState({ popup: { feature, coordinates, data } })
     }
 }
 
-export default TrackedEntityLayer
+const TrackedEntityLayerWithBaseUrl = (props) => (
+    <BaseUrlShim>
+        {({ baseUrl }) => <TrackedEntityLayer baseUrl={baseUrl} {...props} />}
+    </BaseUrlShim>
+)
+
+export default TrackedEntityLayerWithBaseUrl

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -10,6 +10,35 @@ const getJsonResponse = async (response) => {
     return json
 }
 
+export const apiFetchWithBaseUrl = async ({ url, method, body, baseUrl }) => {
+    const options = {
+        headers: {
+            'Content-Type': 'application/json', // Default API response
+        },
+        credentials: 'include',
+    }
+
+    if (method && body) {
+        options.method = method
+
+        if (isString(body)) {
+            options.headers['Content-Type'] = 'text/html'
+            options.body = body
+        } else if (isObject(body)) {
+            options.body = JSON.stringify(body)
+        }
+    }
+
+    // TODO: Better error handling
+    return fetch(encodeURI(baseUrl + url), options)
+        .then((response) =>
+            ['POST', 'PUT', 'PATCH'].includes(method)
+                ? response
+                : getJsonResponse(response)
+        )
+        .catch((error) => console.log('Error: ', error))
+}
+
 export const apiFetch = async (url, method, body) => {
     const options = {
         headers: {


### PR DESCRIPTION
apiFetch currently uses d2 to get the baseUrl. This PR is part of removing d2 from maps, which is also good for the migration to platform.

apiFetchWithBaseUrl is a copy of apiFetch except that it uses the passed in baseUrl instead of baseUrl from d2. Eventually both these functions will go away, but for now i wanted to keep them separate since apiFetch is dependent on d2