### PR TITLE
fix: draw layers with opacity (DHIS2-15793)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@dhis2/app-service-alerts": "^3.9.4",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",
         "@dhis2/d2-i18n": "^1.1.1",
-        "@dhis2/maps-gl": "^3.8.4",
+        "@dhis2/maps-gl": "^3.8.5",
         "@dhis2/ui": "^8.13.15",
         "@krakenjs/post-robot": "^11.0.0",
         "abortcontroller-polyfill": "^1.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2236,10 +2236,10 @@
     markdown-it "^8.4.2"
     prop-types "^15.6.2"
 
-"@dhis2/maps-gl@^3.8.4":
-  version "3.8.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-3.8.4.tgz#88ff4430447b0cacbe8ea5ff7db28bcf24e0b30f"
-  integrity sha512-K7iO8kC8Wfnlhx4nv7bA1tkcKyCbEH6MuGbU2HqVdVTqfEHW+3OMSsamOZdRorg/eynJYmJsPguva+PQtgW5Bg==
+"@dhis2/maps-gl@^3.8.5":
+  version "3.8.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-3.8.5.tgz#0bf52902736996093dc977b55f3626ed56aacbc1"
+  integrity sha512-2Pi6GtfElyJ4L9Cwl/WmxV28HT9h4euZE9XH0Pt1jhGSW108knoHXymfW9jRT1ZLk8Cwi9Xlsvv7wHzJ4nSGCQ==
   dependencies:
     "@mapbox/sphericalmercator" "^1.2.0"
     "@turf/area" "^6.5.0"


### PR DESCRIPTION
Fixes: https://dhis2.atlassian.net/browse/DHIS2-15793

This PR will make sure DHIS2 Maps get this fix: https://github.com/dhis2/maps-gl/pull/549

After this PR there the no opacity flashing is no longer present:

![ezgif com-video-to-gif](https://github.com/dhis2/maps-gl/assets/548708/de52a9c6-62fb-4c7b-90bf-6bc77cea1a5a)

