### PR TITLE
fix: calculate orgunit dimension height rather than passing prop

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-02-19T19:52:22.886Z\n"
-"PO-Revision-Date: 2023-02-19T19:52:22.886Z\n"
+"POT-Creation-Date: 2023-02-21T14:09:45.303Z\n"
+"PO-Revision-Date: 2023-02-21T14:09:45.303Z\n"
 
 msgid "Maps"
 msgstr ""
@@ -702,10 +702,13 @@ msgid ""
 "styling is {{max}}."
 msgstr ""
 
-msgid "No data found for this period."
+msgid "Use associated geometry"
 msgstr ""
 
-msgid "Use associated geometry"
+msgid "None (default)"
+msgstr ""
+
+msgid "No data found for this period."
 msgstr ""
 
 msgid "Image of the organisation unit"

--- a/src/components/edit/FacilityDialog.js
+++ b/src/components/edit/FacilityDialog.js
@@ -99,12 +99,7 @@ const FacilityDialog = ({
             </Tabs>
             <div className={styles.tabContent}>
                 {tab === ORGUNITS_TAB && (
-                    <div
-                        className={styles.flexRowFlow}
-                        data-test="facilitydialog-orgunitstab"
-                    >
-                        <OrgUnitSelect warning={orgUnitsError} />
-                    </div>
+                    <OrgUnitSelect warning={orgUnitsError} />
                 )}
                 {tab === 'style' && (
                     <div

--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -209,9 +209,7 @@ const EarthEngineDialog = (props) => {
                     />
                 )}
                 {tab === 'orgunits' && (
-                    <div className={styles.flexRowFlow}>
-                        <OrgUnitSelect selectDefaultLevel={true} />
-                    </div>
+                    <OrgUnitSelect selectDefaultLevel={true} />
                 )}
                 {tab === 'style' && (
                     <StyleTab

--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -252,19 +252,13 @@ class EventDialog extends Component {
                         </div>
                     )}
                     {tab === 'orgunits' && (
-                        <div
-                            className={styles.flexRowFlow}
-                            data-test="eventdialog-orgunittab"
-                        >
-                            <OrgUnitSelect
-                                selectRoots={true}
-                                hideAssociatedGeometry={true}
-                                hideLevelSelect={true}
-                                hideGroupSelect={true}
-                                warning={orgUnitsError}
-                                style="event"
-                            />
-                        </div>
+                        <OrgUnitSelect
+                            selectRoots={true}
+                            hideAssociatedGeometry={true}
+                            hideLevelSelect={true}
+                            hideGroupSelect={true}
+                            warning={orgUnitsError}
+                        />
                     )}
                     {tab === 'filter' && (
                         <div

--- a/src/components/edit/orgUnit/OrgUnitDialog.js
+++ b/src/components/edit/orgUnit/OrgUnitDialog.js
@@ -61,12 +61,7 @@ class OrgUnitDialog extends Component {
                 </Tabs>
                 <div className={styles.tabContent}>
                     {tab === 'orgunits' && (
-                        <div
-                            className={styles.flexRowFlow}
-                            data-test="orgunitdialog-orgunitstab"
-                        >
-                            <OrgUnitSelect warning={orgUnitsError} />
-                        </div>
+                        <OrgUnitSelect warning={orgUnitsError} />
                     )}
                     {tab === 'style' && (
                         <div

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -256,7 +256,7 @@ class ThematicDialog extends Component {
                         {i18n.t('Style')}
                     </Tab>
                 </Tabs>
-                <div className={styles.tabContent} data-test="tab-content">
+                <div className={styles.tabContent}>
                     {tab === 'data' && (
                         <div
                             className={styles.flexRowFlow}

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -256,7 +256,7 @@ class ThematicDialog extends Component {
                         {i18n.t('Style')}
                     </Tab>
                 </Tabs>
-                <div className={styles.tabContent}>
+                <div className={styles.tabContent} data-test="tab-content">
                     {tab === 'data' && (
                         <div
                             className={styles.flexRowFlow}
@@ -431,15 +431,10 @@ class ThematicDialog extends Component {
                         </div>
                     )}
                     {tab === 'orgunits' && (
-                        <div
-                            className={styles.flexRowFlow}
-                            data-test="thematicdialog-orgunitstab"
-                        >
-                            <OrgUnitSelect
-                                selectDefaultLevel={true}
-                                warning={orgUnitsError}
-                            />
-                        </div>
+                        <OrgUnitSelect
+                            selectDefaultLevel={true}
+                            warning={orgUnitsError}
+                        />
                     )}
                     {tab === 'filter' && (
                         <div

--- a/src/components/edit/trackedEntity/TrackedEntityDialog.js
+++ b/src/components/edit/trackedEntity/TrackedEntityDialog.js
@@ -268,18 +268,15 @@ class TrackedEntityDialog extends Component {
                         </div>
                     )}
                     {tab === 'orgunits' && (
-                        <div className={styles.flexRowFlow}>
-                            <OrgUnitSelect
-                                selectRoots={true}
-                                hideUserOrgUnits={true}
-                                hideAssociatedGeometry={true}
-                                hideSelectMode={false}
-                                hideLevelSelect={true}
-                                hideGroupSelect={true}
-                                warning={orgUnitsError}
-                                style="trackedEntity"
-                            />
-                        </div>
+                        <OrgUnitSelect
+                            selectRoots={true}
+                            hideUserOrgUnits={true}
+                            hideAssociatedGeometry={true}
+                            hideSelectMode={false}
+                            hideLevelSelect={true}
+                            hideGroupSelect={true}
+                            warning={orgUnitsError}
+                        />
                     )}
                     {tab === 'style' && (
                         <div className={styles.flexColumnFlow}>

--- a/src/components/orgunits/AssociatedGeometrySelect.js
+++ b/src/components/orgunits/AssociatedGeometrySelect.js
@@ -34,7 +34,7 @@ const AssociatedGeometrySelect = () => {
     const attribute = attributes.find((a) => a.id === geometryField)
 
     return (
-        <div className={styles.geometryField}>
+        <div className={styles.geometryField} data-test="assoc-geometry">
             <SelectField
                 prefix={i18n.t('Use associated geometry')}
                 items={[

--- a/src/components/orgunits/AssociatedGeometrySelect.js
+++ b/src/components/orgunits/AssociatedGeometrySelect.js
@@ -34,7 +34,7 @@ const AssociatedGeometrySelect = () => {
     const attribute = attributes.find((a) => a.id === geometryField)
 
     return (
-        <div className={styles.geometryField} data-test="assoc-geometry">
+        <div className={styles.geometryField}>
             <SelectField
                 prefix={i18n.t('Use associated geometry')}
                 items={[

--- a/src/components/orgunits/OrgUnitSelect.js
+++ b/src/components/orgunits/OrgUnitSelect.js
@@ -31,6 +31,10 @@ const ORG_UNIT_TREE_QUERY = {
     },
 }
 
+const TWO_OTHER_SELECTS = 'two'
+const ONE_OTHER_SELECT = 'one'
+const NO_OTHER_SELECTS = 'none'
+
 const OrgUnitSelect = ({
     hideUserOrgUnits = false,
     hideAssociatedGeometry = false,
@@ -40,7 +44,6 @@ const OrgUnitSelect = ({
     selectDefaultLevel = false,
     selectRoots = false,
     warning,
-    style,
 }) => {
     const { loading, data, error } = useDataQuery(ORG_UNIT_TREE_QUERY)
     const rows = useSelector((state) => state.layerEdit.rows)
@@ -93,17 +96,33 @@ const OrgUnitSelect = ({
         return <Help error>{error.message}</Help>
     }
 
+    const numOtherSelects =
+        !hideAssociatedGeometry && !hideSelectMode
+            ? TWO_OTHER_SELECTS
+            : !hideAssociatedGeometry || !hideSelectMode
+            ? ONE_OTHER_SELECT
+            : NO_OTHER_SELECTS
+
     return (
-        <div className={cx(styles.orgUnitSelect, [styles[style]])}>
-            <OrgUnitDimension
-                roots={roots?.map((r) => r.id)}
-                selected={orgUnits}
-                onSelect={setOrgUnitItems}
-                hideUserOrgUnits={hideUserOrgUnits}
-                hideLevelSelect={hideLevelSelect}
-                hideGroupSelect={hideGroupSelect}
-                warning={!hasOrgUnits ? warning : null}
-            />
+        <div className={styles.orgUnitSelect} data-test="org-unit-select">
+            <div
+                className={cx({
+                    [styles.two]: numOtherSelects === TWO_OTHER_SELECTS,
+                    [styles.one]: numOtherSelects === ONE_OTHER_SELECT,
+                    [styles.none]: numOtherSelects === NO_OTHER_SELECTS,
+                })}
+                data-test="orgunit-dimension-container"
+            >
+                <OrgUnitDimension
+                    roots={roots?.map((r) => r.id)}
+                    selected={orgUnits}
+                    onSelect={setOrgUnitItems}
+                    hideUserOrgUnits={hideUserOrgUnits}
+                    hideLevelSelect={hideLevelSelect}
+                    hideGroupSelect={hideGroupSelect}
+                    warning={!hasOrgUnits ? warning : null}
+                />
+            </div>
             {!hideAssociatedGeometry && <AssociatedGeometrySelect />}
             {!hideSelectMode && <OrgUnitSelectMode />}
         </div>
@@ -118,7 +137,6 @@ OrgUnitSelect.propTypes = {
     hideUserOrgUnits: PropTypes.bool,
     selectDefaultLevel: PropTypes.bool,
     selectRoots: PropTypes.bool,
-    style: PropTypes.string,
     warning: PropTypes.string,
 }
 

--- a/src/components/orgunits/OrgUnitSelect.js
+++ b/src/components/orgunits/OrgUnitSelect.js
@@ -111,7 +111,6 @@ const OrgUnitSelect = ({
                     [styles.one]: numOtherSelects === ONE_OTHER_SELECT,
                     [styles.none]: numOtherSelects === NO_OTHER_SELECTS,
                 })}
-                data-test="orgunit-dimension-container"
             >
                 <OrgUnitDimension
                     roots={roots?.map((r) => r.id)}

--- a/src/components/orgunits/styles/OrgUnitSelect.module.css
+++ b/src/components/orgunits/styles/OrgUnitSelect.module.css
@@ -1,15 +1,21 @@
-.orgUnitSelect :global(.orgUnitTreeWrapper) {
-    max-height: 220px;
+.orgUnitSelect {
+    margin: 0 var(--spacers-dp16);
+    height: 100%;
 }
 
 .orgUnitSelect :global(.userOrgUnitsWrapper label) {
     margin-right: 34px;
 }
 
-.event :global(.orgUnitTreeWrapper),
-.trackedEntity :global(.orgUnitTreeWrapper) {
-    max-height: 315px;
-}   
+.two {
+    height: calc(100% - 108px);
+}
+.one {
+    height: calc(100% - 54px);
+}
+.none {
+    height: 100%;
+}
 
 .loader {
     position: absolute;

--- a/src/components/orgunits/styles/OrgUnitSelect.module.css
+++ b/src/components/orgunits/styles/OrgUnitSelect.module.css
@@ -8,10 +8,10 @@
 }
 
 .two {
-    height: calc(100% - 108px);
+    height: calc(100% - 110px);
 }
 .one {
-    height: calc(100% - 54px);
+    height: calc(100% - 56px);
 }
 .none {
     height: 100%;


### PR DESCRIPTION
Instead of overriding the orgUnitWrapper from the analytics lib (and passing in "style"), calculate the needed height based on how many additional selects are present. Removed the `flexRowFlow` class since it doesn't have any effect. 54px and 108px are the heights of 1 or 2 select fields (incl padding, border, margin)

![image](https://user-images.githubusercontent.com/6113918/220364053-3f752c63-8475-4b01-be00-bddb64edaffb.png)

![image](https://user-images.githubusercontent.com/6113918/220364160-826b10e9-cd67-40d9-84cc-cc53183ceb1a.png)


![image](https://user-images.githubusercontent.com/6113918/220364101-54a51832-be7a-479e-b8d3-55f5c1fca11e.png)

![image](https://user-images.githubusercontent.com/6113918/220364208-c901ef55-2fc2-4b6b-83a9-b9758caf0ae1.png)

![image](https://user-images.githubusercontent.com/6113918/220364245-2caab7bc-472e-42d2-8dcf-eedc8616c7cc.png)
![image](https://user-images.githubusercontent.com/6113918/220364306-a469dda4-7d2d-47ff-85f1-ac0c006f162d.png)




