### PR TITLE
chore: use reportportal fork

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -34,7 +34,7 @@ module.exports = defineConfig({
         parallel: true,
         debug: false,
         restClientConfig: {
-            timeout: 360000,
+            timeout: 660000,
         },
         attributes: [
             {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "@dhis2/maps-gl": "^3.8.5",
         "@dhis2/ui": "^8.13.15",
         "@krakenjs/post-robot": "^11.0.0",
-        "@reportportal/agent-js-cypress": "^5.1.4",
+        "@reportportal/agent-js-cypress": "git+https://github.com/dhis2/agent-js-cypress.git#develop",
         "@reportportal/agent-js-jest": "^5.0.6",
         "abortcontroller-polyfill": "^1.7.5",
         "array-move": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2957,10 +2957,9 @@
     "@react-hook/passive-layout-effect" "^1.2.0"
     "@react-hook/resize-observer" "^1.2.1"
 
-"@reportportal/agent-js-cypress@^5.1.4":
+"@reportportal/agent-js-cypress@git+https://github.com/dhis2/agent-js-cypress.git#develop":
   version "5.1.4"
-  resolved "https://registry.yarnpkg.com/@reportportal/agent-js-cypress/-/agent-js-cypress-5.1.4.tgz#43d61a6c1e954930cb4d95ad55c892467b484551"
-  integrity sha512-K5a6qwtnMpIO7qAUP1k4ABWmxEImO3eF9d+gdwe4SnDqeKCWB6SqC2MRt/ZcgSNlDTbYxJife5rr0f0OMg+pbA==
+  resolved "git+https://github.com/dhis2/agent-js-cypress.git#d3afea4e74abdbef39c1121f820f23deca2368f4"
   dependencies:
     "@reportportal/client-javascript" "^5.0.14"
     glob "^7.2.3"


### PR DESCRIPTION
Now you will be able to:
- see all the cypress tests merged in one Report portal launch
- find a launch by : 
   - PR_TITLE
   - BRANCH_NAME
   - CI_BUILD_ID

![image](https://github.com/dhis2/maps-app/assets/125370676/6bfe652d-9686-42d9-aec5-f40adf1ed779)

Part of the work was done at the level of : 

- https://github.com/dhis2/agent-js-cypress/commit/d3afea4e74abdbef39c1121f820f23deca2368f4
- https://github.com/dhis2/workflows/pull/46
- https://github.com/dhis2/workflows/pull/47
