### PR TITLE
fix: org unit levels do not have short names

### DIFF
--- a/src/components/orgunits/OrgUnitLevelSelect.js
+++ b/src/components/orgunits/OrgUnitLevelSelect.js
@@ -4,17 +4,16 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { isValidUid } from '../../util/helpers.js'
 import { SelectField } from '../core/index.js'
-import { useUserSettings } from '../UserSettingsProvider.js'
 
 // Load org unit levels
 const ORG_UNIT_LEVELS_QUERY = {
     levels: {
         resource: 'organisationUnitLevels',
-        params: ({ nameProperty }) => ({
-            fields: ['id', `${nameProperty}~rename(name)`, 'level'],
+        params: {
+            fields: ['id', 'displayName~rename(name)', 'level'],
             order: `level:asc`,
             paging: false,
-        }),
+        },
     },
 }
 
@@ -41,10 +40,7 @@ const style = {
 }
 
 const OrgUnitLevelSelect = ({ orgUnitLevel, disabled, onChange }) => {
-    const { nameProperty } = useUserSettings()
-    const { loading, error, data } = useDataQuery(ORG_UNIT_LEVELS_QUERY, {
-        variables: { nameProperty },
-    })
+    const { loading, error, data } = useDataQuery(ORG_UNIT_LEVELS_QUERY)
     const value = getOrgUnitLevelUid(
         orgUnitLevel,
         data?.levels.organisationUnitLevels


### PR DESCRIPTION
Bug introduced during recent refactorings.

Before:
<img width="641" alt="image" src="https://user-images.githubusercontent.com/6113918/219334835-73547f3d-0dbb-406a-b952-56332197e671.png">


After:
<img width="665" alt="image" src="https://user-images.githubusercontent.com/6113918/219334993-09235d74-92aa-473d-9f6c-6d056be6c6d0.png">
