### PR TITLE
fix: set rendering strategy to single if not relative period (DHIS2-15435)

### DIFF
--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -22,6 +22,7 @@ import {
     DEFAULT_ORG_UNIT_LEVEL,
     CLASSIFICATION_PREDEFINED,
     CLASSIFICATION_EQUAL_INTERVALS,
+    RENDERING_STRATEGY_SINGLE,
 } from '../../../constants/layers.js'
 import {
     RELATIVE_PERIODS,
@@ -175,11 +176,22 @@ class ThematicDialog extends Component {
     componentDidUpdate(prev) {
         const {
             columns,
+            periodType,
+            renderingStrategy,
             setClassification,
             setLegendSet,
+            setRenderingStrategy,
             validateLayer,
             onLayerValidation,
         } = this.props
+
+        // Set rendering strategy to single if not relative period
+        if (
+            periodType !== RELATIVE_PERIODS &&
+            renderingStrategy !== RENDERING_STRATEGY_SINGLE
+        ) {
+            setRenderingStrategy(RENDERING_STRATEGY_SINGLE)
+        }
 
         // Set the default classification/legend for selected data item without visiting the style tab
         if (columns !== prev.columns) {


### PR DESCRIPTION
This PR will make sure that "Display periods" for thematic layer is set to "Single (aggregate)" if a non-relative period is selected. Timeline and split view maps are only supported for relative periods so far.  

Fixes: https://dhis2.atlassian.net/browse/DHIS2-15435
