### PR TITLE
feat(plugin): send installation status [v40]

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "postinstall": "patch-package"
     },
     "devDependencies": {
-        "@dhis2/cli-app-scripts": "^10.3.5",
+        "@dhis2/cli-app-scripts": "^10.3.7",
         "@dhis2/cli-style": "^10.4.3",
         "@dhis2/cypress-commands": "^9.0.2",
         "@dhis2/cypress-plugins": "^9.0.2",

--- a/src/PluginWrapper.js
+++ b/src/PluginWrapper.js
@@ -5,6 +5,7 @@ import { debounce } from 'lodash/fp'
 import PropTypes from 'prop-types'
 import React, { useEffect, useLayoutEffect, useState } from 'react'
 import { Plugin } from './components/plugin/Plugin.js'
+import { getPWAInstallationStatus } from './util/getPWAInstallationStatus.js'
 
 const LoadingMask = () => {
     return (
@@ -68,6 +69,10 @@ CacheableSectionWrapper.propTypes = {
     isParentCached: PropTypes.bool,
 }
 
+const sendInstallationStatus = (installationStatus) => {
+    postRobot.send(window.parent, 'installationStatus', { installationStatus })
+}
+
 const PluginWrapper = () => {
     const [propsFromParent, setPropsFromParent] = useState()
     const [renderId, setRenderId] = useState(null)
@@ -79,6 +84,12 @@ const PluginWrapper = () => {
             .send(window.top, 'getProps')
             .then(receivePropsFromParent)
             .catch((err) => console.error(err))
+
+        // Get & send PWA installation status now, and also prepare to send
+        // future updates (installing/ready)
+        getPWAInstallationStatus({
+            onStateChange: sendInstallationStatus,
+        }).then(sendInstallationStatus)
 
         // Allow parent to update props
         const listener = postRobot.on(

--- a/src/util/getPWAInstallationStatus.js
+++ b/src/util/getPWAInstallationStatus.js
@@ -1,0 +1,63 @@
+export const INSTALLATION_STATES = {
+    READY: 'READY',
+    INSTALLING: 'INSTALLING',
+}
+
+function handleInstallingWorker({ installingWorker, onStateChange }) {
+    installingWorker.onstatechange = () => {
+        if (installingWorker.state === 'activated') {
+            // ... and update state to 'ready'
+            onStateChange(INSTALLATION_STATES.READY)
+        }
+    }
+}
+
+/**
+ * Gets the current installation state of the PWA features, which is intended
+ * to be reported from this plugin to the parent app to indicate that the
+ * static assets are cached and ready to be accessed locally instead of over
+ * the network.
+ *
+ * Returns either READY, INSTALLING, or `null` for not installed/won't install
+ */
+export async function getPWAInstallationStatus({ onStateChange }) {
+    if (!navigator.serviceWorker) {
+        // Nothing to do here
+        return null
+    }
+
+    const registration = await navigator.serviceWorker.getRegistration()
+    if (!registration) {
+        // This shouldn't happen since this is a PWA app, but return null
+        return null
+    }
+
+    if (registration.active) {
+        return INSTALLATION_STATES.READY
+    }
+    // note that 'registration.waiting' is skipped - it implies there's an active one
+    if (registration.installing) {
+        handleInstallingWorker({
+            installingWorker: registration.installing,
+            onStateChange,
+        })
+        return INSTALLATION_STATES.INSTALLING
+    }
+
+    // It shouldn't normally be possible to get here, but just in case,
+    // listen for installations
+    registration.onupdatefound = () => {
+        // update state for this plugin to 'installing'
+        onStateChange(INSTALLATION_STATES.INSTALLING)
+
+        // also listen for the installing worker to become active
+        const installingWorker = registration.installing
+        if (!installingWorker) {
+            return
+        }
+        handleInstallingWorker({ installingWorker, onStateChange })
+    }
+
+    // and in the mean time, return null to show 'not installed'
+    return null
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2007,12 +2007,12 @@
     react-beautiful-dnd "^10.1.1"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2/app-adapter@10.3.5":
-  version "10.3.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-10.3.5.tgz#0e4c41d6567cff7f4bb8c75e970fc856b0c58fff"
-  integrity sha512-3XAPb/3nJF6cA6PPzu0WXeHi2LJWt46eNs73SCmxFOz+6fLCOXGSqNUw6VBMS0BleqhV1WXWn163IPHLz3mhqA==
+"@dhis2/app-adapter@10.3.7":
+  version "10.3.7"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-10.3.7.tgz#4d01b06ce972d48e71b694d0e98cd18c949f7bb6"
+  integrity sha512-T3AG+yW73HrtlDRl+a8lMg6Z4pVwjTXl4pJA458fVXomEKpHFilYV2GjY7nVRCUXC6bDLsV5rvDxkgHZqhSsSA==
   dependencies:
-    "@dhis2/pwa" "10.3.5"
+    "@dhis2/pwa" "10.3.7"
     moment "^2.24.0"
 
 "@dhis2/app-runtime-adapter-d2@^1.1.0":
@@ -2069,15 +2069,15 @@
   dependencies:
     lodash "^4.17.21"
 
-"@dhis2/app-shell@10.3.5":
-  version "10.3.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-10.3.5.tgz#d3466cbf7ee03e1007c1c2d27993e19a735eab54"
-  integrity sha512-LG8xeV2k43SYzikKmdVg+xq6zJlV6XOO8v5n43H7PysLGF9aRq29IRKHwyhXY3bA3Z/FFJGf6GnjLcHNUseJ5w==
+"@dhis2/app-shell@10.3.7":
+  version "10.3.7"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-10.3.7.tgz#f4eaf54cbf16044830a6f57f0992856c015eb3ab"
+  integrity sha512-vDjNSPwAlly0xZMk1lKIm3IO4eAyve4qF2RJ2tiKrHkXgWUokwsuboCCs/rQgqLcfnhwWj2NmGwheGYc49ZOEA==
   dependencies:
-    "@dhis2/app-adapter" "10.3.5"
+    "@dhis2/app-adapter" "10.3.7"
     "@dhis2/app-runtime" "^3.9.0"
     "@dhis2/d2-i18n" "^1.1.1"
-    "@dhis2/pwa" "10.3.5"
+    "@dhis2/pwa" "10.3.7"
     "@dhis2/ui" "^8.12.3"
     classnames "^2.2.6"
     moment "^2.29.1"
@@ -2090,10 +2090,10 @@
     typeface-roboto "^0.0.75"
     typescript "^3.6.3"
 
-"@dhis2/cli-app-scripts@^10.3.5":
-  version "10.3.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-10.3.5.tgz#0417f585f2515da4793a03e84f9d9dc6459196fd"
-  integrity sha512-J9mp9eiNbL6Uz/kyDypQtC/NkNaAG/tDwlnPeCAvZkIzFIUocvhzfbNM7ov67sSh6+onCa+R4l/oemXUB3nvaw==
+"@dhis2/cli-app-scripts@^10.3.7":
+  version "10.3.7"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-10.3.7.tgz#52e3af69ea19e0ed0ee765f4ce5cf9966f4ff7cf"
+  integrity sha512-QzrrsXKQ2Ammw6faSnC1EiVDnXmeErrAHw7NNyskQ1bCzDbgFvu9lzT+3zsAQoikaqdBawePY8KI6LXRENlWOw==
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.8.3"
@@ -2102,7 +2102,7 @@
     "@babel/preset-env" "^7.14.7"
     "@babel/preset-react" "^7.0.0"
     "@babel/preset-typescript" "^7.6.0"
-    "@dhis2/app-shell" "10.3.5"
+    "@dhis2/app-shell" "10.3.7"
     "@dhis2/cli-helpers-engine" "^3.2.0"
     "@jest/core" "^27.0.6"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.5.4"
@@ -2253,10 +2253,10 @@
   resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-3.1.2.tgz#65b8ad2da8cd2f72bc8b951049a6c9d1b97af3e9"
   integrity sha512-eM0jjLOWvtXWqSFp5YC4DHFpkP8Y1D2eUwGV7MBWjni+o27oesVan+oT7WHeOeLdlAd4acRJrnaaAyB4Ck1wGQ==
 
-"@dhis2/pwa@10.3.5":
-  version "10.3.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-10.3.5.tgz#9571fcc47a4624266933b7905aa547458d18b4d2"
-  integrity sha512-hvRqDx7jyqYzqX2quP5OW3MjkqsCTmtxqNr91tjaZtiA/MCrlcj+hFnH2DpK6BNJ48OVo4XauWllfa0bjGHCfg==
+"@dhis2/pwa@10.3.7":
+  version "10.3.7"
+  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-10.3.7.tgz#7e94b249ce20d1c338bfba9f5f5242f9a7b8b077"
+  integrity sha512-YDPO/Jx6e9Btsg65mBjhA7OSLo0UFrHMHVemfKSkiOjZMqY5s+AnNQcNyxG0CxaBjUrgZmXsA7hfle9XAt1FSg==
   dependencies:
     idb "^6.0.0"
     workbox-core "^6.1.5"


### PR DESCRIPTION
Backport of https://github.com/dhis2/maps-app/pull/2580

Sends PWA installation status to the parent app to share when it is cached and ready to be served locally