### PR TITLE
fix: store basemap config for interpretation map

### DIFF
--- a/src/actions/basemap.js
+++ b/src/actions/basemap.js
@@ -5,9 +5,9 @@ export const addBasemaps = (basemaps) => ({
     payload: basemaps,
 })
 
-export const selectBasemap = (id) => ({
+export const selectBasemap = (payload) => ({
     type: types.BASEMAP_SELECTED,
-    id,
+    payload,
 })
 
 export const toggleBasemapExpand = () => ({

--- a/src/components/app/FileMenu.js
+++ b/src/components/app/FileMenu.js
@@ -142,7 +142,10 @@ const FileMenu = ({ map, newMap, tOpenMap, setMapProps }) => {
                 keyDefaultBaseMap
             )
 
+            delete newMapConfig.basemap
             delete newMapConfig.mapViews
+
+            console.log('setMapProps basemap', newMapConfig.basemap)
             setMapProps(newMapConfig)
 
             saveAsAlert.show({ msg: getSavedMessage(config.name) })

--- a/src/components/app/FileMenu.js
+++ b/src/components/app/FileMenu.js
@@ -145,7 +145,6 @@ const FileMenu = ({ map, newMap, tOpenMap, setMapProps }) => {
             delete newMapConfig.basemap
             delete newMapConfig.mapViews
 
-            console.log('setMapProps basemap', newMapConfig.basemap)
             setMapProps(newMapConfig)
 
             saveAsAlert.show({ msg: getSavedMessage(config.name) })

--- a/src/components/layers/basemaps/Basemap.js
+++ b/src/components/layers/basemaps/Basemap.js
@@ -5,12 +5,12 @@ import React from 'react'
 import styles from './styles/Basemap.module.css'
 
 // TODO: Use ImageSelect.js component for selectable image
-const Basemap = ({ id, img, name, isSelected, onClick }) => {
+const Basemap = ({ id, img, name, config, isSelected, onClick }) => {
     return (
         <div
             className={styles.container}
             title={name}
-            onClick={() => onClick(id)}
+            onClick={() => onClick({ id, config })}
             data-test="basemaplistitem"
         >
             <div
@@ -40,6 +40,7 @@ const Basemap = ({ id, img, name, isSelected, onClick }) => {
 }
 
 Basemap.propTypes = {
+    config: PropTypes.object.isRequired,
     id: PropTypes.string.isRequired,
     isSelected: PropTypes.bool.isRequired,
     name: PropTypes.string.isRequired,

--- a/src/reducers/map.js
+++ b/src/reducers/map.js
@@ -20,13 +20,13 @@ const defaultState = {
 const basemap = (state, action) => {
     switch (action.type) {
         case types.BASEMAP_SELECTED:
-            if (state.id === action.id) {
+            if (state.id === action.payload.id) {
                 return state
             }
 
             return {
                 ...state,
-                id: action.id,
+                ...action.payload,
             }
 
         case types.BASEMAP_CHANGE_OPACITY:


### PR DESCRIPTION
This PR will store the basemap config in redux store when a basemap is selected. This config is then available when a user opens a map in the interpretation dialog. 

After this PR: 
<img width="1100" alt="Screenshot 2023-03-13 at 23 37 28" src="https://user-images.githubusercontent.com/548708/224849153-0131023f-45c6-4493-82c2-10d2e7085006.png">

Before: 
<img width="1433" alt="Screenshot 2023-03-13 at 10 13 50" src="https://user-images.githubusercontent.com/548708/224849229-1aa51840-8c36-456a-943c-d89766bcfa5c.png">
