### PR TITLE
fix: force table cell content to wrap to prevent overly wide modal

### DIFF
--- a/src/components/map/layers/EventPopup.js
+++ b/src/components/map/layers/EventPopup.js
@@ -5,6 +5,7 @@ import React, { useEffect } from 'react'
 import { EVENT_ID_FIELD } from '../../../util/geojson.js'
 import { formatTime, formatCoordinate } from '../../../util/helpers.js'
 import Popup from '../Popup.js'
+import classes from './styles/EventPopup.module.css'
 
 // Returns true if value is not undefined or null;
 const hasValue = (value) => value !== undefined || value !== null
@@ -47,7 +48,7 @@ const getDataRows = ({ displayElements, dataValues, styleDataItem, value }) => {
 
         dataRows.push(
             <tr key={id}>
-                <th>{name}</th>
+                <td className={classes.header}>{name}</td>
                 <td>{formattedValue}</td>
             </tr>
         )
@@ -87,7 +88,7 @@ const EventPopup = ({
         <Popup
             coordinates={coordinates}
             onClose={onClose}
-            className="dhis2-map-popup-event"
+            className={classes.eventPopup}
         >
             {error && <span>{i18n.t('Could not retrieve event data')}</span>}
             {!error && (
@@ -102,10 +103,10 @@ const EventPopup = ({
                             })}
                         {type === 'Point' && (
                             <tr>
-                                <th>
+                                <td className={classes.header}>
                                     {eventCoordinateFieldName ||
                                         i18n.t('Event location')}
-                                </th>
+                                </td>
                                 <td>
                                     {coord[0].toFixed(6)} {coord[1].toFixed(6)}
                                 </td>
@@ -113,13 +114,17 @@ const EventPopup = ({
                         )}
                         {orgUnitName && (
                             <tr>
-                                <th>{i18n.t('Organisation unit')}</th>
+                                <td className={classes.header}>
+                                    {i18n.t('Organisation unit')}
+                                </td>
                                 <td>{orgUnitName}</td>
                             </tr>
                         )}
                         {eventDate && (
                             <tr>
-                                <th>{i18n.t('Event time')}</th>
+                                <td className={classes.header}>
+                                    {i18n.t('Event time')}
+                                </td>
                                 <td>{formatTime(eventDate)}</td>
                             </tr>
                         )}

--- a/src/components/map/layers/EventPopup.js
+++ b/src/components/map/layers/EventPopup.js
@@ -27,7 +27,7 @@ const getDataRows = ({ displayElements, dataValues, styleDataItem, value }) => {
     ) {
         dataRows.push(
             <tr key={styleDataItem.id}>
-                <th>{styleDataItem.name}</th>
+                <td>{styleDataItem.name}</td>
                 <td>{hasValue(value) ? value : i18n.t('Not set')}</td>
             </tr>
         )
@@ -48,7 +48,7 @@ const getDataRows = ({ displayElements, dataValues, styleDataItem, value }) => {
 
         dataRows.push(
             <tr key={id}>
-                <td className={classes.header}>{name}</td>
+                <td>{name}</td>
                 <td>{formattedValue}</td>
             </tr>
         )
@@ -103,7 +103,7 @@ const EventPopup = ({
                             })}
                         {type === 'Point' && (
                             <tr>
-                                <td className={classes.header}>
+                                <td>
                                     {eventCoordinateFieldName ||
                                         i18n.t('Event location')}
                                 </td>
@@ -114,17 +114,13 @@ const EventPopup = ({
                         )}
                         {orgUnitName && (
                             <tr>
-                                <td className={classes.header}>
-                                    {i18n.t('Organisation unit')}
-                                </td>
+                                <td>{i18n.t('Organisation unit')}</td>
                                 <td>{orgUnitName}</td>
                             </tr>
                         )}
                         {eventDate && (
                             <tr>
-                                <td className={classes.header}>
-                                    {i18n.t('Event time')}
-                                </td>
+                                <td>{i18n.t('Event time')}</td>
                                 <td>{formatTime(eventDate)}</td>
                             </tr>
                         )}

--- a/src/components/map/layers/EventPopup.js
+++ b/src/components/map/layers/EventPopup.js
@@ -27,7 +27,7 @@ const getDataRows = ({ displayElements, dataValues, styleDataItem, value }) => {
     ) {
         dataRows.push(
             <tr key={styleDataItem.id}>
-                <td>{styleDataItem.name}</td>
+                <th>{styleDataItem.name}</th>
                 <td>{hasValue(value) ? value : i18n.t('Not set')}</td>
             </tr>
         )
@@ -48,7 +48,7 @@ const getDataRows = ({ displayElements, dataValues, styleDataItem, value }) => {
 
         dataRows.push(
             <tr key={id}>
-                <td>{name}</td>
+                <th>{name}</th>
                 <td>{formattedValue}</td>
             </tr>
         )
@@ -103,10 +103,10 @@ const EventPopup = ({
                             })}
                         {type === 'Point' && (
                             <tr>
-                                <td>
+                                <th>
                                     {eventCoordinateFieldName ||
                                         i18n.t('Event location')}
-                                </td>
+                                </th>
                                 <td>
                                     {coord[0].toFixed(6)} {coord[1].toFixed(6)}
                                 </td>
@@ -114,13 +114,13 @@ const EventPopup = ({
                         )}
                         {orgUnitName && (
                             <tr>
-                                <td>{i18n.t('Organisation unit')}</td>
+                                <th>{i18n.t('Organisation unit')}</th>
                                 <td>{orgUnitName}</td>
                             </tr>
                         )}
                         {eventDate && (
                             <tr>
-                                <td>{i18n.t('Event time')}</td>
+                                <th>{i18n.t('Event time')}</th>
                                 <td>{formatTime(eventDate)}</td>
                             </tr>
                         )}

--- a/src/components/map/layers/styles/EventPopup.module.css
+++ b/src/components/map/layers/styles/EventPopup.module.css
@@ -1,0 +1,20 @@
+.eventPopup {
+    max-height: 300px;
+    overflow: auto;
+    line-height: 14px;
+    max-width: 400px;
+}
+
+.eventPopup tr td {
+    text-align: left;
+    vertical-align: top;
+}
+
+.eventPopup tr td:first-child {
+    font-weight: 500;
+    padding-right: var(--spacers-dp4);
+}
+
+.eventPopup tr td:last-child {
+    min-width: 120px;
+}

--- a/src/components/map/layers/styles/EventPopup.module.css
+++ b/src/components/map/layers/styles/EventPopup.module.css
@@ -5,16 +5,16 @@
     max-width: 400px;
 }
 
-.eventPopup tr td {
+.eventPopup th, .eventPopup td {
     text-align: left;
     vertical-align: top;
 }
 
-.eventPopup tr td:first-child {
+.eventPopup tr th {
     font-weight: 500;
     padding-right: var(--spacers-dp4);
 }
 
-.eventPopup tr td:last-child {
+.eventPopup tr td {
     min-width: 120px;
 }

--- a/src/components/map/styles/Popup.css
+++ b/src/components/map/styles/Popup.css
@@ -7,10 +7,6 @@
     min-width: 150px;
 }
 
-.dhis2-map-popup-event {
-    overflow-x: auto;
-}
-
-.dhis2-map-popup-event th {
-    text-align: left;
+.maplibregl-popup-close-button:focus {
+    outline: none;
 }


### PR DESCRIPTION
Fixes: https://dhis2.atlassian.net/browse/DHIS2-5920

* Adding a `max-width` to the popup results in table cell content wrapping when needed.
* Event popup styles migrated from maps-gl. Styles are still in maps-gl as well so as not to break 2.38 and 2.39.
* Removed unused styles in popup.css

Before:
![image](https://github.com/dhis2/maps-app/assets/6113918/cf0768a7-365e-4826-a136-76dc61a48ab7)



After:
![image](https://github.com/dhis2/maps-app/assets/6113918/1facb1e1-7292-44e4-b3fc-b812b05e3e46)
