### PR TITLE
fix: wait for system settings to load before fetching/initialising a map

### DIFF
--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -34,11 +34,10 @@ const App = () => {
             }
         }
 
-        // Fetch map after system settings is loaded
-        if (systemSettings.keyDefaultBaseMap) {
+        if (!isEmpty(systemSettings)) {
             fetchData()
         }
-    }, [engine, currentAO, systemSettings.keyDefaultBaseMap, dispatch])
+    }, [engine, currentAO, systemSettings, dispatch])
 
     useEffect(() => {
         if (!isEmpty(systemSettings)) {
@@ -50,12 +49,12 @@ const App = () => {
         }
     }, [systemSettings, dispatch])
 
-    return (
+    return !isEmpty(systemSettings) ? (
         <div className={styles.app}>
             <CssVariables colors spacers theme />
             <AppLayout />
         </div>
-    )
+    ) : null
 }
 
 export default App

--- a/src/components/plugin/MapContainer.js
+++ b/src/components/plugin/MapContainer.js
@@ -1,4 +1,5 @@
 import { useDataEngine } from '@dhis2/app-runtime'
+import isEmpty from 'lodash/isEmpty'
 import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
 import { getConfigFromNonMapConfig } from '../../util/getConfigFromNonMapConfig.js'
@@ -11,7 +12,7 @@ import Map from './Map.js'
 
 const MapContainer = ({ visualization }) => {
     const engine = useDataEngine()
-    const { keyBingMapsApiKey, keyDefaultBaseMap } = useSystemSettings()
+    const systemSettings = useSystemSettings()
     const [config, setConfig] = useState(null)
 
     useEffect(() => {
@@ -24,6 +25,7 @@ const MapContainer = ({ visualization }) => {
         } = visualization
 
         const prepareConfig = async () => {
+            const { keyBingMapsApiKey, keyDefaultBaseMap } = systemSettings
             let initialConfig
             if (id) {
                 const map = await fetchMap(id, engine, keyDefaultBaseMap)
@@ -59,11 +61,10 @@ const MapContainer = ({ visualization }) => {
             })
         }
 
-        // Wait for keyDefaultBaseMap before prepare config
-        if (keyDefaultBaseMap) {
+        if (!isEmpty(systemSettings)) {
             prepareConfig()
         }
-    }, [visualization, keyBingMapsApiKey, keyDefaultBaseMap, engine])
+    }, [visualization, systemSettings, engine])
 
     // eslint-disable-next-line no-unused-vars
     const { basemap, mapViews, userOrgUnit, id, ...rest } = visualization


### PR DESCRIPTION
System settings needs to be loaded before we can fetch or load a new map. The useSystemSettings hook returns an empty object before the settings are fetched. 

This PR checks if the object is not empty before continue rendering of the app or fetch map data (plugin). 

Better to check for `if (!isEmpty(systemSettings))` instead of `if (systemSettings.keyDefaultBaseMap`), as keyDefaultBaseMap might not exist if not set. 

This could have been solved cleaner - f.ex. by returning a loading prop for useSystemSettings hook. 

Fixes issue where bing maps key is not available when basemap is first added: 

<img width="344" alt="Screenshot 2023-03-17 at 11 33 25" src="https://user-images.githubusercontent.com/548708/225910077-ce259d98-f43f-434c-bd6c-63c826e30c48.png">


 