### PR TITLE
fix: hide "show longitude/latitude" from context menu for split view maps (DHIS2-15798)

### DIFF
--- a/cypress/elements/map_canvas.js
+++ b/cypress/elements/map_canvas.js
@@ -1,0 +1,3 @@
+import { EXTENDED_TIMEOUT } from '../support/util.js'
+
+export const getMaps = () => cy.get('.dhis2-map canvas', EXTENDED_TIMEOUT)

--- a/cypress/elements/map_context_menu.js
+++ b/cypress/elements/map_context_menu.js
@@ -1,0 +1,47 @@
+export const DRILL_UP = 'context-menu-drill-up'
+export const DRILL_DOWN = 'context-menu-drill-down'
+export const VIEW_PROFILE = 'context-menu-view-profile'
+export const SHOW_LONG_LAT = 'context-menu-show-long-lat'
+
+const ALL_OPTIONS = [DRILL_UP, DRILL_DOWN, VIEW_PROFILE, SHOW_LONG_LAT]
+
+export const expectContextMenuOptions = (availableOptions) => {
+    cy.get('canvas.mapboxgl-canvas')
+        .first()
+        .then(($el) => {
+            const xpos = $el.width() / 2
+            const ypos = $el.height() / 2
+
+            // right clicking on the center of the map should hit an OU
+            cy.get('canvas.mapboxgl-canvas').first().rightclick(xpos, ypos)
+
+            // menu has correct number of items
+            cy.getByDataTest('context-menu')
+                .find('li')
+                .should('have.length', availableOptions.length)
+
+            const unavailableOptions = ALL_OPTIONS.filter(
+                (opt) => !availableOptions.map((opt) => opt.name).includes(opt)
+            )
+
+            unavailableOptions.forEach((name) =>
+                cy.getByDataTest(name).should('not.exist')
+            )
+
+            availableOptions.forEach((option) => {
+                // check the menu items
+                cy.getByDataTest(option.name).should('be.visible')
+                if (option.disabled) {
+                    cy.getByDataTest(option.name).should(
+                        'have.class',
+                        'disabled'
+                    )
+                } else {
+                    cy.getByDataTest(option.name).should(
+                        'not.have.class',
+                        'disabled'
+                    )
+                }
+            })
+        })
+}

--- a/cypress/elements/map_context_menu.js
+++ b/cypress/elements/map_context_menu.js
@@ -1,3 +1,5 @@
+import { getMaps } from './map_canvas.js'
+
 export const DRILL_UP = 'context-menu-drill-up'
 export const DRILL_DOWN = 'context-menu-drill-down'
 export const VIEW_PROFILE = 'context-menu-view-profile'
@@ -6,14 +8,14 @@ export const SHOW_LONG_LAT = 'context-menu-show-long-lat'
 const ALL_OPTIONS = [DRILL_UP, DRILL_DOWN, VIEW_PROFILE, SHOW_LONG_LAT]
 
 export const expectContextMenuOptions = (availableOptions) => {
-    cy.get('canvas.mapboxgl-canvas')
+    getMaps()
         .first()
         .then(($el) => {
             const xpos = $el.width() / 2
             const ypos = $el.height() / 2
 
             // right clicking on the center of the map should hit an OU
-            cy.get('canvas.mapboxgl-canvas').first().rightclick(xpos, ypos)
+            getMaps().first().rightclick(xpos, ypos)
 
             // menu has correct number of items
             cy.getByDataTest('context-menu')

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -1,8 +1,8 @@
+import { getMaps } from '../../elements/map_canvas.js'
 import {
     DRILL_UP,
     DRILL_DOWN,
     VIEW_PROFILE,
-    SHOW_LONG_LAT,
     expectContextMenuOptions,
 } from '../../elements/map_context_menu.js'
 import { ThematicLayer } from '../../elements/thematic_layer.js'
@@ -54,7 +54,7 @@ context('Thematic Layers', () => {
         //     '96.28 - 102.8 (4)',
         // ]);
 
-        cy.get('canvas.mapboxgl-canvas').should('have.length', 1)
+        getMaps().should('have.length', 1)
     })
 
     it('adds a thematic layer for OU Bombali', () => {
@@ -80,7 +80,7 @@ context('Thematic Layers', () => {
         //     '89.46 - 91.6 (1)',
         // ]);
 
-        cy.get('canvas.mapboxgl-canvas').should('have.length', 1)
+        getMaps().should('have.length', 1)
     })
 
     it('adds a thematic layer with start and end date', () => {
@@ -101,7 +101,7 @@ context('Thematic Layers', () => {
             `Feb 1, ${CURRENT_YEAR} - Nov 30, ${CURRENT_YEAR}`
         )
 
-        cy.get('canvas.mapboxgl-canvas').should('have.length', 1)
+        getMaps().should('have.length', 1)
     })
 
     it('adds a thematic layer with split view period', () => {
@@ -125,7 +125,7 @@ context('Thematic Layers', () => {
         Layer.validateCardTitle('ANC 1 Coverage')
 
         // check for 3 maps
-        cy.get('canvas.mapboxgl-canvas').should('have.length', 3)
+        getMaps().should('have.length', 3)
 
         // wait to make sure the maps are loaded
         cy.wait(2000) // eslint-disable-line cypress/no-unnecessary-waiting

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -1,3 +1,10 @@
+import {
+    DRILL_UP,
+    DRILL_DOWN,
+    VIEW_PROFILE,
+    SHOW_LONG_LAT,
+    expectContextMenuOptions,
+} from '../../elements/map_context_menu.js'
 import { ThematicLayer } from '../../elements/thematic_layer.js'
 import { CURRENT_YEAR } from '../../support/util.js'
 
@@ -37,8 +44,6 @@ context('Thematic Layers', () => {
 
         Layer.validateDialogClosed(true)
 
-        // TODO: use visual snapshot testing to check the rendering of the map
-
         Layer.validateCardTitle(INDICATOR_NAME)
         // TODO: test this in a way that is not dependent on the date
         // Layer.validateCardItems([
@@ -48,6 +53,8 @@ context('Thematic Layers', () => {
         //     '89.76 - 96.28 (3)',
         //     '96.28 - 102.8 (4)',
         // ]);
+
+        cy.get('canvas.mapboxgl-canvas').should('have.length', 1)
     })
 
     it('adds a thematic layer for OU Bombali', () => {
@@ -63,8 +70,6 @@ context('Thematic Layers', () => {
 
         Layer.validateDialogClosed(true)
 
-        // TODO: use visual snapshot testing to check the rendering of the map
-
         Layer.validateCardTitle(INDICATOR_NAME)
         // TODO: test this in a way that is not dependent on the date
         // Layer.validateCardItems([
@@ -74,6 +79,8 @@ context('Thematic Layers', () => {
         //     '87.32 - 89.46 (0)',
         //     '89.46 - 91.6 (1)',
         // ]);
+
+        cy.get('canvas.mapboxgl-canvas').should('have.length', 1)
     })
 
     it('adds a thematic layer with start and end date', () => {
@@ -93,5 +100,40 @@ context('Thematic Layers', () => {
         Layer.validateCardTitle(INDICATOR_NAME).validateCardPeriod(
             `Feb 1, ${CURRENT_YEAR} - Nov 30, ${CURRENT_YEAR}`
         )
+
+        cy.get('canvas.mapboxgl-canvas').should('have.length', 1)
+    })
+
+    it('adds a thematic layer with split view period', () => {
+        Layer.openDialog('Thematic')
+            .selectIndicatorGroup('ANC')
+            .selectIndicator('ANC 1 Coverage')
+            .selectTab('Period')
+
+        cy.getByDataTest('relative-period-select-content').click()
+        cy.contains('Last 3 months').click()
+
+        cy.get('[type="radio"]').should('have.length', 3)
+        cy.get('[type="radio"]').check('SPLIT_BY_PERIOD')
+
+        cy.getByDataTest('dhis2-uicore-modalactions')
+            .contains('Add layer')
+            .click()
+
+        Layer.validateDialogClosed(true)
+
+        Layer.validateCardTitle('ANC 1 Coverage')
+
+        // check for 3 maps
+        cy.get('canvas.mapboxgl-canvas').should('have.length', 3)
+
+        // wait to make sure the maps are loaded
+        cy.wait(2000) // eslint-disable-line cypress/no-unnecessary-waiting
+
+        expectContextMenuOptions([
+            { name: DRILL_UP, disabled: true },
+            { name: DRILL_DOWN },
+            { name: VIEW_PROFILE },
+        ])
     })
 })

--- a/src/components/core/Radio.js
+++ b/src/components/core/Radio.js
@@ -21,6 +21,7 @@ const Radio = ({ value, disabled, dense = true, dataTest, label }) => {
             checked={value === radio}
             onChange={onClick}
             dataTest={dataTest}
+            value={value}
         />
     )
 }

--- a/src/components/map/ContextMenu.js
+++ b/src/components/map/ContextMenu.js
@@ -108,9 +108,10 @@ const ContextMenu = (props) => {
                 onClickOutside={closeContextMenu}
             >
                 <div className={styles.menu}>
-                    <Menu dense>
+                    <Menu dense dataTest="context-menu">
                         {layerType !== FACILITY_LAYER && feature && (
                             <MenuItem
+                                dataTest="context-menu-drill-up"
                                 label={i18n.t('Drill up one level')}
                                 icon={<IconArrowUp16 />}
                                 disabled={!attr.hasCoordinatesUp}
@@ -120,6 +121,7 @@ const ContextMenu = (props) => {
 
                         {layerType !== FACILITY_LAYER && feature && (
                             <MenuItem
+                                dataTest="context-menu-drill-down"
                                 label={i18n.t('Drill down one level')}
                                 icon={<IconArrowDown16 />}
                                 disabled={!attr.hasCoordinatesDown}
@@ -129,6 +131,7 @@ const ContextMenu = (props) => {
 
                         {feature && (
                             <MenuItem
+                                dataTest="context-menu-view-profile"
                                 label={i18n.t('View profile')}
                                 icon={<IconInfo16 />}
                                 onClick={() => onClick('show_info')}
@@ -137,6 +140,7 @@ const ContextMenu = (props) => {
 
                         {coordinates && !isSplitView && (
                             <MenuItem
+                                dataTest="context-menu-show-long-lat"
                                 label={i18n.t('Show longitude/latitude')}
                                 icon={<IconLocation16 />}
                                 onClick={() => onClick('show_coordinate')}
@@ -145,6 +149,7 @@ const ContextMenu = (props) => {
 
                         {earthEngineLayers.map((layer) => (
                             <MenuItem
+                                dataTest="context-menu-show-ee-value"
                                 key={layer.id}
                                 label={i18n.t('Show {{name}}', {
                                     name: layer.name.toLowerCase(),

--- a/src/components/map/ContextMenu.js
+++ b/src/components/map/ContextMenu.js
@@ -18,7 +18,11 @@ import {
     showEarthEngineValue,
 } from '../../actions/map.js'
 import { setOrgUnitProfile } from '../../actions/orgUnits.js'
-import { FACILITY_LAYER, EARTH_ENGINE_LAYER } from '../../constants/layers.js'
+import {
+    FACILITY_LAYER,
+    EARTH_ENGINE_LAYER,
+    RENDERING_STRATEGY_SPLIT_BY_PERIOD,
+} from '../../constants/layers.js'
 import { drillUpDown } from '../../util/map.js'
 import styles from './styles/ContextMenu.module.css'
 
@@ -43,6 +47,9 @@ const ContextMenu = (props) => {
     if (!position) {
         return null
     }
+
+    const isSplitView =
+        layerConfig?.renderingStrategy === RENDERING_STRATEGY_SPLIT_BY_PERIOD
 
     const left = offset[0] + position[0]
     const top = offset[1] + position[1]
@@ -128,7 +135,7 @@ const ContextMenu = (props) => {
                             />
                         )}
 
-                        {coordinates && (
+                        {coordinates && !isSplitView && (
                             <MenuItem
                                 label={i18n.t('Show longitude/latitude')}
                                 icon={<IconLocation16 />}


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-15798 

This PR will remove "Show longitude/latitude" from the context menu for split view maps, as it is not supported. 

After this PR the menu item is removed: 

![Screenshot 2023-09-04 at 11 56 58](https://github.com/dhis2/maps-app/assets/548708/0b20cf31-2c29-4cef-8557-7583aa19bb65)
