### PR TITLE
chore: set default org unit level and roots

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "profile": "yarn start --profile",
     "extract-pot": "d2-i18n-extract -p src/ -o i18n/",
     "localize": "yarn extract-pot && d2-i18n-generate -n default -p ./i18n/ -o ./src/locales/",
-    "analyze-bundle": "webpack --profile --json --progress > .webpack-profile.json && webpack-bundle-analyzer .webpack-profile.json",
-    "validate": "npm ls"
+    "analyze-bundle": "webpack --profile --json --progress > .webpack-profile.json && webpack-bundle-analyzer .webpack-profile.json"
   },
   "dependencies": {
     "@dhis2/analytics": "^24.9.0",
@@ -128,10 +127,5 @@
         "href": ".."
       }
     }
-  },
-  "pre-commit": [
-    "lint",
-    "validate",
-    "test"
-  ]
+  }
 }

--- a/src/components/OrgUnitsProvider.js
+++ b/src/components/OrgUnitsProvider.js
@@ -1,0 +1,51 @@
+import { useDataEngine } from '@dhis2/app-runtime'
+import PropTypes from 'prop-types'
+import React, { useContext, useState, useEffect, createContext } from 'react'
+
+// Fetches the root org units associated with the current user with fallback to data capture org units
+const ORG_UNITS_QUERY = {
+    roots: {
+        resource: 'organisationUnits',
+        params: () => ({
+            fields: ['id', 'displayName~rename(name)', 'path'],
+            userDataViewFallback: true,
+        }),
+    },
+    levels: {
+        resource: 'organisationUnitLevels',
+        params: {
+            fields: ['id', 'displayName~rename(name)', 'level'],
+            order: 'level:asc',
+            paging: false,
+        },
+    },
+}
+
+export const OrgUnitsCtx = createContext({})
+
+const OrgUnitsProvider = ({ children }) => {
+    const [orgUnits, setOrgUnits] = useState({})
+    const engine = useDataEngine()
+
+    useEffect(() => {
+        engine.query(ORG_UNITS_QUERY, {
+            onComplete: ({ levels, roots }) =>
+                setOrgUnits({
+                    levels: levels.organisationUnitLevels,
+                    roots: roots.organisationUnits,
+                }),
+        })
+    }, [engine])
+
+    return (
+        <OrgUnitsCtx.Provider value={orgUnits}>{children}</OrgUnitsCtx.Provider>
+    )
+}
+
+OrgUnitsProvider.propTypes = {
+    children: PropTypes.node,
+}
+
+export default OrgUnitsProvider
+
+export const useOrgUnits = () => useContext(OrgUnitsCtx)

--- a/src/components/OrgUnitsProvider.js
+++ b/src/components/OrgUnitsProvider.js
@@ -24,7 +24,8 @@ const ORG_UNITS_QUERY = {
 export const OrgUnitsCtx = createContext({})
 
 const OrgUnitsProvider = ({ children }) => {
-    const [orgUnits, setOrgUnits] = useState({})
+    const [orgUnits, setOrgUnits] = useState()
+    const [error, setError] = useState()
     const engine = useDataEngine()
 
     useEffect(() => {
@@ -34,11 +35,20 @@ const OrgUnitsProvider = ({ children }) => {
                     levels: levels.organisationUnitLevels,
                     roots: roots.organisationUnits,
                 }),
+            onError: setError,
         })
     }, [engine])
 
     return (
-        <OrgUnitsCtx.Provider value={orgUnits}>{children}</OrgUnitsCtx.Provider>
+        <OrgUnitsCtx.Provider
+            value={{
+                ...orgUnits,
+                loading: !orgUnits,
+                error,
+            }}
+        >
+            {children}
+        </OrgUnitsCtx.Provider>
     )
 }
 

--- a/src/components/OrgUnitsProvider.js
+++ b/src/components/OrgUnitsProvider.js
@@ -43,7 +43,7 @@ const OrgUnitsProvider = ({ children }) => {
         <OrgUnitsCtx.Provider
             value={{
                 ...orgUnits,
-                loading: !orgUnits,
+                loading: !orgUnits && !error,
                 error,
             }}
         >

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -10,6 +10,7 @@ import { apiVersion } from '../constants/settings.js'
 import i18n from '../locales/index.js'
 import { NAMESPACE } from '../util/analyticalObject.js'
 import App from './app/App.js'
+import OrgUnitsProvider from './OrgUnitsProvider.js'
 import SystemSettingsProvider from './SystemSettingsProvider.js'
 import UserSettingsProvider, {
     UserSettingsCtx,
@@ -37,58 +38,66 @@ const d2Config = {
     ],
 }
 
-const Root = ({ store }) => (
-    <DataProvider
-        config={{
-            baseUrl: process.env.DHIS2_BASE_URL,
-            apiVersion,
-        }}
-    >
-        <ReduxProvider store={store}>
-            <D2Shim d2Config={d2Config} i18nRoot="./i18n_old">
-                {({ d2, d2Error }) => {
-                    if (!d2 && !d2Error) {
-                        return (
-                            <div
-                                style={{
-                                    position: 'absolute',
-                                    width: '100%',
-                                    height: '100%',
-                                    top: 0,
-                                }}
-                            >
-                                <CenteredContent>
-                                    <CircularLoader />
-                                </CenteredContent>
-                            </div>
-                        )
-                    }
+const Root = ({ store }) => {
+    return (
+        <DataProvider
+            config={{
+                baseUrl: process.env.DHIS2_BASE_URL,
+                apiVersion,
+            }}
+        >
+            <ReduxProvider store={store}>
+                <D2Shim d2Config={d2Config} i18nRoot="./i18n_old">
+                    {({ d2, d2Error }) => {
+                        if (!d2 && !d2Error) {
+                            return (
+                                <div
+                                    style={{
+                                        position: 'absolute',
+                                        width: '100%',
+                                        height: '100%',
+                                        top: 0,
+                                    }}
+                                >
+                                    <CenteredContent>
+                                        <CircularLoader />
+                                    </CenteredContent>
+                                </div>
+                            )
+                        }
 
-                    return (
-                        <DataStoreProvider namespace={NAMESPACE}>
-                            <WindowDimensionsProvider>
-                                <SystemSettingsProvider>
-                                    <UserSettingsProvider>
-                                        <UserSettingsCtx.Consumer>
-                                            {({ keyUiLocale }) => {
-                                                if (!keyUiLocale) {
-                                                    return null
-                                                }
-                                                i18n.changeLanguage(keyUiLocale)
-                                                moment.locale(keyUiLocale)
-                                                return <App />
-                                            }}
-                                        </UserSettingsCtx.Consumer>
-                                    </UserSettingsProvider>
-                                </SystemSettingsProvider>
-                            </WindowDimensionsProvider>
-                        </DataStoreProvider>
-                    )
-                }}
-            </D2Shim>
-        </ReduxProvider>
-    </DataProvider>
-)
+                        return (
+                            <DataStoreProvider namespace={NAMESPACE}>
+                                <WindowDimensionsProvider>
+                                    <OrgUnitsProvider>
+                                        <SystemSettingsProvider>
+                                            <UserSettingsProvider>
+                                                <UserSettingsCtx.Consumer>
+                                                    {({ keyUiLocale }) => {
+                                                        if (!keyUiLocale) {
+                                                            return null
+                                                        }
+                                                        i18n.changeLanguage(
+                                                            keyUiLocale
+                                                        )
+                                                        moment.locale(
+                                                            keyUiLocale
+                                                        )
+                                                        return <App />
+                                                    }}
+                                                </UserSettingsCtx.Consumer>
+                                            </UserSettingsProvider>
+                                        </SystemSettingsProvider>
+                                    </OrgUnitsProvider>
+                                </WindowDimensionsProvider>
+                            </DataStoreProvider>
+                        )
+                    }}
+                </D2Shim>
+            </ReduxProvider>
+        </DataProvider>
+    )
+}
 
 Root.propTypes = {
     store: PropTypes.object.isRequired,

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -38,66 +38,62 @@ const d2Config = {
     ],
 }
 
-const Root = ({ store }) => {
-    return (
-        <DataProvider
-            config={{
-                baseUrl: process.env.DHIS2_BASE_URL,
-                apiVersion,
-            }}
-        >
-            <ReduxProvider store={store}>
-                <D2Shim d2Config={d2Config} i18nRoot="./i18n_old">
-                    {({ d2, d2Error }) => {
-                        if (!d2 && !d2Error) {
-                            return (
-                                <div
-                                    style={{
-                                        position: 'absolute',
-                                        width: '100%',
-                                        height: '100%',
-                                        top: 0,
-                                    }}
-                                >
-                                    <CenteredContent>
-                                        <CircularLoader />
-                                    </CenteredContent>
-                                </div>
-                            )
-                        }
-
+const Root = ({ store }) => (
+    <DataProvider
+        config={{
+            baseUrl: process.env.DHIS2_BASE_URL,
+            apiVersion,
+        }}
+    >
+        <ReduxProvider store={store}>
+            <D2Shim d2Config={d2Config} i18nRoot="./i18n_old">
+                {({ d2, d2Error }) => {
+                    if (!d2 && !d2Error) {
                         return (
-                            <DataStoreProvider namespace={NAMESPACE}>
-                                <WindowDimensionsProvider>
-                                    <OrgUnitsProvider>
-                                        <SystemSettingsProvider>
-                                            <UserSettingsProvider>
-                                                <UserSettingsCtx.Consumer>
-                                                    {({ keyUiLocale }) => {
-                                                        if (!keyUiLocale) {
-                                                            return null
-                                                        }
-                                                        i18n.changeLanguage(
-                                                            keyUiLocale
-                                                        )
-                                                        moment.locale(
-                                                            keyUiLocale
-                                                        )
-                                                        return <App />
-                                                    }}
-                                                </UserSettingsCtx.Consumer>
-                                            </UserSettingsProvider>
-                                        </SystemSettingsProvider>
-                                    </OrgUnitsProvider>
-                                </WindowDimensionsProvider>
-                            </DataStoreProvider>
+                            <div
+                                style={{
+                                    position: 'absolute',
+                                    width: '100%',
+                                    height: '100%',
+                                    top: 0,
+                                }}
+                            >
+                                <CenteredContent>
+                                    <CircularLoader />
+                                </CenteredContent>
+                            </div>
                         )
-                    }}
-                </D2Shim>
-            </ReduxProvider>
-        </DataProvider>
-    )
-}
+                    }
+
+                    return (
+                        <DataStoreProvider namespace={NAMESPACE}>
+                            <WindowDimensionsProvider>
+                                <OrgUnitsProvider>
+                                    <SystemSettingsProvider>
+                                        <UserSettingsProvider>
+                                            <UserSettingsCtx.Consumer>
+                                                {({ keyUiLocale }) => {
+                                                    if (!keyUiLocale) {
+                                                        return null
+                                                    }
+                                                    i18n.changeLanguage(
+                                                        keyUiLocale
+                                                    )
+                                                    moment.locale(keyUiLocale)
+                                                    return <App />
+                                                }}
+                                            </UserSettingsCtx.Consumer>
+                                        </UserSettingsProvider>
+                                    </SystemSettingsProvider>
+                                </OrgUnitsProvider>
+                            </WindowDimensionsProvider>
+                        </DataStoreProvider>
+                    )
+                }}
+            </D2Shim>
+        </ReduxProvider>
+    </DataProvider>
+)
 
 Root.propTypes = {
     store: PropTypes.object.isRequired,

--- a/src/components/edit/LayerEdit.js
+++ b/src/components/edit/LayerEdit.js
@@ -17,6 +17,7 @@ import {
     setLayerLoading,
 } from '../../actions/layers.js'
 import { EARTH_ENGINE_LAYER } from '../../constants/layers.js'
+import { useOrgUnits } from '../OrgUnitsProvider.js'
 import { useSystemSettings } from '../SystemSettingsProvider.js'
 import EarthEngineDialog from './earthEngine/EarthEngineDialog.js'
 import EventDialog from './event/EventDialog.js'
@@ -53,6 +54,7 @@ const LayerEdit = ({
 }) => {
     const [isValidLayer, setIsValidLayer] = useState(false)
     const { keyAnalysisRelativePeriod } = useSystemSettings()
+    const orgUnits = useOrgUnits()
 
     const onValidateLayer = () => setIsValidLayer(true)
 
@@ -108,6 +110,7 @@ const LayerEdit = ({
                     <LayerDialog
                         {...layer}
                         defaultPeriod={keyAnalysisRelativePeriod}
+                        orgUnits={orgUnits}
                         validateLayer={isValidLayer}
                         onLayerValidation={onLayerValidation}
                     />

--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -3,9 +3,17 @@ import { NoticeBox } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useState, useEffect, useCallback } from 'react'
 import { connect } from 'react-redux'
-import { setFilter, setBufferRadius } from '../../../actions/layerEdit.js'
+import {
+    setOrgUnits,
+    setFilter,
+    setBufferRadius,
+} from '../../../actions/layerEdit.js'
 import { getEarthEngineLayer } from '../../../constants/earthEngine.js'
-import { EE_BUFFER, NONE } from '../../../constants/layers.js'
+import {
+    DEFAULT_ORG_UNIT_LEVEL,
+    EE_BUFFER,
+    NONE,
+} from '../../../constants/layers.js'
 import {
     getPeriodFromFilter,
     getPeriods,
@@ -27,9 +35,12 @@ const EarthEngineDialog = (props) => {
     const {
         datasetId,
         band,
+        rows,
         params,
         filter,
         areaRadius,
+        orgUnits,
+        setOrgUnits,
         orgUnitField,
         setFilter,
         setBufferRadius,
@@ -94,6 +105,20 @@ const EarthEngineDialog = (props) => {
             }
         }
     }, [periods, filter, setPeriod])
+
+    // Set default org unit level
+    useEffect(() => {
+        if (!rows) {
+            const defaultLevel = orgUnits.levels?.[DEFAULT_ORG_UNIT_LEVEL]
+
+            if (defaultLevel) {
+                setOrgUnits({
+                    dimension: 'ou',
+                    items: [{ id: `LEVEL-${defaultLevel.id}` }],
+                })
+            }
+        }
+    }, [rows, orgUnits, setOrgUnits])
 
     useEffect(() => {
         if (!hasOrgUnitField && areaRadius === undefined) {
@@ -208,9 +233,7 @@ const EarthEngineDialog = (props) => {
                         className={styles.flexRowFlow}
                     />
                 )}
-                {tab === 'orgunits' && (
-                    <OrgUnitSelect selectDefaultLevel={true} />
-                )}
+                {tab === 'orgunits' && <OrgUnitSelect />}
                 {tab === 'style' && (
                     <StyleTab
                         unit={unit}
@@ -227,6 +250,7 @@ EarthEngineDialog.propTypes = {
     datasetId: PropTypes.string.isRequired,
     setBufferRadius: PropTypes.func.isRequired,
     setFilter: PropTypes.func.isRequired,
+    setOrgUnits: PropTypes.func.isRequired,
     validateLayer: PropTypes.bool.isRequired,
     onLayerValidation: PropTypes.func.isRequired,
     areaRadius: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -234,6 +258,7 @@ EarthEngineDialog.propTypes = {
     filter: PropTypes.array,
     legend: PropTypes.object,
     orgUnitField: PropTypes.string,
+    orgUnits: PropTypes.object,
     params: PropTypes.shape({
         max: PropTypes.number.isRequired,
         min: PropTypes.number.isRequired,
@@ -242,6 +267,11 @@ EarthEngineDialog.propTypes = {
     rows: PropTypes.array,
 }
 
-export default connect(null, { setFilter, setBufferRadius }, null, {
-    forwardRef: true,
-})(EarthEngineDialog)
+export default connect(
+    null,
+    { setOrgUnits, setFilter, setBufferRadius },
+    null,
+    {
+        forwardRef: true,
+    }
+)(EarthEngineDialog)

--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -140,12 +140,10 @@ class EventDialog extends Component {
 
         // Set org unit tree roots as default
         if (!rows && orgUnits.roots) {
-            if (orgUnits.roots) {
-                setOrgUnits({
-                    dimension: 'ou',
-                    items: orgUnits.roots,
-                })
-            }
+            setOrgUnits({
+                dimension: 'ou',
+                items: orgUnits.roots,
+            })
         }
     }
 

--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -14,6 +14,7 @@ import {
     setPeriod,
     setStartDate,
     setEndDate,
+    setOrgUnits,
 } from '../../../actions/layerEdit.js'
 import {
     DEFAULT_START_DATE,
@@ -61,6 +62,7 @@ class EventDialog extends Component {
         setEventPointColor: PropTypes.func.isRequired,
         setEventPointRadius: PropTypes.func.isRequired,
         setEventStatus: PropTypes.func.isRequired,
+        setOrgUnits: PropTypes.func.isRequired,
         setPeriod: PropTypes.func.isRequired,
         setProgram: PropTypes.func.isRequired,
         setProgramStage: PropTypes.func.isRequired,
@@ -78,6 +80,7 @@ class EventDialog extends Component {
         filters: PropTypes.array,
         legendSet: PropTypes.object,
         method: PropTypes.number,
+        orgUnits: PropTypes.object,
         program: PropTypes.shape({
             id: PropTypes.string.isRequired,
         }),
@@ -104,14 +107,17 @@ class EventDialog extends Component {
 
     componentDidMount() {
         const {
+            rows,
             filters,
             defaultPeriod,
             settings,
             startDate,
             endDate,
+            orgUnits,
             setPeriod,
             setStartDate,
             setEndDate,
+            setOrgUnits,
         } = this.props
 
         const period = getPeriodFromFilters(filters)
@@ -130,6 +136,16 @@ class EventDialog extends Component {
         } else if (!startDate && !endDate) {
             setStartDate(DEFAULT_START_DATE)
             setEndDate(DEFAULT_END_DATE)
+        }
+
+        // Set org unit tree roots as default
+        if (!rows && orgUnits.roots) {
+            if (orgUnits.roots) {
+                setOrgUnits({
+                    dimension: 'ou',
+                    items: orgUnits.roots,
+                })
+            }
         }
     }
 
@@ -253,7 +269,6 @@ class EventDialog extends Component {
                     )}
                     {tab === 'orgunits' && (
                         <OrgUnitSelect
-                            selectRoots={true}
                             hideAssociatedGeometry={true}
                             hideLevelSelect={true}
                             hideGroupSelect={true}
@@ -445,6 +460,7 @@ export default connect(
         setPeriod,
         setStartDate,
         setEndDate,
+        setOrgUnits,
     },
     null,
     {

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -10,6 +10,7 @@ import {
     setLegendSet,
     setNoDataColor,
     setOperand,
+    setOrgUnits,
     setPeriod,
     setPeriodType,
     setRenderingStrategy,
@@ -18,6 +19,7 @@ import {
 } from '../../../actions/layerEdit.js'
 import { dimConf } from '../../../constants/dimension.js'
 import {
+    DEFAULT_ORG_UNIT_LEVEL,
     CLASSIFICATION_PREDEFINED,
     CLASSIFICATION_EQUAL_INTERVALS,
 } from '../../../constants/layers.js'
@@ -71,6 +73,7 @@ class ThematicDialog extends Component {
         setLegendSet: PropTypes.func.isRequired,
         setNoDataColor: PropTypes.func.isRequired,
         setOperand: PropTypes.func.isRequired,
+        setOrgUnits: PropTypes.func.isRequired,
         setPeriod: PropTypes.func.isRequired,
         setPeriodType: PropTypes.func.isRequired,
         setProgram: PropTypes.func.isRequired,
@@ -90,6 +93,7 @@ class ThematicDialog extends Component {
         method: PropTypes.number,
         noDataColor: PropTypes.string,
         operand: PropTypes.bool,
+        orgUnits: PropTypes.object,
         periodType: PropTypes.string,
         program: PropTypes.object,
         radiusHigh: PropTypes.number,
@@ -109,13 +113,16 @@ class ThematicDialog extends Component {
         const {
             valueType,
             columns,
+            rows,
             filters,
             defaultPeriod,
+            orgUnits,
             setValueType,
             startDate,
             settings,
             endDate,
             setPeriod,
+            setOrgUnits,
         } = this.props
 
         const dataItem = getDataItemFromColumns(columns)
@@ -148,6 +155,18 @@ class ThematicDialog extends Component {
             setPeriod({
                 id: defaultPeriod,
             })
+        }
+
+        // Set default org unit level
+        if (!rows) {
+            const defaultLevel = orgUnits.levels?.[DEFAULT_ORG_UNIT_LEVEL]
+
+            if (defaultLevel) {
+                setOrgUnits({
+                    dimension: 'ou',
+                    items: [{ id: `LEVEL-${defaultLevel.id}` }],
+                })
+            }
         }
     }
 
@@ -431,10 +450,7 @@ class ThematicDialog extends Component {
                         </div>
                     )}
                     {tab === 'orgunits' && (
-                        <OrgUnitSelect
-                            selectDefaultLevel={true}
-                            warning={orgUnitsError}
-                        />
+                        <OrgUnitSelect warning={orgUnitsError} />
                     )}
                     {tab === 'filter' && (
                         <div
@@ -635,6 +651,7 @@ export default connect(
         setLegendSet,
         setNoDataColor,
         setOperand,
+        setOrgUnits,
         setPeriod,
         setPeriodType,
         setRenderingStrategy,

--- a/src/components/edit/trackedEntity/TrackedEntityDialog.js
+++ b/src/components/edit/trackedEntity/TrackedEntityDialog.js
@@ -13,6 +13,7 @@ import {
     setTrackedEntityRelationshipOutsideProgram,
     setStartDate,
     setEndDate,
+    setOrgUnits,
     setEventPointColor,
     setEventPointRadius,
     setRelatedPointColor,
@@ -57,6 +58,7 @@ class TrackedEntityDialog extends Component {
         setEventPointColor: PropTypes.func.isRequired,
         setEventPointRadius: PropTypes.func.isRequired,
         setFollowUpStatus: PropTypes.func.isRequired,
+        setOrgUnits: PropTypes.func.isRequired,
         setProgram: PropTypes.func.isRequired,
         setProgramStatus: PropTypes.func.isRequired,
         setRelatedPointColor: PropTypes.func.isRequired,
@@ -71,6 +73,7 @@ class TrackedEntityDialog extends Component {
         eventPointColor: PropTypes.string,
         eventPointRadius: PropTypes.number,
         followUp: PropTypes.bool,
+        orgUnits: PropTypes.object,
         program: PropTypes.object,
         programStatus: PropTypes.string,
         relatedPointColor: PropTypes.string,
@@ -92,11 +95,14 @@ class TrackedEntityDialog extends Component {
 
     componentDidMount() {
         const {
+            rows,
             startDate,
             endDate,
             relationshipType,
+            orgUnits,
             setStartDate,
             setEndDate,
+            setOrgUnits,
         } = this.props
 
         // Set default period (last year)
@@ -109,6 +115,16 @@ class TrackedEntityDialog extends Component {
             this.setState({
                 showRelationshipsChecked: true,
             })
+        }
+
+        // Set org unit tree roots as default
+        if (!rows && orgUnits.roots) {
+            if (orgUnits.roots) {
+                setOrgUnits({
+                    dimension: 'ou',
+                    items: orgUnits.roots,
+                })
+            }
         }
     }
 
@@ -269,7 +285,6 @@ class TrackedEntityDialog extends Component {
                     )}
                     {tab === 'orgunits' && (
                         <OrgUnitSelect
-                            selectRoots={true}
                             hideUserOrgUnits={true}
                             hideAssociatedGeometry={true}
                             hideSelectMode={false}
@@ -408,6 +423,7 @@ export default connect(
         setTrackedEntityRelationshipOutsideProgram,
         setStartDate,
         setEndDate,
+        setOrgUnits,
         setEventPointColor,
         setEventPointRadius,
         setRelatedPointColor,

--- a/src/components/edit/trackedEntity/TrackedEntityDialog.js
+++ b/src/components/edit/trackedEntity/TrackedEntityDialog.js
@@ -119,12 +119,10 @@ class TrackedEntityDialog extends Component {
 
         // Set org unit tree roots as default
         if (!rows && orgUnits.roots) {
-            if (orgUnits.roots) {
-                setOrgUnits({
-                    dimension: 'ou',
-                    items: orgUnits.roots,
-                })
-            }
+            setOrgUnits({
+                dimension: 'ou',
+                items: orgUnits.roots,
+            })
         }
     }
 

--- a/src/components/orgunits/OrgUnitSelect.js
+++ b/src/components/orgunits/OrgUnitSelect.js
@@ -3,16 +3,16 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import { CenteredContent, CircularLoader, Help } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { useCallback, useEffect } from 'react'
+import React, { useCallback } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { setOrgUnits } from '../../actions/layerEdit.js'
-import { DEFAULT_ORG_UNIT_LEVEL } from '../../constants/layers.js'
 import { translateOrgUnitLevels } from '../../util/orgUnits.js'
 import AssociatedGeometrySelect from './AssociatedGeometrySelect.js'
 import OrgUnitSelectMode from './OrgUnitSelectMode.js'
 import styles from './styles/OrgUnitSelect.module.css'
 
-// Fetches the root org units associated with the current user with fallback to data capture org units
+// Fetches org unit levels and the root org units associated with the current user
+// with fallback to data capture org units
 const ORG_UNIT_TREE_QUERY = {
     tree: {
         resource: 'organisationUnits',
@@ -41,8 +41,6 @@ const OrgUnitSelect = ({
     hideSelectMode = true,
     hideLevelSelect = false,
     hideGroupSelect = false,
-    selectDefaultLevel = false,
-    selectRoots = false,
     warning,
 }) => {
     const { loading, data, error } = useDataQuery(ORG_UNIT_TREE_QUERY)
@@ -62,27 +60,12 @@ const OrgUnitSelect = ({
 
     const roots = data?.tree.organisationUnits
     const orgUnitLevels = data?.levels.organisationUnitLevels
-    const defaultLevel = orgUnitLevels?.[DEFAULT_ORG_UNIT_LEVEL]
 
     const orgUnits = translateOrgUnitLevels(
         rows?.find((r) => r.dimension === 'ou'),
         orgUnitLevels
     )
     const hasOrgUnits = !!orgUnits.length
-
-    useEffect(() => {
-        if (!rows && !hasOrgUnits && selectRoots && roots) {
-            setOrgUnitItems({
-                items: roots,
-            })
-        }
-    }, [rows, selectRoots, roots, hasOrgUnits, setOrgUnitItems])
-
-    useEffect(() => {
-        if (!rows && !hasOrgUnits && selectDefaultLevel && defaultLevel) {
-            setOrgUnitItems({ items: [{ id: `LEVEL-${defaultLevel.id}` }] })
-        }
-    }, [rows, selectDefaultLevel, defaultLevel, hasOrgUnits, setOrgUnitItems])
 
     if (loading) {
         return (
@@ -134,8 +117,6 @@ OrgUnitSelect.propTypes = {
     hideLevelSelect: PropTypes.bool,
     hideSelectMode: PropTypes.bool,
     hideUserOrgUnits: PropTypes.bool,
-    selectDefaultLevel: PropTypes.bool,
-    selectRoots: PropTypes.bool,
     warning: PropTypes.string,
 }
 

--- a/src/components/orgunits/OrgUnitSelect.js
+++ b/src/components/orgunits/OrgUnitSelect.js
@@ -1,4 +1,5 @@
 import { OrgUnitDimension } from '@dhis2/analytics'
+import { CenteredContent, CircularLoader, Help } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useCallback } from 'react'
@@ -22,7 +23,7 @@ const OrgUnitSelect = ({
     hideGroupSelect = false,
     warning,
 }) => {
-    const { roots, levels } = useOrgUnits()
+    const { roots, levels, loading, error } = useOrgUnits()
     const rows = useSelector((state) => state.layerEdit.rows)
     const dispatch = useDispatch()
 
@@ -42,6 +43,22 @@ const OrgUnitSelect = ({
         levels
     )
     const hasOrgUnits = !!orgUnits.length
+
+    if (loading) {
+        return (
+            <div className={styles.loader}>
+                <CenteredContent>
+                    <CircularLoader />
+                </CenteredContent>
+            </div>
+        )
+    } else if (error?.message) {
+        return (
+            <div className={styles.orgUnitSelect}>
+                <Help error>{error.message}</Help>
+            </div>
+        )
+    }
 
     const numOtherSelects =
         !hideAssociatedGeometry && !hideSelectMode

--- a/src/components/orgunits/OrgUnitSelect.js
+++ b/src/components/orgunits/OrgUnitSelect.js
@@ -44,18 +44,18 @@ const OrgUnitSelect = ({
     )
     const hasOrgUnits = !!orgUnits.length
 
-    if (loading) {
+    if (error?.message) {
+        return (
+            <div className={styles.orgUnitSelect}>
+                <Help error>{error.message}</Help>
+            </div>
+        )
+    } else if (loading) {
         return (
             <div className={styles.loader}>
                 <CenteredContent>
                     <CircularLoader />
                 </CenteredContent>
-            </div>
-        )
-    } else if (error?.message) {
-        return (
-            <div className={styles.orgUnitSelect}>
-                <Help error>{error.message}</Help>
             </div>
         )
     }


### PR DESCRIPTION
This PR is partly a revert of https://github.com/dhis2/maps-app/pull/2459

In #2459 we set the default org units in the new OrgUnitSelect component. The problem with this approach is the users needs to visit the Org unit tab in the layer dialog before the default value is set. We would like users to create new layers with minimal number of clicks, and in this PR we set the default Org units when the layer dialog is opened (like previously).

A new OrgUnitsProvider component was created to only fetch the default values once. 

After this PR: 

Thematic layer with default org unit level selected: 
![Screenshot 2023-02-27 at 20 43 04](https://user-images.githubusercontent.com/548708/221666610-48d73e28-853c-4fc4-a131-7cbf975d5a84.png)

Earth Engine layer with default org unit level selected: 
![Screenshot 2023-02-27 at 20 44 28](https://user-images.githubusercontent.com/548708/221666829-a031a3b8-9cfd-4024-bcc6-1bd6aceb9725.png)

Event layer with the org unit root selected:
![Screenshot 2023-02-27 at 20 45 30](https://user-images.githubusercontent.com/548708/221667008-13499565-4b0a-4491-9a92-68f9709a9dbd.png)

Tracked entity layer with the org unit root selected:
![Screenshot 2023-02-27 at 20 46 20](https://user-images.githubusercontent.com/548708/221667180-653f2c7b-5653-41d6-979d-945cf39db4ee.png)
