### PR TITLE
chore: refator app component from redux connect to useDispatch

### DIFF
--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -6,9 +6,8 @@ import { useSetting } from '@dhis2/app-service-datastore'
 import i18n from '@dhis2/d2-i18n'
 import { CssReset, CssVariables, HeaderBar } from '@dhis2/ui'
 import isEmpty from 'lodash/isEmpty'
-import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
-import { connect } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { tSetAnalyticalObject } from '../../actions/analyticalObject.js'
 import { removeBingBasemaps, setBingMapsApiKey } from '../../actions/basemap.js'
 import { tSetExternalLayers } from '../../actions/externalLayers.js'
@@ -33,54 +32,42 @@ import { useSystemSettings } from '../SystemSettingsProvider.js'
 import AppMenu from './AppMenu.js'
 import styles from './styles/App.module.css'
 
-const App = ({
-    removeBingBasemaps,
-    setBingMapsApiKey,
-    tSetAnalyticalObject,
-    tSetOrgUnitTree,
-    tSetExternalLayers,
-    tOpenMap,
-}) => {
+const App = () => {
     const [basemapsLoaded, setBasemapsLoaded] = useState(false)
     const systemSettings = useSystemSettings()
     const engine = useDataEngine()
     const [currentAO] = useSetting(CURRENT_AO_KEY)
+    const dispatch = useDispatch()
 
     useEffect(() => {
         async function fetchData() {
-            await tSetOrgUnitTree()
-            await tSetExternalLayers(engine)
+            await dispatch(tSetOrgUnitTree())
+            await dispatch(tSetExternalLayers(engine))
             setBasemapsLoaded(true)
 
             const mapId = getUrlParameter('id')
             if (mapId) {
-                await tOpenMap(mapId, systemSettings.keyDefaultBaseMap, engine)
+                await dispatch(
+                    tOpenMap(mapId, systemSettings.keyDefaultBaseMap, engine)
+                )
             }
 
             if (getUrlParameter('currentAnalyticalObject') === 'true') {
-                await tSetAnalyticalObject(currentAO)
+                await dispatch(tSetAnalyticalObject(currentAO))
             }
         }
         fetchData()
-    }, [
-        engine,
-        currentAO,
-        systemSettings.keyDefaultBaseMap,
-        tOpenMap,
-        tSetAnalyticalObject,
-        tSetExternalLayers,
-        tSetOrgUnitTree,
-    ])
+    }, [engine, currentAO, systemSettings.keyDefaultBaseMap, dispatch])
 
     useEffect(() => {
         if (!isEmpty(systemSettings)) {
             if (!systemSettings.keyBingMapsApiKey) {
-                removeBingBasemaps()
+                dispatch(removeBingBasemaps())
             } else {
-                setBingMapsApiKey(systemSettings.keyBingMapsApiKey)
+                dispatch(setBingMapsApiKey(systemSettings.keyBingMapsApiKey))
             }
         }
-    }, [systemSettings, removeBingBasemaps, setBingMapsApiKey])
+    }, [systemSettings, dispatch])
 
     return (
         <FatalErrorBoundary>
@@ -112,20 +99,4 @@ const App = ({
     )
 }
 
-App.propTypes = {
-    removeBingBasemaps: PropTypes.func,
-    setBingMapsApiKey: PropTypes.func,
-    tOpenMap: PropTypes.func,
-    tSetAnalyticalObject: PropTypes.func,
-    tSetExternalLayers: PropTypes.func,
-    tSetOrgUnitTree: PropTypes.func,
-}
-
-export default connect(null, {
-    removeBingBasemaps,
-    setBingMapsApiKey,
-    tOpenMap,
-    tSetAnalyticalObject,
-    tSetExternalLayers,
-    tSetOrgUnitTree,
-})(App)
+export default App

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -50,9 +50,7 @@ const App = () => {
                 await dispatch(
                     tOpenMap(mapId, systemSettings.keyDefaultBaseMap, engine)
                 )
-            }
-
-            if (getUrlParameter('currentAnalyticalObject') === 'true') {
+            } else if (getUrlParameter('currentAnalyticalObject') === 'true') {
                 await dispatch(tSetAnalyticalObject(currentAO))
             }
         }


### PR DESCRIPTION
This PR will switch from redux connect to useDispatch to fire actions. 

Also includes a small fix to restrict having both map id in URL combined with currentAnalyticalObject (to avoid loading both a saved map and an analytical object from data store).  