### PR TITLE
fix: issues found during team testing of 2.40 release

### DIFF
--- a/src/components/app/FileMenu.js
+++ b/src/components/app/FileMenu.js
@@ -34,7 +34,7 @@ const saveAsNewMapMutation = {
     data: ({ data }) => data,
 }
 
-const getMapName = (name) =>
+export const getMapName = (name) =>
     name ||
     i18n.t('Untitled map, {{date}}', {
         date: new Date().toLocaleDateString(undefined, {

--- a/src/components/download/DownloadSettings.js
+++ b/src/components/download/DownloadSettings.js
@@ -47,7 +47,7 @@ const DownloadSettings = () => {
             mapEl = mapEl.parentNode
         }
 
-        downloadMapImage(mapEl, filename).then(onClose).catch(setError)
+        downloadMapImage(mapEl, filename).catch(setError)
     }, [name, includeMargins, onClose])
 
     const hasLayers = mapViews.length > 0

--- a/src/components/download/DownloadSettings.js
+++ b/src/components/download/DownloadSettings.js
@@ -6,9 +6,9 @@ import { setDownloadMode, setDownloadConfig } from '../../actions/download.js'
 import { standardizeFilename } from '../../util/dataDownload.js'
 import { downloadMapImage, downloadSupport } from '../../util/export-image.js'
 import { getSplitViewLayer } from '../../util/helpers.js'
+import { getMapName } from '../app/FileMenu.js'
 import Drawer from '../core/Drawer.js'
 import { Checkbox, Help } from '../core/index.js'
-import { getMapName } from '../app/FileMenu.js'
 import LegendLayers from './LegendLayers.js'
 import NorthArrowPosition from './NorthArrowPosition.js'
 import styles from './styles/DownloadSettings.module.css'
@@ -49,7 +49,7 @@ const DownloadSettings = () => {
         }
 
         downloadMapImage(mapEl, filename).catch(setError)
-    }, [name, includeMargins, onClose])
+    }, [name, includeMargins])
 
     const hasLayers = mapViews.length > 0
 

--- a/src/components/download/DownloadSettings.js
+++ b/src/components/download/DownloadSettings.js
@@ -8,6 +8,7 @@ import { downloadMapImage, downloadSupport } from '../../util/export-image.js'
 import { getSplitViewLayer } from '../../util/helpers.js'
 import Drawer from '../core/Drawer.js'
 import { Checkbox, Help } from '../core/index.js'
+import { getMapName } from '../app/FileMenu.js'
 import LegendLayers from './LegendLayers.js'
 import NorthArrowPosition from './NorthArrowPosition.js'
 import styles from './styles/DownloadSettings.module.css'
@@ -40,7 +41,7 @@ const DownloadSettings = () => {
     )
 
     const onDownload = useCallback(() => {
-        const filename = standardizeFilename(name, 'png')
+        const filename = standardizeFilename(getMapName(name), 'png')
         let mapEl = document.getElementById('dhis2-map-container')
 
         if (includeMargins) {

--- a/src/reducers/dataTable.js
+++ b/src/reducers/dataTable.js
@@ -8,6 +8,7 @@ const dataTable = (state = null, action) => {
         case types.DATA_TABLE_CLOSE:
         case types.MAP_NEW:
         case types.MAP_SET:
+        case types.DOWNLOAD_MODE_SET:
             return null
 
         case types.DATA_TABLE_TOGGLE:

--- a/src/util/dataDownload.js
+++ b/src/util/dataDownload.js
@@ -45,8 +45,9 @@ export const addPropNames = (layer, data) => {
 }
 
 // Replaces anything that's not a letter, number or space
+// Multiple spaces is replaced by a single space in the last replace
 export const standardizeFilename = (name, ext) => 
-    `${name.replace(/[^a-z0-9 ]/gi, '')}.${ext}`
+    `${name.replace(/[^a-z0-9 ]/gi, '').replace(/  +/g, ' ')}.${ext}`
 
 export const createGeoJsonBlob = (data) => {
     const geojson = {

--- a/src/util/dataDownload.js
+++ b/src/util/dataDownload.js
@@ -44,13 +44,9 @@ export const addPropNames = (layer, data) => {
           )
 }
 
-// Replaces anything that's not a letter or a number, and makes it all lower case
-// If no rawName the filename will start with "map_"
-// A short random string is added to avoid multiple files with the same filename
-export const standardizeFilename = (rawName, ext) =>
-    `${
-        rawName ? rawName.replace(/[^a-z0-9]/gi, '_').toLowerCase() : 'map_'
-    }_${Math.random().toString(36).substring(7)}.${ext}`
+// Replaces anything that's not a letter, number or space
+export const standardizeFilename = (name, ext) => 
+    `${name.replace(/[^a-z0-9 ]/gi, '')}.${ext}`
 
 export const createGeoJsonBlob = (data) => {
     const geojson = {

--- a/src/util/dataDownload.js
+++ b/src/util/dataDownload.js
@@ -46,7 +46,7 @@ export const addPropNames = (layer, data) => {
 
 // Replaces anything that's not a letter, number or space
 // Multiple spaces is replaced by a single space in the last replace
-export const standardizeFilename = (name, ext) => 
+export const standardizeFilename = (name, ext) =>
     `${name.replace(/[^a-z0-9 ]/gi, '').replace(/  +/g, ' ')}.${ext}`
 
 export const createGeoJsonBlob = (data) => {


### PR DESCRIPTION
Fixes: 
1. Download mode is kept when user is downloading a map
2. Close data table if entering download mode
3. Download filename changes: Special characters are removed (not replaced with '_'. Uppercase letters and spaces are kept in the filename. We don't append a random string at the end. Filename examples with or without a map name:

![Screenshot 2023-03-13 at 17 01 50](https://user-images.githubusercontent.com/548708/224758276-411b726d-a796-4c03-b0cf-334d4aa974a8.png)

