### PR TITLE
fix: include name in default org unit level

### DIFF
--- a/src/components/edit/FacilityDialog.js
+++ b/src/components/edit/FacilityDialog.js
@@ -74,10 +74,12 @@ const FacilityDialog = ({
         if (!id) {
             // Set default org unit level
             if (facilityOrgUnitLevel) {
+                const { id, name } = facilityOrgUnitLevel
+
                 dispatch(
                     setOrgUnits({
                         dimension: 'ou',
-                        items: [{ id: `LEVEL-${facilityOrgUnitLevel.id}` }],
+                        items: [{ id: `LEVEL-${id}`, name }],
                     })
                 )
             }

--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -112,9 +112,11 @@ const EarthEngineDialog = (props) => {
             const defaultLevel = orgUnits.levels?.[DEFAULT_ORG_UNIT_LEVEL]
 
             if (defaultLevel) {
+                const { id, name } = defaultLevel
+
                 setOrgUnits({
                     dimension: 'ou',
-                    items: [{ id: `LEVEL-${defaultLevel.id}` }],
+                    items: [{ id: `LEVEL-${id}`, name }],
                 })
             }
         }

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -162,9 +162,11 @@ class ThematicDialog extends Component {
             const defaultLevel = orgUnits.levels?.[DEFAULT_ORG_UNIT_LEVEL]
 
             if (defaultLevel) {
+                const { id, name } = defaultLevel
+
                 setOrgUnits({
                     dimension: 'ou',
-                    items: [{ id: `LEVEL-${defaultLevel.id}` }],
+                    items: [{ id: `LEVEL-${id}`, name }],
                 })
             }
         }

--- a/src/util/orgUnits.js
+++ b/src/util/orgUnits.js
@@ -213,9 +213,8 @@ export const translateOrgUnitLevels = (orgUnits, orgUnitLevels = []) => {
             )
 
             if (level) {
-                return {
-                    id: `LEVEL-${level.id}`,
-                }
+                const { id, name } = level
+                return { id: `LEVEL-${id}`, name }
             }
         }
 


### PR DESCRIPTION
This PR will include `name` when setting the default org unit level. `name` is a required prop for `OrgUnitDimension` component in `@dhis2/analytics`.