### PR TITLE
fix: maps-gl upgrade with SVG symbols support (DHIS2-14440)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@dhis2/d2-ui-core": "^7.4.0",
         "@dhis2/d2-ui-org-unit-dialog": "^7.4.0",
         "@dhis2/d2-ui-org-unit-tree": "^7.4.0",
-        "@dhis2/maps-gl": "^3.5.3",
+        "@dhis2/maps-gl": "^3.7.0",
         "@dhis2/ui": "^8.4.13",
         "abortcontroller-polyfill": "^1.7.3",
         "array-move": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4650,10 +4650,10 @@
     markdown-it "^8.4.2"
     prop-types "^15.6.2"
 
-"@dhis2/maps-gl@^3.5.3":
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-3.5.3.tgz#58060cb0f611804eeb5205e0ffa2056e7d21fa37"
-  integrity sha512-npaPv3CDLUl6sXB966a21zVfu1b3+sICYopPSPtcxIKHACSmCsjIYpkMpzBdXAy/+x9HkjOqGezLfr7pMQoS9Q==
+"@dhis2/maps-gl@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-3.7.0.tgz#5f664a5029fcb0a14d989109fb1131e484747642"
+  integrity sha512-SFnbekSYxy7B50ufxbFJkBIaBwcdwXf5qFm9St+jZ4XNtt2sFW5mstxGowCvw2823bpXFJ0EoN9+7+rHutEZ4Q==
   dependencies:
     "@mapbox/sphericalmercator" "^1.2.0"
     "@turf/area" "^6.5.0"


### PR DESCRIPTION
Fixes for master/2.40: https://dhis2.atlassian.net/browse/DHIS2-14440

This PR will upgrade to the maps-gl 3.7.0 with SVG symbols support:
https://github.com/dhis2/maps-gl/releases/tag/v3.7.0
