### PR TITLE
fix: map rotation and pitch

### DIFF
--- a/src/components/download/NorthArrow.js
+++ b/src/components/download/NorthArrow.js
@@ -2,6 +2,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useState, useCallback, useEffect } from 'react'
 import { useSelector } from 'react-redux'
+import useBasemapConfig from '../../hooks/useBasemapConfig.js'
 import styles from './styles/NorthArrow.module.css'
 
 const NorthArrow = ({
@@ -9,11 +10,13 @@ const NorthArrow = ({
     downloadMapInfoOpen,
     width = 90,
     height = 90,
-    color = 'black',
     northLetter = 'N',
 }) => {
     const [rotation, setRotation] = useState(map.getBearing())
     const position = useSelector((state) => state.download.northArrowPosition)
+    const basemap = useSelector((state) => state.map.basemap)
+    const { isDark } = useBasemapConfig(basemap)
+    const color = isDark ? 'white' : 'black';
 
     const onMapRotate = useCallback((evt) => {
         setRotation(-evt.target.getBearing())

--- a/src/components/download/NorthArrow.js
+++ b/src/components/download/NorthArrow.js
@@ -16,7 +16,7 @@ const NorthArrow = ({
     const position = useSelector((state) => state.download.northArrowPosition)
     const basemap = useSelector((state) => state.map.basemap)
     const { isDark } = useBasemapConfig(basemap)
-    const color = isDark ? 'white' : 'black';
+    const color = isDark ? 'white' : 'black'
 
     const onMapRotate = useCallback((evt) => {
         setRotation(-evt.target.getBearing())
@@ -67,7 +67,6 @@ const NorthArrow = ({
 NorthArrow.propTypes = {
     downloadMapInfoOpen: PropTypes.bool.isRequired,
     map: PropTypes.object.isRequired,
-    color: PropTypes.string,
     height: PropTypes.number,
     northLetter: PropTypes.string,
     width: PropTypes.number,

--- a/src/components/map/MapPosition.js
+++ b/src/components/map/MapPosition.js
@@ -25,7 +25,7 @@ const MapPosition = () => {
         showOverviewMap,
         showNorthArrow,
     } = useSelector((state) => state.download)
-    const layers = useSelector((state) => state.map.mapViews)
+    const { id: mapId, mapViews: layers } = useSelector((state) => state.map)
     const { layersPanelOpen, rightPanelOpen, dataTableHeight } = useSelector(
         (state) => state.ui
     )
@@ -58,12 +58,24 @@ const MapPosition = () => {
         downloadMapInfoOpen,
     ])
 
+    // Reset bearing and pitch when new map (mapId changed)
+    useEffect(() => {
+        if (map) {
+            const mapgl = map.getMapGL();
+            mapgl.setBearing(0);
+            mapgl.setPitch(0);
+        }
+    }, [map, mapId])
+
     // Fit layer bounds when app mode is toggled
     useEffect(() => {
         if (map) {
-            map.getMapGL().once('resize', () => {
+            const mapgl = map.getMapGL();
+
+            mapgl.once('resize', () => {
                 map.fitBounds(map.getLayersBounds(), {
                     padding: 40,
+                    bearing: mapgl.getBearing(),
                 })
             })
 

--- a/src/components/map/MapPosition.js
+++ b/src/components/map/MapPosition.js
@@ -61,16 +61,16 @@ const MapPosition = () => {
     // Reset bearing and pitch when new map (mapId changed)
     useEffect(() => {
         if (map) {
-            const mapgl = map.getMapGL();
-            mapgl.setBearing(0);
-            mapgl.setPitch(0);
+            const mapgl = map.getMapGL()
+            mapgl.setBearing(0)
+            mapgl.setPitch(0)
         }
     }, [map, mapId])
 
     // Fit layer bounds when app mode is toggled
     useEffect(() => {
         if (map) {
-            const mapgl = map.getMapGL();
+            const mapgl = map.getMapGL()
 
             mapgl.once('resize', () => {
                 map.fitBounds(map.getLayersBounds(), {

--- a/src/components/map/layers/Layer.js
+++ b/src/components/map/layers/Layer.js
@@ -135,7 +135,11 @@ class Layer extends PureComponent {
         const { map } = this.context
 
         if (this.layer.getBounds) {
-            map.fitBounds(this.layer.getBounds(), { padding: 40, duration: 0 })
+            map.fitBounds(this.layer.getBounds(), {
+                padding: 40, 
+                duration: 0,
+                bearing: map.getMapGL().getBearing(),
+            })
         }
     }
 

--- a/src/components/map/layers/Layer.js
+++ b/src/components/map/layers/Layer.js
@@ -136,7 +136,7 @@ class Layer extends PureComponent {
 
         if (this.layer.getBounds) {
             map.fitBounds(this.layer.getBounds(), {
-                padding: 40, 
+                padding: 40,
                 duration: 0,
                 bearing: map.getMapGL().getBearing(),
             })


### PR DESCRIPTION
This PR will: 
1. Keep the map rotation when entering/leaving download mode
2. Reset the map rotation to north when a new map is opened/created
3. If the basemap is dark the north arrow will be white:

![Screenshot 2023-03-14 at 13 55 49](https://user-images.githubusercontent.com/548708/225007542-fc57d2b7-d934-4d10-af49-30d3af60761b.png)
