### PR TITLE
fix: avoid infinite loop when opening event data table

### DIFF
--- a/src/components/loaders/LayersLoader.js
+++ b/src/components/loaders/LayersLoader.js
@@ -7,8 +7,8 @@ const LayersLoader = () => {
     const layers = useSelector((state) =>
         state.map.mapViews.filter(
             (layer) =>
-                (!layer.isLoaded && !layer.isLoading) ||
-                (layer.showDataTable && !layer.isExtended)
+                !layer.isLoading &&
+                (!layer.isLoaded || (layer.showDataTable && !layer.isExtended))
         )
     )
     const dispatch = useDispatch()


### PR DESCRIPTION
This PR avoids an infinite loop when the data table was opened for an event data table with extended data. 

This fix is to always check if the layer is already loading.

After this PR data table show with extended data:

<img width="1353" alt="Screenshot 2023-03-17 at 15 56 58" src="https://user-images.githubusercontent.com/548708/225941328-5d3951b0-4074-456d-aff1-89c43620a973.png">