### PR TITLE
fix: don't show north arrow for split view maps

### DIFF
--- a/src/components/download/DownloadSettings.js
+++ b/src/components/download/DownloadSettings.js
@@ -155,7 +155,7 @@ const DownloadSettings = () => {
                                     )
                                 }
                             />
-                            {showNorthArrow && (
+                            {showNorthArrow && !isSplitView && (
                                 <NorthArrowPosition
                                     position={northArrowPosition}
                                     onChange={(value) =>

--- a/src/components/map/MapPosition.js
+++ b/src/components/map/MapPosition.js
@@ -107,7 +107,7 @@ const MapPosition = () => {
                                     isSplitView={isSplitView}
                                 />
                             )}
-                            {showNorthArrow && (
+                            {showNorthArrow && !isSplitView && (
                                 <NorthArrow
                                     map={map.getMapGL()}
                                     downloadMapInfoOpen={downloadMapInfoOpen}


### PR DESCRIPTION
This PR will hide the north arrow in download mode for split view maps. It will also hide the north arrow position select in the left panel. 

The north arrow is not supported for split view maps. 

Fixes: https://dhis2.atlassian.net/browse/DHIS2-15436

After this PR: 
![Screenshot 2023-06-22 at 14 16 25](https://github.com/dhis2/maps-app/assets/548708/59de7230-6baf-4f76-a992-65719d6e7a88)

Before: 
![Screenshot 2023-06-22 at 14 17 11](https://github.com/dhis2/maps-app/assets/548708/208f9354-8cf1-429b-8987-8663b2cf79f0)
