### PR TITLE
fix: use programIndicators endpoint respecting sharing settings

### DIFF
--- a/src/components/program/ProgramIndicatorSelect.js
+++ b/src/components/program/ProgramIndicatorSelect.js
@@ -6,7 +6,7 @@ import React, { useEffect } from 'react'
 import { SelectField } from '../core/index.js'
 import { useUserSettings } from '../UserSettingsProvider.js'
 
-// Load program indicators for one porgram
+// Load program indicators for one program
 const PROGRAM_INDICATORS_QUERY = {
     indicators: {
         resource: 'programIndicators',

--- a/src/components/program/ProgramIndicatorSelect.js
+++ b/src/components/program/ProgramIndicatorSelect.js
@@ -9,10 +9,10 @@ import { useUserSettings } from '../UserSettingsProvider.js'
 // Load program indicators for one porgram
 const PROGRAM_INDICATORS_QUERY = {
     indicators: {
-        resource: 'programs',
-        id: ({ id }) => id,
-        params: ({ nameProperty }) => ({
-            fields: `programIndicators[dimensionItem~rename(id),${nameProperty}~rename(name)]`,
+        resource: 'programIndicators',
+        params: ({ id, nameProperty }) => ({
+            filter: `program.id:eq:${id}`,
+            fields: ['id', `${nameProperty}~rename(name)`],
             paging: false,
         }),
     },


### PR DESCRIPTION
This PR will use the programIndicators API endpoint to fetch program indicators. This endpoint is respecting the sharing settings for the user. 

After this PR "BCG doses" is not included when "Public access" is set to "No access": 

![Screenshot 2023-09-05 at 14 51 16](https://github.com/dhis2/maps-app/assets/548708/93dac907-8d8c-4af6-b3cc-4606fd2e672d)

![Screenshot 2023-09-06 at 10 54 38](https://github.com/dhis2/maps-app/assets/548708/841dd771-c906-4153-970d-dbdca5f3a109)

Before this PR "BCG doses" is included: 

![Screenshot 2023-09-06 at 10 56 55](https://github.com/dhis2/maps-app/assets/548708/ebad7a0c-42d3-47ef-963e-42c2d7a81352)
