### PR TITLE
fix: check both id and mapViews when preparing the map configuration

### DIFF
--- a/src/components/plugin/MapContainer.js
+++ b/src/components/plugin/MapContainer.js
@@ -25,7 +25,7 @@ const MapContainer = ({ visualization }) => {
 
         const prepareConfig = async () => {
             let initialConfig
-            if (id) {
+            if (id && !mapViews) {
                 const map = await fetchMap(id, engine, keyDefaultBaseMap)
                 initialConfig = getMigratedMapConfig(map, keyDefaultBaseMap)
             } else if (!mapViews) {


### PR DESCRIPTION
The dashboard now includes the id in the config, so only checking id caused the map config to be fetched anew, thus ignoring any filtering that had been applied in the dashboard 