### PR TITLE
fix: DHIS2 Maps UI fixes for 2.40 release

### DIFF
--- a/src/components/app/styles/App.module.css
+++ b/src/components/app/styles/App.module.css
@@ -8,6 +8,12 @@
     isolation: isolate;
 }
 
+/* Avoid vertical layer dialog scroll on small screens */
+:global(#dhis2-portal-root) aside[role=dialog],
+:global(#dhis2-portal-root) aside[role=dialog] > div > div {
+    max-height: calc(100vh - 64px)
+}
+
 .app {
     font-family: 'Roboto', sans-serif;
     height: 100vh;


### PR DESCRIPTION

Avoid vertical scroll in layer dialogs

After this PR: 
<img width="268" alt="Screenshot 2023-02-28 at 17 14 01" src="https://user-images.githubusercontent.com/548708/221913001-9dcc2fe6-6403-4fca-bd05-f922ab0496e7.png">

Before: 
<img width="1438" alt="Screenshot 2023-02-28 at 17 14 16" src="https://user-images.githubusercontent.com/548708/221913079-898c9ec9-2dfa-439a-8d00-822a814ce670.png">

