### PR TITLE
fix: Building footprints earth engine layer was showing an error even though there was no error

### DIFF
--- a/src/components/layers/overlays/OverlayCard.js
+++ b/src/components/layers/overlays/OverlayCard.js
@@ -57,7 +57,7 @@ const OverlayCard = ({
         isVisible,
         layer: layerType,
         isLoaded,
-        error,
+        loadError,
     } = layer
 
     const canEdit = layerType !== EXTERNAL_LAYER
@@ -66,11 +66,11 @@ const OverlayCard = ({
     const canOpenAs = OPEN_AS_LAYER_TYPES.includes(layerType)
 
     const getCardContent = () => {
-        if (error) {
+        if (loadError) {
             return (
                 <div className={styles.noticebox}>
                     <NoticeBox error title={i18n.t('Failed to load layer')}>
-                        <p>{error.message}</p>
+                        <p>{loadError.message}</p>
                     </NoticeBox>
                 </div>
             )
@@ -130,7 +130,7 @@ const OverlayCard = ({
                           }
                         : undefined
                 }
-                hasError={!!error}
+                hasError={!!loadError}
             >
                 {getCardContent()}
             </LayerCard>

--- a/src/components/loaders/GeoJsonUrlLoader.js
+++ b/src/components/loaders/GeoJsonUrlLoader.js
@@ -17,13 +17,13 @@ const GeoJsonUrlLoader = ({ config, onLoad }) => {
 
     useEffect(() => {
         geoJsonUrlLoader(config, engine, instanceBaseUrl).then((data) => {
-            if (data.error) {
+            if (data.loadError) {
                 loadFailedAlert.show({
                     msg: i18n.t(
                         'Failed to load layer "{{layername}}": {{message}}',
                         {
                             layername: data.name,
-                            message: data.error.message || data.error,
+                            message: data.loadError.message || data.loadError,
                             nsSeparator: '^^',
                         }
                     ),

--- a/src/loaders/geoJsonUrlLoader.js
+++ b/src/loaders/geoJsonUrlLoader.js
@@ -75,12 +75,12 @@ const geoJsonUrlLoader = async (layer, engine, instanceBaseUrl) => {
     }
 
     let geoJson
-    let error
+    let loadError
 
     try {
         geoJson = await fetchData(newConfig.url, engine, instanceBaseUrl)
     } catch (err) {
-        error = err
+        loadError = err
     }
 
     const legend = {
@@ -99,14 +99,14 @@ const geoJsonUrlLoader = async (layer, engine, instanceBaseUrl) => {
         ...layer,
         name: newConfig.name, // TODO - will be fixed by DHIS2-16088
         legend,
-        data: (!error && buildGeoJsonFeatures(geoJson)) || [],
+        data: (!loadError && buildGeoJsonFeatures(geoJson)) || [],
         config: newConfig,
         featureStyle,
         isLoaded: true,
         isLoading: false,
         isExpanded: true,
         isVisible: true,
-        error,
+        loadError,
     }
 }
 


### PR DESCRIPTION
the building footprints earth engine layer has a property named `error`. That was getting picked up by the new notice box in the Card that was added to report geojson loading errors. Solution was to rename the error property in geojsonloader to `loadError`.

![image](https://github.com/dhis2/maps-app/assets/6113918/0ad56b85-7468-41ed-a9d8-1fd7bb8d50e1)