### PR TITLE
fix: post a data statistics view when map is open or saved

### DIFF
--- a/cypress/integration/filemenu.cy.js
+++ b/cypress/integration/filemenu.cy.js
@@ -39,9 +39,16 @@ describe('File menu', () => {
             req.continue()
         }).as('saveMap')
 
+        cy.intercept({ method: 'POST', url: /dataStatistics/ }).as(
+            'postDataStatistics'
+        )
+
         saveNewMap(MAP_TITLE)
 
         cy.wait('@saveMap').its('response.statusCode').should('eq', 201)
+        cy.wait('@postDataStatistics')
+            .its('response.statusCode')
+            .should('eq', 201)
     })
 
     it.skip('save existing as new map', () => {
@@ -67,9 +74,16 @@ describe('File menu', () => {
             req.continue()
         }).as('saveAsNewMap')
 
+        cy.intercept({ method: 'POST', url: /dataStatistics/ }).as(
+            'postDataStatistics'
+        )
+
         saveAsNewMap(SAVEAS_MAP_TITLE)
 
         cy.wait('@saveAsNewMap').its('response.statusCode').should('eq', 201)
+        cy.wait('@postDataStatistics')
+            .its('response.statusCode')
+            .should('eq', 201)
     })
 
     it.skip('save changes to existing map', () => {

--- a/cypress/integration/smoke.cy.js
+++ b/cypress/integration/smoke.cy.js
@@ -9,7 +9,14 @@ context('Smoke Test', () => {
     })
 
     it('loads with map id', () => {
+        cy.intercept({ method: 'POST', url: /dataStatistics/ }).as(
+            'postDataStatistics'
+        )
         cy.visit('/?id=ytkZY3ChM6J', EXTENDED_TIMEOUT) //ANC: 3rd visit coverage last year by district
+
+        cy.wait('@postDataStatistics')
+            .its('response.statusCode')
+            .should('eq', 201)
 
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 

--- a/src/actions/map.js
+++ b/src/actions/map.js
@@ -55,7 +55,7 @@ export const tOpenMap =
             // record visualization view
             dataEngine.mutate(dataStatisticsMutation, {
                 variables: { id: mapId },
-                onError: (error) => console.log('Error: ', error),
+                onError: (error) => console.error('Error: ', error),
             })
 
             const basemapConfig =

--- a/src/actions/map.js
+++ b/src/actions/map.js
@@ -1,6 +1,7 @@
 import log from 'loglevel'
 import * as types from '../constants/actionTypes.js'
 import { getFallbackBasemap } from '../constants/basemaps.js'
+import { dataStatisticsMutation } from '../util/apiDataStatistics.js'
 import { addOrgUnitPaths } from '../util/helpers.js'
 import { fetchMap } from '../util/requests.js'
 
@@ -50,6 +51,12 @@ export const tOpenMap =
     (mapId, keyDefaultBaseMap, dataEngine) => async (dispatch, getState) => {
         try {
             const map = await fetchMap(mapId, dataEngine, keyDefaultBaseMap)
+
+            // record visualization view
+            dataEngine.mutate(dataStatisticsMutation, {
+                variables: { id: mapId },
+                onError: (error) => console.log('Error: ', error),
+            })
 
             const basemapConfig =
                 getState().basemaps.find((bm) => bm.id === map.basemap.id) ||

--- a/src/components/app/FileMenu.js
+++ b/src/components/app/FileMenu.js
@@ -13,6 +13,7 @@ import {
     ALERT_OPTIONS_DYNAMIC,
     ALERT_SUCCESS_DELAY,
 } from '../../constants/alerts.js'
+import { dataStatisticsMutation } from '../../util/apiDataStatistics.js'
 import { cleanMapConfig } from '../../util/favorites.js'
 import { fetchMap } from '../../util/requests.js'
 import { useSystemSettings } from '../SystemSettingsProvider.js'
@@ -81,6 +82,10 @@ const FileMenu = ({ map, newMap, tOpenMap, setMapProps }) => {
             }),
     })
 
+    const [postDataStatistics] = useDataMutation(dataStatisticsMutation, {
+        onError: (e) => console.error('Error:', e.message),
+    })
+
     const onFileMenuError = (e) =>
         fileMenuErrorAlert.show({
             msg: e.message,
@@ -100,6 +105,8 @@ const FileMenu = ({ map, newMap, tOpenMap, setMapProps }) => {
             id: map.id,
             data: config,
         })
+
+        postDataStatistics({ id: map.id })
 
         saveAlert.show({ msg: getSavedMessage(config.name) })
     }
@@ -136,8 +143,10 @@ const FileMenu = ({ map, newMap, tOpenMap, setMapProps }) => {
         })
 
         if (response.status === 'OK') {
+            const newMapId = response.response.uid
+            postDataStatistics({ id: newMapId })
             const newMapConfig = await fetchMap(
-                response.response.uid,
+                newMapId,
                 engine,
                 keyDefaultBaseMap
             )

--- a/src/util/apiDataStatistics.js
+++ b/src/util/apiDataStatistics.js
@@ -1,0 +1,8 @@
+export const dataStatisticsMutation = {
+    resource: 'dataStatistics',
+    params: ({ id }) => ({
+        favorite: id,
+        eventType: 'VISUALIZATION_VIEW',
+    }),
+    type: 'create',
+}


### PR DESCRIPTION
Fixes one part of https://dhis2.atlassian.net/browse/DHIS2-15800

When a map is opened, saved or save as, then POST a VISUALIZATION_VIEW event. The result is that the count in the Side panel "About this map" will show the correct number of views for the map.

![image](https://github.com/dhis2/maps-app/assets/6113918/b6d9ada2-63f6-454e-b302-c6a1f6a95dda)
