### PR TITLE
chore: update the toolbar feature commit with a fix for interpretationId url parameter

### DIFF
--- a/cypress/integration/interpretations.cy.js
+++ b/cypress/integration/interpretations.cy.js
@@ -67,4 +67,33 @@ context('Interpretations', () => {
 
         deleteMap()
     })
+
+    it('opens and closes the interpretation panel', () => {
+        cy.intercept({ method: 'POST', url: /dataStatistics/ }).as(
+            'postDataStatistics'
+        )
+        cy.visit(
+            '/?id=ZBjCfSaLSqD&interpretationId=yKqhXZdeJ6a',
+            EXTENDED_TIMEOUT
+        ) //ANC: LLITN coverage district and facility
+
+        cy.wait('@postDataStatistics')
+            .its('response.statusCode')
+            .should('eq', 201)
+
+        cy.getByDataTest('interpretation-modal')
+            .find('h1')
+            .contains(
+                'Viewing interpretation: ANC: LLITN coverage district and facility'
+            )
+            .should('be.visible')
+
+        cy.getByDataTest('interpretation-modal')
+            .findByDataTest('dhis2-modal-close-button')
+            .click()
+
+        cy.getByDataTest('interpretation-modal').should('not.exist')
+
+        cy.getByDataTest('interpretations-list').should('be.visible')
+    })
 })

--- a/cypress/integration/smoke.cy.js
+++ b/cypress/integration/smoke.cy.js
@@ -38,4 +38,46 @@ context('Smoke Test', () => {
         Layer.validateCardTitle('ANC 1 Coverage')
         cy.get('canvas.maplibregl-canvas').should('be.visible')
     })
+
+    it('loads with map id and interpretationid lowercase', () => {
+        cy.intercept({ method: 'POST', url: /dataStatistics/ }).as(
+            'postDataStatistics'
+        )
+        cy.visit(
+            '/?id=ZBjCfSaLSqD&interpretationid=yKqhXZdeJ6a',
+            EXTENDED_TIMEOUT
+        ) //ANC: LLITN coverage district and facility
+
+        cy.wait('@postDataStatistics')
+            .its('response.statusCode')
+            .should('eq', 201)
+
+        cy.getByDataTest('interpretation-modal')
+            .find('h1')
+            .contains(
+                'Viewing interpretation: ANC: LLITN coverage district and facility'
+            )
+            .should('be.visible')
+    })
+
+    it('loads with map id and interpretationId uppercase', () => {
+        cy.intercept({ method: 'POST', url: /dataStatistics/ }).as(
+            'postDataStatistics'
+        )
+        cy.visit(
+            '/?id=ZBjCfSaLSqD&interpretationId=yKqhXZdeJ6a',
+            EXTENDED_TIMEOUT
+        ) //ANC: LLITN coverage district and facility
+
+        cy.wait('@postDataStatistics')
+            .its('response.statusCode')
+            .should('eq', 201)
+
+        cy.getByDataTest('interpretation-modal')
+            .find('h1')
+            .contains(
+                'Viewing interpretation: ANC: LLITN coverage district and facility'
+            )
+            .should('be.visible')
+    })
 })

--- a/src/components/app/App.js
+++ b/src/components/app/App.js
@@ -7,6 +7,7 @@ import { useDispatch } from 'react-redux'
 import { tSetAnalyticalObject } from '../../actions/analyticalObject.js'
 import { removeBingBasemaps, setBingMapsApiKey } from '../../actions/basemap.js'
 import { tSetExternalLayers } from '../../actions/externalLayers.js'
+import { setInterpretation } from '../../actions/interpretations.js'
 import { tOpenMap } from '../../actions/map.js'
 import { CURRENT_AO_KEY } from '../../util/analyticalObject.js'
 import { getUrlParameter } from '../../util/requests.js'
@@ -32,6 +33,15 @@ const App = () => {
                 )
             } else if (getUrlParameter('currentAnalyticalObject') === 'true') {
                 await dispatch(tSetAnalyticalObject(currentAO))
+            }
+
+            // analytics interpretation component uses camelcase
+            const interpretationId =
+                getUrlParameter('interpretationid') ||
+                getUrlParameter('interpretationId')
+
+            if (interpretationId) {
+                dispatch(setInterpretation(interpretationId))
             }
         }
 

--- a/src/components/app/DetailsPanel.js
+++ b/src/components/app/DetailsPanel.js
@@ -12,19 +12,11 @@ const DetailsPanel = ({ interpretationsRenderCount }) => {
     const interpretationId = useSelector((state) => state.interpretation?.id)
 
     const getContent = () => {
-        if (interpretationId) {
+        if (interpretationId || (detailsPanelOpen && !viewOrgUnitProfile)) {
             return <Interpretations renderCount={interpretationsRenderCount} />
         }
 
-        if (!detailsPanelOpen) {
-            return null
-        }
-
-        return viewOrgUnitProfile ? (
-            <OrgUnitProfile />
-        ) : (
-            <Interpretations renderCount={interpretationsRenderCount} />
-        )
+        return detailsPanelOpen ? <OrgUnitProfile /> : null
     }
 
     return (

--- a/src/components/app/DetailsPanel.js
+++ b/src/components/app/DetailsPanel.js
@@ -9,8 +9,13 @@ import styles from './styles/DetailsPanel.module.css'
 const DetailsPanel = ({ interpretationsRenderCount }) => {
     const detailsPanelOpen = useSelector((state) => state.ui.rightPanelOpen)
     const viewOrgUnitProfile = useSelector((state) => state.orgUnitProfile)
+    const interpretationId = useSelector((state) => state.interpretation.id)
 
     const getContent = () => {
+        if (interpretationId) {
+            return <Interpretations renderCount={interpretationsRenderCount} />
+        }
+
         if (!detailsPanelOpen) {
             return null
         }

--- a/src/components/app/DetailsPanel.js
+++ b/src/components/app/DetailsPanel.js
@@ -9,7 +9,7 @@ import styles from './styles/DetailsPanel.module.css'
 const DetailsPanel = ({ interpretationsRenderCount }) => {
     const detailsPanelOpen = useSelector((state) => state.ui.rightPanelOpen)
     const viewOrgUnitProfile = useSelector((state) => state.orgUnitProfile)
-    const interpretationId = useSelector((state) => state.interpretation.id)
+    const interpretationId = useSelector((state) => state.interpretation?.id)
 
     const getContent = () => {
         if (interpretationId) {

--- a/src/components/app/__tests__/Detailspanel.spec.js
+++ b/src/components/app/__tests__/Detailspanel.spec.js
@@ -1,0 +1,153 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { Provider } from 'react-redux'
+import configureMockStore from 'redux-mock-store'
+import DetailsPanel from '../DetailsPanel.js'
+
+const mockStore = configureMockStore()
+
+jest.mock(
+    '../../interpretations/Interpretations.js',
+    () =>
+        function MockInterpretations() {
+            return <div>Interpretations</div>
+        }
+)
+
+jest.mock(
+    '../../orgunits/OrgUnitProfile.js',
+    () =>
+        function MockOrgUnitProfile() {
+            return <div>Org Unit Profile</div>
+        }
+)
+
+/*
+Yes, Yes, Yes
+Yes, Yes, No
+Yes, No, Yes
+Yes, No, No
+No, Yes, Yes
+No, Yes, No
+No, No, Yes
+No, No, No
+*/
+
+describe('DetailsPanel', () => {
+    test('renders InterpretationsPanel when has interpretationId, has orgUnitProfile and panel is open', () => {
+        const store = {
+            interpretation: { id: 'abc123' },
+            orgUnitProfile: 'xyzpdq',
+            ui: { rightPanelOpen: true },
+        }
+
+        const { container } = render(
+            <Provider store={mockStore(store)}>
+                <DetailsPanel interpretationsRenderCount={1} />
+            </Provider>
+        )
+        expect(container).toMatchSnapshot()
+    })
+    test('renders InterpretationsPanel when has interpretationId, has orgUnitProfile and panel is closed', () => {
+        const store = {
+            interpretation: { id: 'abc123' },
+            orgUnitProfile: 'xyzpdq',
+            ui: { rightPanelOpen: false },
+        }
+
+        const { container } = render(
+            <Provider store={mockStore(store)}>
+                <DetailsPanel interpretationsRenderCount={1} />
+            </Provider>
+        )
+        expect(container).toMatchSnapshot()
+    })
+    test('renders InterpretationsPanel when has interpretationId, no orgUnitProfile and panel is open', () => {
+        const store = {
+            interpretation: { id: 'abc123' },
+            orgUnitProfile: null,
+            ui: { rightPanelOpen: true },
+        }
+
+        const { container } = render(
+            <Provider store={mockStore(store)}>
+                <DetailsPanel interpretationsRenderCount={1} />
+            </Provider>
+        )
+        expect(container).toMatchSnapshot()
+    })
+
+    test('renders InterpretationsPanel when has interpretationId, no orgUnitProfile and panel is closed', () => {
+        const store = {
+            interpretation: { id: 'abc123' },
+            orgUnitProfile: null,
+            ui: { rightPanelOpen: false },
+        }
+
+        const { container } = render(
+            <Provider store={mockStore(store)}>
+                <DetailsPanel interpretationsRenderCount={1} />
+            </Provider>
+        )
+        expect(container).toMatchSnapshot()
+    })
+
+    test('renders OrgUnitProfile when no interpretationId, has orgUnitProfile and panel is open', () => {
+        const store = {
+            interpretation: {},
+            orgUnitProfile: 'xyzpdq',
+            ui: { rightPanelOpen: true },
+        }
+
+        const { container } = render(
+            <Provider store={mockStore(store)}>
+                <DetailsPanel interpretationsRenderCount={1} />
+            </Provider>
+        )
+        expect(container).toMatchSnapshot()
+    })
+
+    test('renders null when no interpretationId, has orgUnitProfile, and panel closed', () => {
+        const store = {
+            interpretation: {},
+            orgUnitProfile: 'xyzpdq',
+            ui: { rightPanelOpen: false },
+        }
+
+        const { container } = render(
+            <Provider store={mockStore(store)}>
+                <DetailsPanel interpretationsRenderCount={1} />
+            </Provider>
+        )
+        expect(container).toMatchSnapshot()
+    })
+    test('renders InterpretationsPanel when no interpretationId, no orgUnitProfile and panel open', () => {
+        const store = {
+            interpretation: {},
+            orgUnitProfile: null,
+            ui: { rightPanelOpen: true },
+        }
+
+        const { container } = render(
+            <Provider store={mockStore(store)}>
+                <DetailsPanel interpretationsRenderCount={1} />
+            </Provider>
+        )
+        expect(container).toMatchSnapshot()
+    })
+
+    test('renders null when no interpretationId, no orgUnitProfile, and panel closed', () => {
+        const store = {
+            interpretation: {},
+            orgUnitProfile: null,
+            ui: { rightPanelOpen: false },
+        }
+
+        const { container } = render(
+            <Provider store={mockStore(store)}>
+                <DetailsPanel interpretationsRenderCount={1} />
+            </Provider>
+        )
+        expect(container).toMatchSnapshot()
+    })
+})

--- a/src/components/app/__tests__/Detailspanel.spec.js
+++ b/src/components/app/__tests__/Detailspanel.spec.js
@@ -22,17 +22,6 @@ jest.mock(
         }
 )
 
-/*
-Yes, Yes, Yes
-Yes, Yes, No
-Yes, No, Yes
-Yes, No, No
-No, Yes, Yes
-No, Yes, No
-No, No, Yes
-No, No, No
-*/
-
 describe('DetailsPanel', () => {
     test('renders InterpretationsPanel when has interpretationId, has orgUnitProfile and panel is open', () => {
         const store = {

--- a/src/components/app/__tests__/__snapshots__/Detailspanel.spec.js.snap
+++ b/src/components/app/__tests__/__snapshots__/Detailspanel.spec.js.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DetailsPanel renders InterpretationsPanel when has interpretationId, has orgUnitProfile and panel is closed 1`] = `
+<div>
+  <div
+    class="detailsPanel collapsed"
+  >
+    <div>
+      Interpretations
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsPanel renders InterpretationsPanel when has interpretationId, has orgUnitProfile and panel is open 1`] = `
+<div>
+  <div
+    class="detailsPanel"
+  >
+    <div>
+      Interpretations
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsPanel renders InterpretationsPanel when has interpretationId, no orgUnitProfile and panel is closed 1`] = `
+<div>
+  <div
+    class="detailsPanel collapsed"
+  >
+    <div>
+      Interpretations
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsPanel renders InterpretationsPanel when has interpretationId, no orgUnitProfile and panel is open 1`] = `
+<div>
+  <div
+    class="detailsPanel"
+  >
+    <div>
+      Interpretations
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsPanel renders InterpretationsPanel when no interpretationId, no orgUnitProfile and panel open 1`] = `
+<div>
+  <div
+    class="detailsPanel"
+  >
+    <div>
+      Interpretations
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsPanel renders OrgUnitProfile when no interpretationId, has orgUnitProfile and panel is open 1`] = `
+<div>
+  <div
+    class="detailsPanel"
+  >
+    <div>
+      Org Unit Profile
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsPanel renders null when no interpretationId, has orgUnitProfile, and panel closed 1`] = `
+<div>
+  <div
+    class="detailsPanel collapsed"
+  />
+</div>
+`;
+
+exports[`DetailsPanel renders null when no interpretationId, no orgUnitProfile, and panel closed 1`] = `
+<div>
+  <div
+    class="detailsPanel collapsed"
+  />
+</div>
+`;

--- a/src/components/interpretations/Interpretations.js
+++ b/src/components/interpretations/Interpretations.js
@@ -1,9 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
-import { setInterpretation } from '../../actions/interpretations.js'
 import { openInterpretationsPanel } from '../../actions/ui.js'
-import { getUrlParameter } from '../../util/requests.js'
 import InterpretationsPanel from './InterpretationsPanel.js'
 
 const Interpretations = ({ renderCount }) => {
@@ -15,15 +13,7 @@ const Interpretations = ({ renderCount }) => {
 
     useEffect(() => {
         if (isMapLoaded) {
-            // analytics interpretation component uses camelcase
-            const urlInterpretationId =
-                getUrlParameter('interpretationid') ||
-                getUrlParameter('interpretationId')
-
-            if (urlInterpretationId) {
-                dispatch(setInterpretation(urlInterpretationId))
-                dispatch(openInterpretationsPanel())
-            }
+            dispatch(openInterpretationsPanel())
         }
     }, [isMapLoaded, dispatch])
 


### PR DESCRIPTION
With the changes from the toolbar update, the Interpretations panel might not be loaded by default. So when the url included the interpretationId, no component was listening for it, resulting in the interpretation modal not being opened.  The url param listener is thus moved to App. Tests added