### PR TITLE
fix: only show legends for visible layers, fix info icon alignment

### DIFF
--- a/src/components/core/styles/Checkbox.module.css
+++ b/src/components/core/styles/Checkbox.module.css
@@ -1,12 +1,12 @@
 .checkbox {
     margin: var(--spacers-dp12) 0 var(--spacers-dp8);
+    display: flex;
+    align-items: center;
 }
 
-.checkbox label {
-    display: inline-flex!important;
-}
-
+/* This styles the tooltip span containing the svg */
 .checkbox span {
-    margin-left: var(--spacers-dp8);
-    vertical-align: text-bottom;
+    margin-left: var(--spacers-dp4);
+    display:flex;
+    flex-direction: column;
 }

--- a/src/components/download/DownloadSettings.js
+++ b/src/components/download/DownloadSettings.js
@@ -30,7 +30,7 @@ const DownloadSettings = () => {
     } = useSelector((state) => state.download)
 
     const legendLayers = useMemo(
-        () => mapViews.filter((layer) => layer.legend),
+        () => mapViews.filter((layer) => layer.legend && layer.isVisible),
         [mapViews]
     )
 


### PR DESCRIPTION
Info icon alignment:
<img width="305" alt="image" src="https://user-images.githubusercontent.com/6113918/224717457-2fd4ffe9-84eb-4ae6-af2a-66351d5a917f.png">


Legend visibility:
Layers:
<img width="279" alt="image" src="https://user-images.githubusercontent.com/6113918/224717803-62397bf1-c175-4390-83be-32760736182d.png">

Download:
<img width="286" alt="image" src="https://user-images.githubusercontent.com/6113918/224717891-be79e424-f41d-4090-a2d1-4ae8a4711ae9.png">


