### PR TITLE
fix: include path in org unit dimension items (DHIS2-14850, 2.38 backport)

### DIFF
--- a/src/util/favorites.js
+++ b/src/util/favorites.js
@@ -85,6 +85,7 @@ const models = ['program', 'programStage', 'organisationUnitGroupSet'];
 const validModelProperties = [
     'id',
     'name',
+    'path',
     'dimensionType',
     'dimensionItemType',
 ];


### PR DESCRIPTION
This PR will include path for all org unit dimension items to avoid a crash in the org unit modal in DV.

Fixes for 2.38: https://dhis2.atlassian.net/browse/DHIS2-14850

Backport of https://github.com/dhis2/maps-app/pull/2502