### PR TITLE
chore: increase cypress default timeout for DOM activity

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -8,5 +8,6 @@
         "networkMode": "live",
         "dhis2ApiVersion": "40"
     },
-    "testFiles": "**/*.cy.js"
+    "testFiles": "**/*.cy.js",
+    "defaultCommandTimeout": 15000
 }


### PR DESCRIPTION
We seem to get random failures pretty regularly and they are often caused by slow instance. This will increase the default timeout for all DOM activity, which I hope will alleviate some of this.