### PR TITLE
fix: new total population layer (DHIS2-14282, 2.39 backport)

### DIFF
--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -77,10 +77,10 @@ const EarthEngineDialog = props => {
         let isCancelled = false;
 
         if (periodType) {
-            getPeriods(datasetId)
+            getPeriods(datasetId, periodType)
                 .then(periods => {
                     if (!isCancelled) {
-                        setPeriods(periods, periodType);
+                        setPeriods(periods);
                     }
                 })
                 .catch(error =>

--- a/src/components/edit/earthEngine/EarthEngineDialog.js
+++ b/src/components/edit/earthEngine/EarthEngineDialog.js
@@ -33,6 +33,7 @@ const EarthEngineDialog = props => {
     const [error, setError] = useState();
 
     const {
+        layerId,
         datasetId,
         band,
         rows,
@@ -47,7 +48,7 @@ const EarthEngineDialog = props => {
         onLayerValidation,
     } = props;
 
-    const dataset = getEarthEngineLayer(datasetId);
+    const dataset = getEarthEngineLayer(layerId);
 
     const {
         description,
@@ -79,7 +80,7 @@ const EarthEngineDialog = props => {
             getPeriods(datasetId)
                 .then(periods => {
                     if (!isCancelled) {
-                        setPeriods(periods);
+                        setPeriods(periods, periodType);
                     }
                 })
                 .catch(error =>
@@ -237,6 +238,7 @@ const EarthEngineDialog = props => {
 EarthEngineDialog.propTypes = {
     rows: PropTypes.array,
     datasetId: PropTypes.string.isRequired,
+    layerId: PropTypes.string.isRequired,
     band: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
     filter: PropTypes.array,
     params: PropTypes.shape({

--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -5,16 +5,18 @@ import { EARTH_ENGINE_LAYER } from './layers';
 export const earthEngineLayers = () => [
     {
         layer: EARTH_ENGINE_LAYER,
-        datasetId: 'WorldPop/GP/100m/pop',
+        layerId: 'WorldPop/GP/100m/pop_age_sex_cons_unadj_TOTAL',
+        datasetId: 'WorldPop/GP/100m/pop_age_sex_cons_unadj',
         name: i18n.t('Population'),
         unit: i18n.t('people per hectare'),
         description: i18n.t('Estimated number of people living in an area.'),
         source: 'WorldPop / Google Earth Engine',
         sourceUrl:
-            'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop',
+            'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop_age_sex_cons_unadj',
         img: 'images/population.png',
         defaultAggregations: ['sum', 'mean'],
         periodType: 'Yearly',
+        band: 'population',
         filters: ({ id, name, year }) => [
             {
                 id,
@@ -26,13 +28,14 @@ export const earthEngineLayers = () => [
         mosaic: true,
         params: {
             min: 0,
-            max: 10,
+            max: 25,
             palette: '#fee5d9,#fcbba1,#fc9272,#fb6a4a,#de2d26,#a50f15', // Reds
         },
         opacity: 0.9,
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'WorldPop/GP/100m/pop_age_sex_cons_unadj',
         datasetId: 'WorldPop/GP/100m/pop_age_sex_cons_unadj',
         name: i18n.t('Population age groups'),
         unit: i18n.t('people per hectare'),
@@ -211,6 +214,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'GOOGLE/Research/open-buildings/v1/polygons',
         datasetId: 'GOOGLE/Research/open-buildings/v1/polygons',
         format: 'FeatureCollection',
         name: i18n.t('Building footprints'),
@@ -233,6 +237,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'USGS/SRTMGL1_003',
         datasetId: 'USGS/SRTMGL1_003',
         name: i18n.t('Elevation'),
         unit: i18n.t('meters'),
@@ -253,6 +258,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'UCSB-CHG/CHIRPS/PENTAD',
         datasetId: 'UCSB-CHG/CHIRPS/PENTAD',
         name: i18n.t('Precipitation'),
         unit: i18n.t('millimeter'),
@@ -277,6 +283,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'MODIS/006/MOD11A2',
         datasetId: 'MODIS/006/MOD11A2',
         name: i18n.t('Temperature'),
         unit: i18n.t('°C during daytime'),
@@ -307,6 +314,7 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
+        layerId: 'MODIS/006/MCD12Q1',
         datasetId: 'MODIS/006/MCD12Q1', // No longer in use: 'MODIS/051/MCD12Q1',
         name: i18n.t('Landcover'),
         description: i18n.t(
@@ -417,6 +425,37 @@ export const earthEngineLayers = () => [
     {
         layer: EARTH_ENGINE_LAYER,
         legacy: true, // Kept for backward compability
+        layerId: 'WorldPop/GP/100m/pop',
+        datasetId: 'WorldPop/GP/100m/pop',
+        name: i18n.t('Population'),
+        unit: i18n.t('people per hectare'),
+        description: i18n.t('Estimated number of people living in an area.'),
+        source: 'WorldPop / Google Earth Engine',
+        sourceUrl:
+            'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop',
+        img: 'images/population.png',
+        defaultAggregations: ['sum', 'mean'],
+        periodType: 'Yearly',
+        filters: ({ id, name, year }) => [
+            {
+                id,
+                name,
+                type: 'eq',
+                arguments: ['year', year],
+            },
+        ],
+        mosaic: true,
+        params: {
+            min: 0,
+            max: 10,
+            palette: '#fee5d9,#fcbba1,#fc9272,#fb6a4a,#de2d26,#a50f15', // Reds
+        },
+        opacity: 0.9,
+    },
+    {
+        layer: EARTH_ENGINE_LAYER,
+        legacy: true, // Kept for backward compability
+        layerId: 'WorldPop/POP',
         datasetId: 'WorldPop/POP',
         name: i18n.t('Population'),
         unit: i18n.t('people per km²'),
@@ -452,6 +491,7 @@ export const earthEngineLayers = () => [
     {
         layer: EARTH_ENGINE_LAYER,
         legacy: true, // Kept for backward compability
+        layerId: 'NOAA/DMSP-OLS/NIGHTTIME_LIGHTS',
         datasetId: 'NOAA/DMSP-OLS/NIGHTTIME_LIGHTS',
         name: i18n.t('Nighttime lights'),
         unit: i18n.t('light intensity'),
@@ -475,4 +515,4 @@ export const earthEngineLayers = () => [
 ];
 
 export const getEarthEngineLayer = id =>
-    earthEngineLayers().find(l => l.datasetId === id);
+    earthEngineLayers().find(l => l.layerId === id);

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -116,7 +116,6 @@ const earthEngineLoader = async config => {
         dataset = getEarthEngineLayer(layerConfig.id);
 
         if (dataset) {
-            dataset.datasetId = layerConfig.id;
             delete layerConfig.id;
         }
 

--- a/src/util/earthEngine.js
+++ b/src/util/earthEngine.js
@@ -2,7 +2,6 @@ import i18n from '@dhis2/d2-i18n';
 import { formatStartEndDate } from './time';
 import { loadEarthEngineWorker } from '../components/map/MapApi';
 import { apiFetch } from './api';
-import { getEarthEngineLayer } from '../constants/earthEngine';
 
 export const classAggregation = ['percentage', 'hectares', 'acres'];
 
@@ -87,9 +86,7 @@ const getWorkerInstance = async () => {
     return workerPromise;
 };
 
-export const getPeriods = async eeId => {
-    const { periodType } = getEarthEngineLayer(eeId);
-
+export const getPeriods = async (eeId, periodType) => {
     const getPeriod = ({ id, properties }) => {
         const year = new Date(properties['system:time_start']).getFullYear();
         const name =

--- a/src/util/favorites.js
+++ b/src/util/favorites.js
@@ -47,6 +47,7 @@ const validLayerProperties = [
     'labelFontColor',
     'lastUpdated',
     'layer',
+    'layerId',
     'legendSet',
     'method',
     'name',
@@ -127,7 +128,7 @@ const models2objects = config => {
     }
 
     if (layer === EARTH_ENGINE_LAYER) {
-        const { datasetId: id, band, params, aggregationType, filter } = config;
+        const { layerId: id, band, params, aggregationType, filter } = config;
 
         const eeConfig = {
             id,


### PR DESCRIPTION
With this PR we are using the same Earth Engine dataset for both totalt population and age/gender groups. This makes sure that the totalt population numbers are the same.

Fixes for v39: https://dhis2.atlassian.net/browse/DHIS2-14282

v39 backport of https://github.com/dhis2/maps-app/pull/2557

After this PR the total population in Bo is identical to selecting all age/gender groups (851,091):
<img width="274" alt="Screenshot 2023-04-13 at 11 01 59" src="https://user-images.githubusercontent.com/548708/231710745-c20b9931-4af0-41ec-bc39-571dd0a727f3.png">
