### PR TITLE
chore: send success message to slack when release succeeds

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -137,17 +137,22 @@ jobs:
 
     report-release-success:
         runs-on: ubuntu-latest
-        needs: release
+        needs: test
         if: |
             success() &&
-            !cancelled() &&
-            github.ref == 'refs/heads/master'
+            !cancelled()
         steps:
+            - name: get-npm-version
+              id: package-version
+              uses: martinbeentjes/npm-get-version-action@v1.3.1
+              with:
+                  path: package.json
+
             - name: Send success message to analytics-internal-bot slack channel
               id: slack
               uses: slackapi/slack-github-action@v1.23.0
               with:
                   channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-                  slack-message: ':large_green_circle: :maps-app: :tada: Maps-app released <https://github.com/dhis2/maps-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Asuccess>'
+                  slack-message: ':large_green_circle: :maps-app: :tada: Maps-app ${{ steps.package-version.outputs.current-version}} released <https://github.com/dhis2/maps-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Asuccess>'
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -120,8 +120,9 @@ jobs:
 
     report-release-failure:
         runs-on: ubuntu-latest
-        needs: lint
+        needs: release
         if: |
+            failure() &&
             !cancelled() &&
             github.ref == 'refs/heads/master'
         steps:
@@ -155,10 +156,11 @@ jobs:
 
     report-release-success:
         runs-on: ubuntu-latest
-        needs: lint
+        needs: release
         if: |
             success() &&
-            !cancelled()
+            !cancelled() &&
+            github.ref == 'refs/heads/master'
         steps:
             - name: Checkout code
               uses: actions/checkout@master

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -120,39 +120,70 @@ jobs:
 
     report-release-failure:
         runs-on: ubuntu-latest
-        needs: release
+        needs: lint
         if: |
-            failure() &&
             !cancelled() &&
             github.ref == 'refs/heads/master'
         steps:
+            - name: Checkout code
+              uses: actions/checkout@master
+
+            - name: Extract version
+              id: extract_version
+              uses: Saionaro/extract-package-version@v1.2.1
+
             - name: Send failure message to analytics-internal-bot slack channel
               id: slack
               uses: slackapi/slack-github-action@v1.23.0
               with:
                   channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-                  slack-message: ':small_red_triangle_down: Maps-app release <https://github.com/dhis2/maps-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Afailure>'
+                  payload: |
+                      {
+                        "text": ":small_red_triangle_down: :maps-app: Maps version ${{ steps.extract_version.outputs.version }} release <https://github.com/dhis2/maps-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Afailure|failed>",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": ":small_red_triangle_down: :maps-app: Maps version ${{ steps.extract_version.outputs.version }} release <https://github.com/dhis2/maps-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Afailure|failed>"
+                            }
+                          }
+                        ]
+                      }
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
     report-release-success:
         runs-on: ubuntu-latest
-        needs: test
+        needs: lint
         if: |
             success() &&
             !cancelled()
         steps:
-            - name: get-npm-version
-              id: package-version
-              uses: martinbeentjes/npm-get-version-action@v1.3.1
-              with:
-                  path: package.json
+            - name: Checkout code
+              uses: actions/checkout@master
+
+            - name: Extract version
+              id: extract_version
+              uses: Saionaro/extract-package-version@v1.2.1
 
             - name: Send success message to analytics-internal-bot slack channel
               id: slack
               uses: slackapi/slack-github-action@v1.23.0
               with:
                   channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-                  slack-message: format(':large_green_circle: :maps-app: :tada: Maps-app {0} released <https://github.com/dhis2/maps-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Asuccess>', ${{ steps.package-version.outputs.current-version}})
+                  payload: |
+                      {
+                        "text": ":large_green_circle: :maps-app: :tada: Maps app release succeeded for version: ${{ steps.extract_version.outputs.version }}",
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": ":large_green_circle: :maps-app: :tada: Maps version ${{ steps.extract_version.outputs.version }} released <https://github.com/dhis2/maps-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Asuccess|successfully>"
+                            }
+                          }
+                        ]
+                      }
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -134,3 +134,20 @@ jobs:
                   slack-message: ':small_red_triangle_down: Maps-app release <https://github.com/dhis2/maps-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Afailure>'
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+    report-release-success:
+        runs-on: ubuntu-latest
+        needs: release
+        if: |
+            success() &&
+            !cancelled() &&
+            github.ref == 'refs/heads/master'
+        steps:
+            - name: Send success message to analytics-internal-bot slack channel
+              id: slack
+              uses: slackapi/slack-github-action@v1.23.0
+              with:
+                  channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+                  slack-message: ':large_green_circle: :maps-app: :tada: Maps-app released <https://github.com/dhis2/maps-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Asuccess>'
+              env:
+                  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -153,6 +153,6 @@ jobs:
               uses: slackapi/slack-github-action@v1.23.0
               with:
                   channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
-                  slack-message: ':large_green_circle: :maps-app: :tada: Maps-app ${{ steps.package-version.outputs.current-version}} released <https://github.com/dhis2/maps-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Asuccess>'
+                  slack-message: format(':large_green_circle: :maps-app: :tada: Maps-app {0} released <https://github.com/dhis2/maps-app/actions/workflows/dhis2-verify-app.yml?query=branch%3Amaster+is%3Asuccess>', ${{ steps.package-version.outputs.current-version}})
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Be alerted to release success as well as failure in the `analytics-internal-bot` slack channel.

![image](https://github.com/dhis2/maps-app/assets/6113918/5676bd5c-64e9-4d89-a7c7-4fcb43810fbb)
