### PR TITLE
fix: show warning if event filter is not supported

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-04-12T09:23:26.646Z\n"
-"PO-Revision-Date: 2023-04-12T09:23:26.646Z\n"
+"POT-Creation-Date: 2023-09-06T13:08:55.205Z\n"
+"PO-Revision-Date: 2023-09-06T13:08:55.205Z\n"
 
 msgid "Untitled map, {{date}}"
 msgstr "Untitled map, {{date}}"
@@ -1270,6 +1270,9 @@ msgstr "Error: {{message}}"
 
 msgid "You don't have access to this layer data"
 msgstr "You don't have access to this layer data"
+
+msgid "The event filter is not supported"
+msgstr "The event filter is not supported"
 
 msgid "An unknown error occurred while reading layer data"
 msgstr "An unknown error occurred while reading layer data"

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -26,6 +26,10 @@ const accessDeniedAlert = {
     warning: true,
     message: i18n.t("You don't have access to this layer data"),
 }
+const filterErrorAlert = {
+    warning: true,
+    message: i18n.t('The event filter is not supported'),
+}
 const unknownErrorAlert = {
     critical: true,
     message: i18n.t('An unknown error occurred while reading layer data'),
@@ -39,7 +43,11 @@ const eventLoader = async (layerConfig) => {
         await loadEventLayer(config)
     } catch (e) {
         if (e.httpStatusCode === 403 || e.httpStatusCode === 409) {
-            config.alerts = [accessDeniedAlert]
+            config.alerts = [
+                e.message.includes('filter is invalid')
+                    ? filterErrorAlert
+                    : accessDeniedAlert,
+            ]
         } else {
             config.alerts = [unknownErrorAlert]
         }


### PR DESCRIPTION
Improves the error message of: https://dhis2.atlassian.net/browse/DHIS2-13171

This PR will show an error message that the event filter is not supported if the API returns a message that includes "filter is invalid". 

After this PR: 

![Screenshot 2023-09-06 at 15 00 57](https://github.com/dhis2/maps-app/assets/548708/50650bbc-785f-4a3d-bf5b-882715337f2a)

Before this PR the message "You don't have access to this layer data" was shown in this case. 