### PR TITLE
fix: format start/end dates

### DIFF
--- a/src/components/core/DatePicker.js
+++ b/src/components/core/DatePicker.js
@@ -8,8 +8,8 @@ const DatePicker = ({ label, name, defaultVal, onBlur, className }) => {
     const inputEl = useRef(null)
 
     useEffect(() => {
-        if (inputEl.current) {
-            inputEl.current.defaultValue = defaultVal
+        if (inputEl.current && defaultVal) {
+            inputEl.current.defaultValue = defaultVal.slice(0, 10)
         }
     }, [defaultVal])
 


### PR DESCRIPTION
We have switched to the HTML5 date picker which requires date to be in yyyy-mm-dd format. The dates returned from the API also include the time (2021-01-01T01:00:00.000 2022-10-01T02:00:00.000). This PR will strip the time part before passing the value to the date picker.

After this PR the dates show: 

<img width="1352" alt="Screenshot 2023-03-17 at 16 32 35" src="https://user-images.githubusercontent.com/548708/225951351-d5ff1349-983e-4860-a402-249dcae4abff.png">

