### PR TITLE
fix: new total population layer

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-04-12T08:50:51.459Z\n"
-"PO-Revision-Date: 2023-04-12T08:50:51.459Z\n"
+"POT-Creation-Date: 2023-04-12T09:23:26.646Z\n"
+"PO-Revision-Date: 2023-04-12T09:23:26.646Z\n"
 
 msgid "Untitled map, {{date}}"
 msgstr "Untitled map, {{date}}"
@@ -1156,6 +1156,9 @@ msgstr "Barren or sparsely vegetated"
 msgid "Water"
 msgstr "Water"
 
+msgid "people per km²"
+msgstr "people per km²"
+
 msgid "Nighttime lights"
 msgstr "Nighttime lights"
 
@@ -1355,7 +1358,3 @@ msgstr "End date is invalid"
 
 msgid "End date cannot be earlier than start date"
 msgstr "End date cannot be earlier than start date"
-
-msgctxt "old"
-msgid "Population"
-msgstr "Population_old"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-02-28T20:29:35.718Z\n"
-"PO-Revision-Date: 2023-02-28T20:29:35.718Z\n"
+"POT-Creation-Date: 2023-04-12T08:50:51.459Z\n"
+"PO-Revision-Date: 2023-04-12T08:50:51.459Z\n"
 
 msgid "Untitled map, {{date}}"
 msgstr "Untitled map, {{date}}"
@@ -63,37 +63,37 @@ msgid "Yes"
 msgstr "Yes"
 
 msgid "None"
-msgstr ""
+msgstr "None"
 
 msgid "Cascading"
-msgstr ""
+msgstr "Cascading"
 
 msgid "Event location"
 msgstr "Event location"
 
 msgid "Enrollment location"
-msgstr ""
+msgstr "Enrollment location"
 
 msgid "Tracked entity location"
-msgstr ""
+msgstr "Tracked entity location"
 
 msgid "Organisation unit location"
-msgstr ""
+msgstr "Organisation unit location"
 
 msgid "Fallback coordinate field"
-msgstr ""
+msgstr "Fallback coordinate field"
 
 msgid "Coordinate field"
 msgstr "Coordinate field"
 
 msgid "Enrollment > event > tracked entity > org unit coordinate"
-msgstr ""
+msgstr "Enrollment > event > tracked entity > org unit coordinate"
 
 msgid "Event > org unit coordinate"
-msgstr ""
+msgstr "Event > org unit coordinate"
 
 msgid "Event data item"
-msgstr ""
+msgstr "Event data item"
 
 msgid "Selected value not available in in list: {{name}}"
 msgstr "Selected value not available in in list: {{name}}"
@@ -1156,9 +1156,6 @@ msgstr "Barren or sparsely vegetated"
 msgid "Water"
 msgstr "Water"
 
-msgid "people per km²"
-msgstr "people per km²"
-
 msgid "Nighttime lights"
 msgstr "Nighttime lights"
 
@@ -1358,3 +1355,7 @@ msgstr "End date is invalid"
 
 msgid "End date cannot be earlier than start date"
 msgstr "End date cannot be earlier than start date"
+
+msgctxt "old"
+msgid "Population"
+msgstr "Population_old"

--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -33,6 +33,7 @@ const EarthEngineDialog = (props) => {
     const [error, setError] = useState()
 
     const {
+        layerId,
         datasetId,
         band,
         rows,
@@ -48,7 +49,7 @@ const EarthEngineDialog = (props) => {
         onLayerValidation,
     } = props
 
-    const dataset = getEarthEngineLayer(datasetId)
+    const dataset = getEarthEngineLayer(layerId)
 
     const {
         description,
@@ -80,7 +81,7 @@ const EarthEngineDialog = (props) => {
         let isCancelled = false
 
         if (periodType) {
-            getPeriods(datasetId)
+            getPeriods(datasetId, periodType)
                 .then((periods) => {
                     if (!isCancelled) {
                         setPeriods(periods)
@@ -250,6 +251,7 @@ const EarthEngineDialog = (props) => {
 
 EarthEngineDialog.propTypes = {
     datasetId: PropTypes.string.isRequired,
+    layerId: PropTypes.string.isRequired,
     setBufferRadius: PropTypes.func.isRequired,
     setFilter: PropTypes.func.isRequired,
     setOrgUnits: PropTypes.func.isRequired,

--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -2,6 +2,8 @@ import i18n from '@dhis2/d2-i18n'
 import { defaultFilters } from '../util/earthEngine.js'
 import { EARTH_ENGINE_LAYER } from './layers.js'
 
+// layerId should be unique
+// datasetId is the Earth Engine dataset id
 export const earthEngineLayers = () => [
     {
         layer: EARTH_ENGINE_LAYER,

--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -5,16 +5,18 @@ import { EARTH_ENGINE_LAYER } from './layers.js'
 export const earthEngineLayers = () => [
     {
         layer: EARTH_ENGINE_LAYER,
-        datasetId: 'WorldPop/GP/100m/pop',
+        layerId: 'WorldPop/GP/100m/pop_age_sex_cons_unadj_TOTAL',
+        datasetId: 'WorldPop/GP/100m/pop_age_sex_cons_unadj',
         name: i18n.t('Population'),
         unit: i18n.t('people per hectare'),
         description: i18n.t('Estimated number of people living in an area.'),
         source: 'WorldPop / Google Earth Engine',
         sourceUrl:
-            'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop',
+            'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop_age_sex_cons_unadj',
         img: 'images/population.png',
         defaultAggregations: ['sum', 'mean'],
         periodType: 'Yearly',
+        band: 'population',
         filters: ({ id, name, year }) => [
             {
                 id,
@@ -26,13 +28,14 @@ export const earthEngineLayers = () => [
         mosaic: true,
         params: {
             min: 0,
-            max: 10,
+            max: 25,
             palette: '#fee5d9,#fcbba1,#fc9272,#fb6a4a,#de2d26,#a50f15', // Reds
         },
         opacity: 0.9,
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'WorldPop/GP/100m/pop_age_sex_cons_unadj',
         datasetId: 'WorldPop/GP/100m/pop_age_sex_cons_unadj',
         name: i18n.t('Population age groups'),
         unit: i18n.t('people per hectare'),
@@ -211,6 +214,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'GOOGLE/Research/open-buildings/v1/polygons',
         datasetId: 'GOOGLE/Research/open-buildings/v1/polygons',
         format: 'FeatureCollection',
         name: i18n.t('Building footprints'),
@@ -233,6 +237,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'USGS/SRTMGL1_003',
         datasetId: 'USGS/SRTMGL1_003',
         name: i18n.t('Elevation'),
         unit: i18n.t('meters'),
@@ -253,6 +258,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'UCSB-CHG/CHIRPS/PENTAD',
         datasetId: 'UCSB-CHG/CHIRPS/PENTAD',
         name: i18n.t('Precipitation'),
         unit: i18n.t('millimeter'),
@@ -277,6 +283,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'MODIS/006/MOD11A2',
         datasetId: 'MODIS/006/MOD11A2',
         name: i18n.t('Temperature'),
         unit: i18n.t('°C during daytime'),
@@ -307,6 +314,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'MODIS/006/MCD12Q1',
         datasetId: 'MODIS/006/MCD12Q1', // No longer in use: 'MODIS/051/MCD12Q1',
         name: i18n.t('Landcover'),
         description: i18n.t(
@@ -417,6 +425,37 @@ export const earthEngineLayers = () => [
     {
         layer: EARTH_ENGINE_LAYER,
         legacy: true, // Kept for backward compability
+        layerId: 'WorldPop/GP/100m/pop',
+        datasetId: 'WorldPop/GP/100m/pop',
+        name: i18n.t('Population_old'),
+        unit: i18n.t('people per hectare'),
+        description: i18n.t('Estimated number of people living in an area.'),
+        source: 'WorldPop / Google Earth Engine',
+        sourceUrl:
+            'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop',
+        img: 'images/population.png',
+        defaultAggregations: ['sum', 'mean'],
+        periodType: 'Yearly',
+        filters: ({ id, name, year }) => [
+            {
+                id,
+                name,
+                type: 'eq',
+                arguments: ['year', year],
+            },
+        ],
+        mosaic: true,
+        params: {
+            min: 0,
+            max: 10,
+            palette: '#fee5d9,#fcbba1,#fc9272,#fb6a4a,#de2d26,#a50f15', // Reds
+        },
+        opacity: 0.9,
+    },
+    {
+        layer: EARTH_ENGINE_LAYER,
+        legacy: true, // Kept for backward compability
+        layerId: 'WorldPop/POP',
         datasetId: 'WorldPop/POP',
         name: i18n.t('Population'),
         unit: i18n.t('people per km²'),
@@ -452,6 +491,7 @@ export const earthEngineLayers = () => [
     {
         layer: EARTH_ENGINE_LAYER,
         legacy: true, // Kept for backward compability
+        layerId: 'NOAA/DMSP-OLS/NIGHTTIME_LIGHTS',
         datasetId: 'NOAA/DMSP-OLS/NIGHTTIME_LIGHTS',
         name: i18n.t('Nighttime lights'),
         unit: i18n.t('light intensity'),
@@ -475,4 +515,4 @@ export const earthEngineLayers = () => [
 ]
 
 export const getEarthEngineLayer = (id) =>
-    earthEngineLayers().find((l) => l.datasetId === id)
+    earthEngineLayers().find((l) => l.layerId === id)

--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -429,7 +429,7 @@ export const earthEngineLayers = () => [
         legacy: true, // Kept for backward compability
         layerId: 'WorldPop/GP/100m/pop',
         datasetId: 'WorldPop/GP/100m/pop',
-        name: i18n.t('Population_old'),
+        name: i18n.t('Population'),
         unit: i18n.t('people per hectare'),
         description: i18n.t('Estimated number of people living in an area.'),
         source: 'WorldPop / Google Earth Engine',

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -119,7 +119,7 @@ const earthEngineLoader = async (config) => {
         dataset = getEarthEngineLayer(layerConfig.id)
 
         if (dataset) {
-            dataset.datasetId = layerConfig.id
+            // dataset.datasetId = layerConfig.id
             delete layerConfig.id
         }
 

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -86,14 +86,6 @@ const earthEngineLoader = async (config) => {
         // From database as favorite
         layerConfig = JSON.parse(config.config)
 
-        // Backward compability for temperature layer (could also be fixed in a db update script)
-        if (layerConfig.id === 'MODIS/MOD11A2' && layerConfig.filter) {
-            const period = layerConfig.image.slice(-10)
-            layerConfig.id = 'MODIS/006/MOD11A2'
-            layerConfig.image = period
-            layerConfig.filter[0].arguments[1] = period
-        }
-
         // Backward compability for layers with periods saved before 2.36
         // (could also be fixed in a db update script)
         if (layerConfig.image) {
@@ -119,7 +111,6 @@ const earthEngineLoader = async (config) => {
         dataset = getEarthEngineLayer(layerConfig.id)
 
         if (dataset) {
-            // dataset.datasetId = layerConfig.id
             delete layerConfig.id
         }
 

--- a/src/util/earthEngine.js
+++ b/src/util/earthEngine.js
@@ -1,6 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
 import { loadEarthEngineWorker } from '../components/map/MapApi.js'
-import { getEarthEngineLayer } from '../constants/earthEngine.js'
 import { apiFetch } from './api.js'
 import { formatStartEndDate } from './time.js'
 

--- a/src/util/earthEngine.js
+++ b/src/util/earthEngine.js
@@ -95,6 +95,11 @@ export const getPeriods = async (eeId, periodType) => {
         const name =
             periodType === 'Yearly' ? String(year) : getStartEndDate(properties)
 
+        // Remove when old population should not be supported
+        if (eeId === 'WorldPop/POP') {
+            return { id: name, name, year }
+        }
+
         return { id, name, year }
     }
 

--- a/src/util/earthEngine.js
+++ b/src/util/earthEngine.js
@@ -95,11 +95,6 @@ export const getPeriods = async (eeId, periodType) => {
         const name =
             periodType === 'Yearly' ? String(year) : getStartEndDate(properties)
 
-        // Remove when old population should not be supported
-        if (eeId === 'WorldPop/POP') {
-            return { id: name, name, year }
-        }
-
         return { id, name, year }
     }
 

--- a/src/util/earthEngine.js
+++ b/src/util/earthEngine.js
@@ -90,9 +90,7 @@ const getWorkerInstance = async () => {
     return workerPromise
 }
 
-export const getPeriods = async (eeId) => {
-    const { periodType } = getEarthEngineLayer(eeId)
-
+export const getPeriods = async (eeId, periodType) => {
     const getPeriod = ({ id, properties }) => {
         const year = new Date(properties['system:time_start']).getFullYear()
         const name =

--- a/src/util/favorites.js
+++ b/src/util/favorites.js
@@ -51,6 +51,7 @@ const validLayerProperties = [
     'labelTemplate',
     'lastUpdated',
     'layer',
+    'layerId',
     'legendSet',
     'method',
     'name',
@@ -131,7 +132,7 @@ const models2objects = (config) => {
     }
 
     if (layer === EARTH_ENGINE_LAYER) {
-        const { datasetId: id, band, params, aggregationType, filter } = config
+        const { layerId: id, band, params, aggregationType, filter } = config
 
         const eeConfig = {
             id,
@@ -148,6 +149,7 @@ const models2objects = (config) => {
 
         config.config = JSON.stringify(eeConfig)
 
+        delete config.layerId
         delete config.datasetId
         delete config.params
         delete config.filter


### PR DESCRIPTION
With this PR we are using the same Earth Engine dataset for both totalt population and age/gender groups. This makes sure that the totalt population numbers are the same. 

Fixes: https://dhis2.atlassian.net/browse/DHIS2-14282

This means that we only have population values for 2020. 

As we use the same EE dataset for two layers, we couldn't rely to the `datasetId` to be unique, a new `layerId` was therefore added. 

Some code that where included to support old EE layers where removed, as these layers have not been supported for several DHIS2 versions. 

After this PR the total population in Bo is identical to selecting all age/gender groups: 

<img width="369" alt="Screenshot 2023-04-03 at 12 46 52" src="https://user-images.githubusercontent.com/548708/229488779-91339ec4-e1aa-4bba-a50b-f10aa153c81e.png">
<img width="351" alt="Screenshot 2023-04-03 at 12 48 06" src="https://user-images.githubusercontent.com/548708/229488790-e46d4a7a-7d79-41ff-bb1b-0780055de72e.png">

Before this PR the totalt population in Bo is much less: 

<img width="374" alt="Screenshot 2023-04-03 at 12 50 45" src="https://user-images.githubusercontent.com/548708/229489228-f85c0be8-705c-4848-9e74-6fa77b76e425.png">

We should also update the Import/Export app to reflect these changes.

