### PR TITLE
fix: keep layer visibility when period is changed

### DIFF
--- a/src/components/map/layers/Layer.js
+++ b/src/components/map/layers/Layer.js
@@ -107,6 +107,7 @@ class Layer extends PureComponent {
         await this.removeLayer()
         await this.createLayer(true)
         this.setLayerOrder()
+        this.setLayerVisibility()
     }
 
     // Override in subclass if needed


### PR DESCRIPTION
This PR will make sure the layer visibility is kept when the timeline period is changed.

Fixes: https://dhis2.atlassian.net/browse/DHIS2-15439

After this PR: 
![ezgif com-video-to-gif](https://github.com/dhis2/maps-app/assets/548708/57526f03-6743-42c5-927c-1829f96414b5)
