### PR TITLE
fix: remove fallback coordinate field (DHIS2-8165, 2.40.0 backport)

### DIFF
--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -11,7 +11,7 @@ import {
     setEventClustering,
     setEventPointColor,
     setEventPointRadius,
-    setFallbackCoordinateField,
+    // setFallbackCoordinateField,
     setPeriod,
     setStartDate,
     setEndDate,
@@ -63,7 +63,7 @@ class EventDialog extends Component {
         setEventPointColor: PropTypes.func.isRequired,
         setEventPointRadius: PropTypes.func.isRequired,
         setEventStatus: PropTypes.func.isRequired,
-        setFallbackCoordinateField: PropTypes.func.isRequired,
+        // setFallbackCoordinateField: PropTypes.func.isRequired,
         setOrgUnits: PropTypes.func.isRequired,
         setPeriod: PropTypes.func.isRequired,
         setProgram: PropTypes.func.isRequired,
@@ -79,7 +79,7 @@ class EventDialog extends Component {
         eventPointColor: PropTypes.string,
         eventPointRadius: PropTypes.number,
         eventStatus: PropTypes.string,
-        fallbackCoordinateField: PropTypes.string,
+        // fallbackCoordinateField: PropTypes.string,
         filters: PropTypes.array,
         legendSet: PropTypes.object,
         method: PropTypes.number,
@@ -169,7 +169,7 @@ class EventDialog extends Component {
             eventCoordinateField,
             eventPointColor,
             eventPointRadius,
-            fallbackCoordinateField,
+            // fallbackCoordinateField,
             filters = [],
             program,
             programStage,
@@ -186,7 +186,7 @@ class EventDialog extends Component {
             setEventClustering,
             setEventPointColor,
             setEventPointRadius,
-            setFallbackCoordinateField,
+            // setFallbackCoordinateField,
             setPeriod,
         } = this.props
 
@@ -244,7 +244,7 @@ class EventDialog extends Component {
                                 onChange={setEventCoordinateField}
                                 className={styles.select}
                             />
-                            {eventCoordinateField && (
+                            {/* eventCoordinateField && (
                                 <CoordinateField
                                     program={program}
                                     programStage={programStage}
@@ -253,7 +253,7 @@ class EventDialog extends Component {
                                     onChange={setFallbackCoordinateField}
                                     className={styles.select}
                                 />
-                            )}
+                            ) */}
                             <EventStatusSelect
                                 value={eventStatus}
                                 onChange={setEventStatus}
@@ -471,7 +471,7 @@ export default connect(
         setEventClustering,
         setEventPointColor,
         setEventPointRadius,
-        setFallbackCoordinateField,
+        // setFallbackCoordinateField,
         setPeriod,
         setStartDate,
         setEndDate,


### PR DESCRIPTION
This PR will temporarily remove the fallback coordinate field from the event layer dialog as it is not working properly: https://dhis2.atlassian.net/browse/DHIS2-8165?focusedCommentId=182171

patch/2.40.0 backport of https://github.com/dhis2/maps-app/pull/2575

These issues need to be addressed before we can release the new component.

After this PR the fallback coordinate field is not shown:

![Screenshot 2023-04-24 at 10 45 01](https://user-images.githubusercontent.com/548708/233948700-f866e226-45e4-475a-ab46-004022f91090.png)

Before: 

![Screenshot 2023-04-24 at 10 47 46](https://user-images.githubusercontent.com/548708/233948738-dcd2f698-c01a-4f10-8f5e-c40ce6d20abe.png)

