### PR TITLE
chore: remove target-branch from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
     - package-ecosystem: npm
       directory: '/'
       schedule:
-          interval: weekly
+          interval: daily
       open-pull-requests-limit: 10
       versioning-strategy: increase

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,6 @@ updates:
     - package-ecosystem: npm
       directory: '/'
       schedule:
-          interval: daily
+          interval: weekly
       open-pull-requests-limit: 10
-      target-branch: dev
       versioning-strategy: increase

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,5 @@ updates:
       schedule:
           interval: daily
       open-pull-requests-limit: 10
-      target-branch: master
+      target-branch: dev
       versioning-strategy: increase


### PR DESCRIPTION
Test this to see if dependabot uses the default branch set in the repo