### PR TITLE
fix: use display name based on system / user setting (DHIS2-14999)

### DIFF
--- a/src/components/dataSets/DataSetsSelect.js
+++ b/src/components/dataSets/DataSetsSelect.js
@@ -3,24 +3,28 @@ import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { SelectField } from '../core/index.js'
+import { useUserSettings } from '../UserSettingsProvider.js'
 
 // Load all data sets (reporting rates)
 const DATA_SETS_QUERY = {
     sets: {
         resource: 'dataSets',
-        params: {
+        params: ({ nameProperty }) => ({
             fields: [
                 'dimensionItem~rename(id)',
-                'displayName~rename(name)',
+                `${nameProperty}~rename(name)`,
                 'legendSet[id]',
             ],
             paging: false,
-        },
+        }),
     },
 }
 
 const DataSetsSelect = ({ dataSet, onChange, className, errorText }) => {
-    const { loading, error, data } = useDataQuery(DATA_SETS_QUERY)
+    const { nameProperty } = useUserSettings()
+    const { loading, error, data } = useDataQuery(DATA_SETS_QUERY, {
+        variables: { nameProperty },
+    })
 
     const dataSetId = dataSet ? dataSet.id.split('.')[0] : null // Remove ".REPORTING_RATE"
 


### PR DESCRIPTION
This PR use display name for data sets (reporting rates) based on system / user settings. 

Partly fixes: https://dhis2.atlassian.net/browse/DHIS2-14999

Support for display name for org units and org unit groups are not supported in any of the analytics apps, and need to be implemented for the OrgUnitDimension component in @dhis2/analytics. There are currently no plans to add this support. 

After this PR: 

![Screenshot 2023-09-05 at 13 17 57](https://github.com/dhis2/maps-app/assets/548708/969b7fff-1928-498a-89dd-ba9f0525656a)

![Screenshot 2023-09-05 at 13 25 40](https://github.com/dhis2/maps-app/assets/548708/3c53b08f-1e35-4882-a509-c0c533e49d93)

