### PR TITLE
fix: new total population layer (DHIS2-14282, 2.40 backport)

### DIFF
--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -33,6 +33,7 @@ const EarthEngineDialog = (props) => {
     const [error, setError] = useState()
 
     const {
+        layerId,
         datasetId,
         band,
         rows,
@@ -48,7 +49,7 @@ const EarthEngineDialog = (props) => {
         onLayerValidation,
     } = props
 
-    const dataset = getEarthEngineLayer(datasetId)
+    const dataset = getEarthEngineLayer(layerId)
 
     const {
         description,
@@ -80,7 +81,7 @@ const EarthEngineDialog = (props) => {
         let isCancelled = false
 
         if (periodType) {
-            getPeriods(datasetId)
+            getPeriods(datasetId, periodType)
                 .then((periods) => {
                     if (!isCancelled) {
                         setPeriods(periods)
@@ -250,6 +251,7 @@ const EarthEngineDialog = (props) => {
 
 EarthEngineDialog.propTypes = {
     datasetId: PropTypes.string.isRequired,
+    layerId: PropTypes.string.isRequired,
     setBufferRadius: PropTypes.func.isRequired,
     setFilter: PropTypes.func.isRequired,
     setOrgUnits: PropTypes.func.isRequired,

--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -2,19 +2,23 @@ import i18n from '@dhis2/d2-i18n'
 import { defaultFilters } from '../util/earthEngine.js'
 import { EARTH_ENGINE_LAYER } from './layers.js'
 
+// layerId should be unique
+// datasetId is the Earth Engine dataset id
 export const earthEngineLayers = () => [
     {
         layer: EARTH_ENGINE_LAYER,
-        datasetId: 'WorldPop/GP/100m/pop',
+        layerId: 'WorldPop/GP/100m/pop_age_sex_cons_unadj_TOTAL',
+        datasetId: 'WorldPop/GP/100m/pop_age_sex_cons_unadj',
         name: i18n.t('Population'),
         unit: i18n.t('people per hectare'),
         description: i18n.t('Estimated number of people living in an area.'),
         source: 'WorldPop / Google Earth Engine',
         sourceUrl:
-            'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop',
+            'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop_age_sex_cons_unadj',
         img: 'images/population.png',
         defaultAggregations: ['sum', 'mean'],
         periodType: 'Yearly',
+        band: 'population',
         filters: ({ id, name, year }) => [
             {
                 id,
@@ -26,13 +30,14 @@ export const earthEngineLayers = () => [
         mosaic: true,
         params: {
             min: 0,
-            max: 10,
+            max: 25,
             palette: '#fee5d9,#fcbba1,#fc9272,#fb6a4a,#de2d26,#a50f15', // Reds
         },
         opacity: 0.9,
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'WorldPop/GP/100m/pop_age_sex_cons_unadj',
         datasetId: 'WorldPop/GP/100m/pop_age_sex_cons_unadj',
         name: i18n.t('Population age groups'),
         unit: i18n.t('people per hectare'),
@@ -211,6 +216,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'GOOGLE/Research/open-buildings/v1/polygons',
         datasetId: 'GOOGLE/Research/open-buildings/v1/polygons',
         format: 'FeatureCollection',
         name: i18n.t('Building footprints'),
@@ -233,6 +239,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'USGS/SRTMGL1_003',
         datasetId: 'USGS/SRTMGL1_003',
         name: i18n.t('Elevation'),
         unit: i18n.t('meters'),
@@ -253,6 +260,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'UCSB-CHG/CHIRPS/PENTAD',
         datasetId: 'UCSB-CHG/CHIRPS/PENTAD',
         name: i18n.t('Precipitation'),
         unit: i18n.t('millimeter'),
@@ -277,6 +285,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'MODIS/006/MOD11A2',
         datasetId: 'MODIS/006/MOD11A2',
         name: i18n.t('Temperature'),
         unit: i18n.t('°C during daytime'),
@@ -307,6 +316,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'MODIS/006/MCD12Q1',
         datasetId: 'MODIS/006/MCD12Q1', // No longer in use: 'MODIS/051/MCD12Q1',
         name: i18n.t('Landcover'),
         description: i18n.t(
@@ -417,6 +427,37 @@ export const earthEngineLayers = () => [
     {
         layer: EARTH_ENGINE_LAYER,
         legacy: true, // Kept for backward compability
+        layerId: 'WorldPop/GP/100m/pop',
+        datasetId: 'WorldPop/GP/100m/pop',
+        name: i18n.t('Population'),
+        unit: i18n.t('people per hectare'),
+        description: i18n.t('Estimated number of people living in an area.'),
+        source: 'WorldPop / Google Earth Engine',
+        sourceUrl:
+            'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop',
+        img: 'images/population.png',
+        defaultAggregations: ['sum', 'mean'],
+        periodType: 'Yearly',
+        filters: ({ id, name, year }) => [
+            {
+                id,
+                name,
+                type: 'eq',
+                arguments: ['year', year],
+            },
+        ],
+        mosaic: true,
+        params: {
+            min: 0,
+            max: 10,
+            palette: '#fee5d9,#fcbba1,#fc9272,#fb6a4a,#de2d26,#a50f15', // Reds
+        },
+        opacity: 0.9,
+    },
+    {
+        layer: EARTH_ENGINE_LAYER,
+        legacy: true, // Kept for backward compability
+        layerId: 'WorldPop/POP',
         datasetId: 'WorldPop/POP',
         name: i18n.t('Population'),
         unit: i18n.t('people per km²'),
@@ -452,6 +493,7 @@ export const earthEngineLayers = () => [
     {
         layer: EARTH_ENGINE_LAYER,
         legacy: true, // Kept for backward compability
+        layerId: 'NOAA/DMSP-OLS/NIGHTTIME_LIGHTS',
         datasetId: 'NOAA/DMSP-OLS/NIGHTTIME_LIGHTS',
         name: i18n.t('Nighttime lights'),
         unit: i18n.t('light intensity'),
@@ -475,4 +517,4 @@ export const earthEngineLayers = () => [
 ]
 
 export const getEarthEngineLayer = (id) =>
-    earthEngineLayers().find((l) => l.datasetId === id)
+    earthEngineLayers().find((l) => l.layerId === id)

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -119,7 +119,6 @@ const earthEngineLoader = async (config) => {
         dataset = getEarthEngineLayer(layerConfig.id)
 
         if (dataset) {
-            dataset.datasetId = layerConfig.id
             delete layerConfig.id
         }
 

--- a/src/util/earthEngine.js
+++ b/src/util/earthEngine.js
@@ -1,6 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
 import { loadEarthEngineWorker } from '../components/map/MapApi.js'
-import { getEarthEngineLayer } from '../constants/earthEngine.js'
 import { apiFetch } from './api.js'
 import { formatStartEndDate } from './time.js'
 

--- a/src/util/earthEngine.js
+++ b/src/util/earthEngine.js
@@ -90,9 +90,7 @@ const getWorkerInstance = async () => {
     return workerPromise
 }
 
-export const getPeriods = async (eeId) => {
-    const { periodType } = getEarthEngineLayer(eeId)
-
+export const getPeriods = async (eeId, periodType) => {
     const getPeriod = ({ id, properties }) => {
         const year = new Date(properties['system:time_start']).getFullYear()
         const name =

--- a/src/util/favorites.js
+++ b/src/util/favorites.js
@@ -51,6 +51,7 @@ const validLayerProperties = [
     'labelTemplate',
     'lastUpdated',
     'layer',
+    'layerId',
     'legendSet',
     'method',
     'name',
@@ -131,7 +132,7 @@ const models2objects = (config) => {
     }
 
     if (layer === EARTH_ENGINE_LAYER) {
-        const { datasetId: id, band, params, aggregationType, filter } = config
+        const { layerId: id, band, params, aggregationType, filter } = config
 
         const eeConfig = {
             id,


### PR DESCRIPTION
With this PR we are using the same Earth Engine dataset for both totalt population and age/gender groups. This makes sure that the totalt population numbers are the same.

Fixes for v40: https://dhis2.atlassian.net/browse/DHIS2-14282

v40 backport of https://github.com/dhis2/maps-app/pull/2557

After this PR the total population in Bo is identical to selecting all age/gender groups (851,091):

<img width="247" alt="Screenshot 2023-04-12 at 12 19 59" src="https://user-images.githubusercontent.com/548708/231429517-0069477d-7bb3-4ec9-8f27-503cf17f4142.png">
