### PR TITLE
fix: upgrade landcover dataset (DHIS2-15472)

### DIFF
--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -316,15 +316,15 @@ export const earthEngineLayers = () => [
     },
     {
         layer: EARTH_ENGINE_LAYER,
-        layerId: 'MODIS/006/MCD12Q1',
-        datasetId: 'MODIS/006/MCD12Q1', // No longer in use: 'MODIS/051/MCD12Q1',
+        layerId: 'MODIS/006/MCD12Q1', // Layer id kept for backward compability for saved maps
+        datasetId: 'MODIS/061/MCD12Q1', // No longer in use: 'MODIS/006/MCD12Q1' / 'MODIS/051/MCD12Q1',
         name: i18n.t('Landcover'),
         description: i18n.t(
             'Distinct landcover types collected from satellites.'
         ),
         source: 'NASA LP DAAC / Google Earth Engine',
         sourceUrl:
-            'https://developers.google.com/earth-engine/datasets/catalog/MODIS_006_MCD12Q1',
+            'https://developers.google.com/earth-engine/datasets/catalog/MODIS_061_MCD12Q1',
         periodType: 'Yearly',
         band: 'LC_Type1',
         filters: defaultFilters,


### PR DESCRIPTION
Fixes: https://dhis2.atlassian.net/browse/DHIS2-15472

This PR will upgrade to the latest version of the Landcover dataset on Google Earth Engine: 
https://developers.google.com/earth-engine/datasets/catalog/MODIS_061_MCD12Q1

The previous version (https://developers.google.com/earth-engine/datasets/catalog/MODIS_006_MCD12Q1) showed this message: 

![Screenshot 2023-06-27 at 15 41 37](https://github.com/dhis2/maps-app/assets/548708/fe08c5ac-3df7-4263-a825-4b51d1846191)

The layerId was kept so that saved landcover maps will still work. LayerId is only used internally, datasetId is the is the Earth Engine dataset id. 

After this PR the new landcover dataset is loaded: 
![Screenshot 2023-06-27 at 15 48 27](https://github.com/dhis2/maps-app/assets/548708/bc9dca2c-fc17-4689-aba9-5746b1faeb58)
