### PR TITLE
fix: removed maps-gl dependency from util/geojson

### DIFF
--- a/src/components/map/layers/ThematicLayer.js
+++ b/src/components/map/layers/ThematicLayer.js
@@ -12,12 +12,22 @@ import {
 } from '../../../constants/layers.js'
 import { getPeriodFromFilters } from '../../../util/analytics.js'
 import { filterData } from '../../../util/filter.js'
-import { polygonsToPoints } from '../../../util/geojson.js'
 import { getLabelStyle } from '../../../util/labels.js'
 import Timeline from '../../periods/Timeline.js'
+import { poleOfInaccessibility } from '../MapApi.js'
 import PeriodName from '../PeriodName.js'
 import Popup from '../Popup.js'
 import Layer from './Layer.js'
+
+// Translating polygons to points using poleOfInaccessibility from maps-gl
+const polygonsToPoints = (features) =>
+    features.map((feature) => ({
+        ...feature,
+        geometry: {
+            type: 'Point',
+            coordinates: poleOfInaccessibility(feature.geometry),
+        },
+    }))
 
 class ThematicLayer extends Layer {
     createLayer() {

--- a/src/util/geojson.js
+++ b/src/util/geojson.js
@@ -1,6 +1,5 @@
 import FileSaver from 'file-saver' // https://github.com/eligrey/FileSaver.js
 import findIndex from 'lodash/findIndex'
-import { poleOfInaccessibility } from '../components/map/MapApi.js'
 import { isValidCoordinate } from './map.js'
 
 export const META_DATA_FORMAT_ID = 'ID'
@@ -157,19 +156,3 @@ export const getBounds = (bbox) => {
         [extent[2], extent[3]],
     ]
 }
-
-// Translating polygons to points using poleOfInaccessibility from maps-gl
-export const polygonsToPoints = (features) =>
-    features.map((feature) => ({
-        ...feature,
-        geometry: {
-            type: 'Point',
-            coordinates: poleOfInaccessibility(feature.geometry),
-        },
-    }))
-
-// export const downloadStyle = name => {
-//     const sld = createSld(); // TODO: Make generic
-//     const blob = new Blob([sld], { type: 'application/xml;charset=utf-8' });
-//     FileSaver.saveAs(blob, standardizeFilename(name) + '.sld');
-// };


### PR DESCRIPTION
The jest test are fragile when refactoring because of the maps-gl dependency in util/geojson. The function depending on maps-gl is only used in the ThematicLayer, so the function is moved to that file instead.