### PR TITLE
fix: maps-gl upgrade with SVG symbols support (DHIS2-14440, 2.39 backport)

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@dhis2/d2-ui-core": "^7.4.0",
         "@dhis2/d2-ui-org-unit-dialog": "^7.4.0",
         "@dhis2/d2-ui-org-unit-tree": "^7.4.0",
-        "@dhis2/maps-gl": "^3.5.2",
+        "@dhis2/maps-gl": "^3.7.0",
         "@dhis2/ui": "^8.4.13",
         "abortcontroller-polyfill": "^1.7.3",
         "array-move": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4472,10 +4472,10 @@
     markdown-it "^8.4.2"
     prop-types "^15.6.2"
 
-"@dhis2/maps-gl@^3.5.2":
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-3.5.2.tgz#e174490847b25baf077906c996ddb06483c81762"
-  integrity sha512-PAGok+JC9pmT71Odp0oQqEdvdPFkBKO4xolY+pJ8hVzqXuOc3tke01i2giGJUB58vt2jyXpm7pszGpEdUZHP/Q==
+"@dhis2/maps-gl@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-3.7.0.tgz#5f664a5029fcb0a14d989109fb1131e484747642"
+  integrity sha512-SFnbekSYxy7B50ufxbFJkBIaBwcdwXf5qFm9St+jZ4XNtt2sFW5mstxGowCvw2823bpXFJ0EoN9+7+rHutEZ4Q==
   dependencies:
     "@mapbox/sphericalmercator" "^1.2.0"
     "@turf/area" "^6.5.0"


### PR DESCRIPTION
Fixes for 2.39: https://dhis2.atlassian.net/browse/DHIS2-14440

This PR will upgrade to the maps-gl 3.7.0 with SVG symbols support:
https://github.com/dhis2/maps-gl/releases/tag/v3.7.0
