### PR TITLE
fix: include path in org unit dimension items (DHIS2-14850)

### DIFF
--- a/src/util/favorites.js
+++ b/src/util/favorites.js
@@ -89,6 +89,7 @@ const models = ['program', 'programStage', 'organisationUnitGroupSet']
 const validModelProperties = [
     'id',
     'name',
+    'path',
     'dimensionType',
     'dimensionItemType',
 ]


### PR DESCRIPTION
This PR will include path for all org unit dimension items to avoid a crash in the org unit modal in DV. 

Fixes: https://dhis2.atlassian.net/browse/DHIS2-14850