### PR TITLE
chore: RenderingStategy as functional component and usePrevious hook

### DIFF
--- a/src/components/dataItem/CoordinateField.js
+++ b/src/components/dataItem/CoordinateField.js
@@ -1,6 +1,7 @@
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
-import React, { useRef, useMemo, useEffect } from 'react'
+import React, { useMemo, useEffect } from 'react'
+import usePrevious from '../../hooks/usePrevious.js'
 import {
     EVENT_COORDINATE_DEFAULT,
     EVENT_COORDINATE_ENROLLMENT,
@@ -28,7 +29,7 @@ const CoordinateField = ({
         includeTypes,
     })
 
-    const prevProgram = useRef(program)
+    const prevProgram = usePrevious(program)
 
     const isTrackerProgram = !!program?.trackedEntityType
 
@@ -83,11 +84,10 @@ const CoordinateField = ({
 
     // Reset default value when program is changed
     useEffect(() => {
-        if (prevProgram.current !== program) {
+        if (program !== prevProgram) {
             onChange(defaultValue)
-            prevProgram.current = program
         }
-    }, [program, defaultValue, onChange])
+    }, [program, prevProgram, defaultValue, onChange])
 
     return (
         <div className={className}>

--- a/src/components/dataItem/CoordinateField.js
+++ b/src/components/dataItem/CoordinateField.js
@@ -1,7 +1,6 @@
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React, { useMemo, useEffect } from 'react'
-import usePrevious from '../../hooks/usePrevious.js'
 import {
     EVENT_COORDINATE_DEFAULT,
     EVENT_COORDINATE_ENROLLMENT,
@@ -11,6 +10,7 @@ import {
     NONE,
 } from '../../constants/layers.js'
 import { useEventDataItems } from '../../hooks/useEventDataItems.js'
+import usePrevious from '../../hooks/usePrevious.js'
 import { SelectField } from '../core/index.js'
 
 const includeTypes = ['COORDINATE']

--- a/src/components/periods/RenderingStrategy.js
+++ b/src/components/periods/RenderingStrategy.js
@@ -2,7 +2,6 @@ import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import { useSelector } from 'react-redux'
-import usePrevious from '../../hooks/usePrevious.js'
 import {
     RENDERING_STRATEGY_SINGLE,
     RENDERING_STRATEGY_TIMELINE,
@@ -12,6 +11,7 @@ import {
     singleMapPeriods,
     invalidSplitViewPeriods,
 } from '../../constants/periods.js'
+import usePrevious from '../../hooks/usePrevious.js'
 import { Radio, RadioGroup } from '../core/index.js'
 
 const RenderingStrategy = ({

--- a/src/components/periods/RenderingStrategy.js
+++ b/src/components/periods/RenderingStrategy.js
@@ -1,7 +1,8 @@
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
-import { connect } from 'react-redux'
+import React, { useEffect } from 'react'
+import { useSelector } from 'react-redux'
+import usePrevious from '../../hooks/usePrevious.js'
 import {
     RENDERING_STRATEGY_SINGLE,
     RENDERING_STRATEGY_TIMELINE,
@@ -13,24 +14,27 @@ import {
 } from '../../constants/periods.js'
 import { Radio, RadioGroup } from '../core/index.js'
 
-class RenderingStrategy extends Component {
-    static propTypes = {
-        onChange: PropTypes.func.isRequired,
-        hasOtherLayers: PropTypes.bool,
-        hasOtherTimelineLayers: PropTypes.bool,
-        period: PropTypes.object,
-        value: PropTypes.string,
-    }
+const RenderingStrategy = ({
+    layerId,
+    value = RENDERING_STRATEGY_SINGLE,
+    period = {},
+    onChange,
+}) => {
+    const hasOtherLayers = useSelector(
+        ({ map }) => !!map.mapViews.filter(({ id }) => id !== layerId).length
+    )
+    const hasOtherTimelineLayers = useSelector(
+        ({ map }) =>
+            !!map.mapViews.find(
+                (layer) =>
+                    layer.renderingStrategy === RENDERING_STRATEGY_TIMELINE &&
+                    layer.id !== layerId
+            )
+    )
+    const prevPeriod = usePrevious(period)
 
-    static defaultProps = {
-        value: RENDERING_STRATEGY_SINGLE,
-        period: {},
-    }
-
-    componentDidUpdate(prevProps) {
-        const { value, period, onChange } = this.props
-
-        if (period !== prevProps.period) {
+    useEffect(() => {
+        if (period !== prevPeriod) {
             if (
                 singleMapPeriods.includes(period.id) &&
                 value !== RENDERING_STRATEGY_SINGLE
@@ -44,65 +48,50 @@ class RenderingStrategy extends Component {
                 onChange(RENDERING_STRATEGY_SINGLE)
             }
         }
+    }, [value, period, prevPeriod, onChange])
+
+    if (singleMapPeriods.includes(period.id)) {
+        return null
     }
 
-    render() {
-        const {
-            value,
-            period,
-            hasOtherLayers,
-            hasOtherTimelineLayers,
-            onChange,
-        } = this.props
+    let helpText
 
-        if (singleMapPeriods.includes(period.id)) {
-            return null
-        }
-
-        let helpText
-
-        if (hasOtherTimelineLayers) {
-            helpText = i18n.t('Only one timeline is allowed.')
-        } else if (hasOtherLayers) {
-            helpText = i18n.t('Remove other layers to enable split map views.')
-        }
-
-        return (
-            <RadioGroup
-                label={i18n.t('Display periods')}
-                value={value}
-                onChange={onChange}
-                helpText={helpText}
-            >
-                <Radio value="SINGLE" label={i18n.t('Single (aggregate)')} />
-                <Radio
-                    value="TIMELINE"
-                    label={i18n.t('Timeline')}
-                    disabled={hasOtherTimelineLayers}
-                />
-                <Radio
-                    value="SPLIT_BY_PERIOD"
-                    label={i18n.t('Split map views')}
-                    disabled={
-                        hasOtherLayers ||
-                        invalidSplitViewPeriods.includes(period.id)
-                    }
-                />
-            </RadioGroup>
-        )
+    if (hasOtherTimelineLayers) {
+        helpText = i18n.t('Only one timeline is allowed.')
+    } else if (hasOtherLayers) {
+        helpText = i18n.t('Remove other layers to enable split map views.')
     }
+
+    return (
+        <RadioGroup
+            label={i18n.t('Display periods')}
+            value={value}
+            onChange={onChange}
+            helpText={helpText}
+        >
+            <Radio value="SINGLE" label={i18n.t('Single (aggregate)')} />
+            <Radio
+                value="TIMELINE"
+                label={i18n.t('Timeline')}
+                disabled={hasOtherTimelineLayers}
+            />
+            <Radio
+                value="SPLIT_BY_PERIOD"
+                label={i18n.t('Split map views')}
+                disabled={
+                    hasOtherLayers ||
+                    invalidSplitViewPeriods.includes(period.id)
+                }
+            />
+        </RadioGroup>
+    )
 }
 
-export default connect((state, props) => {
-    const { mapViews } = state.map
+RenderingStrategy.propTypes = {
+    onChange: PropTypes.func.isRequired,
+    layerId: PropTypes.string,
+    period: PropTypes.object,
+    value: PropTypes.string,
+}
 
-    return {
-        hasOtherLayers: !!mapViews.filter(({ id }) => id !== props.layerId)
-            .length,
-        hasOtherTimelineLayers: !!mapViews.find(
-            (layer) =>
-                layer.renderingStrategy === RENDERING_STRATEGY_TIMELINE &&
-                layer.id !== props.layerId
-        ),
-    }
-})(RenderingStrategy)
+export default RenderingStrategy

--- a/src/hooks/usePrevious.js
+++ b/src/hooks/usePrevious.js
@@ -1,0 +1,13 @@
+import { useRef, useEffect } from 'react'
+
+const usePrevious = (value) => {
+    const prev = useRef()
+
+    useEffect(() => {
+        prev.current = value
+    }, [value])
+
+    return prev.current
+}
+
+export default usePrevious


### PR DESCRIPTION
This PR will turn RenderingStrategy from a class-based to a functional component. It also creates a new usePrevious hook to access the previous value of a property. The CoordinateField component was updated to use the same hook. 

Both components should work as before as shown in the screen recordings below:

![ezgif com-video-to-gif (3)](https://github.com/dhis2/maps-app/assets/548708/b2fdf3fb-6686-4052-bf75-619d8ca691c8)

![ezgif com-video-to-gif (4)](https://github.com/dhis2/maps-app/assets/548708/96958175-85b1-41e4-847c-542768466ec0)
