### PR TITLE
fix: various fixes after release testing

### DIFF
--- a/cypress/integration/layers/geojsonlayer.cy.js
+++ b/cypress/integration/layers/geojsonlayer.cy.js
@@ -131,7 +131,9 @@ describe('GeoJSON URL Layer', () => {
             .contains('Failed to load layer')
             .should('be.visible')
         cy.getByDataTest('dhis2-uicore-noticebox-content-message')
-            .contains('Error: Url to geojson was not found')
+            .contains(
+                'There was a problem with this layer. Contact a system administrator.'
+            )
             .should('be.visible')
 
         // remove the layer
@@ -194,7 +196,9 @@ describe('GeoJSON URL Layer', () => {
             .contains('Failed to load layer')
             .should('be.visible')
         cy.getByDataTest('dhis2-uicore-noticebox-content-message')
-            .contains('Error: The request for geojson was invalid.')
+            .contains(
+                'There was a problem with this layer. Contact a system administrator.'
+            )
             .should('be.visible')
 
         // remove the layer

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-03-13T09:09:37.325Z\n"
-"PO-Revision-Date: 2024-03-13T09:09:37.325Z\n"
+"POT-Creation-Date: 2024-03-13T10:31:57.389Z\n"
+"PO-Revision-Date: 2024-03-13T10:31:57.389Z\n"
 
 msgid "Untitled map, {{date}}"
 msgstr "Untitled map, {{date}}"
@@ -416,9 +416,6 @@ msgstr "Line/stroke width"
 msgid "Line/stroke width must be between 0-10."
 msgstr "Line/stroke width must be between 0-10."
 
-msgid "Point size"
-msgstr "Point size"
-
 msgid "Labels"
 msgstr "Labels"
 
@@ -511,6 +508,9 @@ msgstr "Display Tracked Entity relationships"
 
 msgid "Tracked entity style"
 msgstr "Tracked entity style"
+
+msgid "Point size"
+msgstr "Point size"
 
 msgid "Related entity style"
 msgstr "Related entity style"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-03-08T11:16:08.077Z\n"
-"PO-Revision-Date: 2024-03-08T11:16:08.077Z\n"
+"POT-Creation-Date: 2024-03-13T09:09:37.325Z\n"
+"PO-Revision-Date: 2024-03-13T09:09:37.325Z\n"
 
 msgid "Untitled map, {{date}}"
 msgstr "Untitled map, {{date}}"
@@ -412,6 +412,9 @@ msgstr "Line/stroke color"
 
 msgid "Line/stroke width"
 msgstr "Line/stroke width"
+
+msgid "Line/stroke width must be between 0-10."
+msgstr "Line/stroke width must be between 0-10."
 
 msgid "Point size"
 msgstr "Point size"
@@ -1349,6 +1352,18 @@ msgstr "The request for geojson was invalid."
 
 msgid "Unknown error occurred while requesting geojson."
 msgstr "Unknown error occurred while requesting geojson."
+
+msgid "Feature"
+msgstr "Feature"
+
+msgid "Polygon"
+msgstr "Polygon"
+
+msgid "Line"
+msgstr "Line"
+
+msgid "Point"
+msgstr "Point"
 
 msgid "Organisation units"
 msgstr "Organisation units"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-03-13T10:31:57.389Z\n"
-"PO-Revision-Date: 2024-03-13T10:31:57.389Z\n"
+"POT-Creation-Date: 2024-03-13T15:13:17.773Z\n"
+"PO-Revision-Date: 2024-03-13T15:13:17.773Z\n"
 
 msgid "Untitled map, {{date}}"
 msgstr "Untitled map, {{date}}"
@@ -639,8 +639,8 @@ msgstr "Group"
 msgid "Filters"
 msgstr "Filters"
 
-msgid "Failed to load layer \"{{layername}}\": {{message}}"
-msgstr "Failed to load layer \"{{layername}}\": {{message}}"
+msgid "{{layername}}: {{message}}"
+msgstr "{{layername}}: {{message}}"
 
 msgid "Drill up one level"
 msgstr "Drill up one level"
@@ -1341,17 +1341,8 @@ msgstr "Facilities: No coordinates found"
 msgid "Url to geojson is invalid."
 msgstr "Url to geojson is invalid."
 
-msgid "Layer authorization is no longer valid."
-msgstr "Layer authorization is no longer valid."
-
-msgid "Url to geojson was not found."
-msgstr "Url to geojson was not found."
-
-msgid "The request for geojson was invalid."
-msgstr "The request for geojson was invalid."
-
-msgid "Unknown error occurred while requesting geojson."
-msgstr "Unknown error occurred while requesting geojson."
+msgid "There was a problem with this layer. Contact a system administrator."
+msgstr "There was a problem with this layer. Contact a system administrator."
 
 msgid "Feature"
 msgstr "Feature"

--- a/src/components/core/NumberField.js
+++ b/src/components/core/NumberField.js
@@ -12,6 +12,8 @@ const NumberField = ({
     step = 1,
     dense = true,
     disabled,
+    helpText,
+    inputWidth,
     onChange,
     className,
 }) => (
@@ -26,6 +28,8 @@ const NumberField = ({
             value={Number.isNaN(value) ? '' : String(value)}
             disabled={disabled}
             onChange={({ value }) => onChange(value)}
+            helpText={helpText}
+            inputWidth={inputWidth}
         />
     </div>
 )
@@ -36,6 +40,8 @@ NumberField.propTypes = {
     className: PropTypes.string,
     dense: PropTypes.bool,
     disabled: PropTypes.bool,
+    helpText: PropTypes.string,
+    inputWidth: PropTypes.string,
     max: PropTypes.number,
     min: PropTypes.number,
     step: PropTypes.number,

--- a/src/components/core/Tabs.js
+++ b/src/components/core/Tabs.js
@@ -15,7 +15,7 @@ const Tabs = ({ value, onChange, children }) => {
 
     return (
         <TabContext.Provider value={{ tab, onChange }}>
-            <TabBar fixed>{children}</TabBar>
+            <TabBar>{children}</TabBar>
         </TabContext.Provider>
     )
 }

--- a/src/components/datatable/useTableData.js
+++ b/src/components/datatable/useTableData.js
@@ -199,6 +199,7 @@ export const useTableData = ({ layer, sortField, sortDirection }) => {
     } = layer || EMPTY_LAYER
 
     const dataWithAggregations = useMemo(() => {
+        errorCode.current = null
         if (serverCluster) {
             errorCode.current = ERROR_SERVER_CLUSTER
             return null

--- a/src/components/edit/shared/FeatureStyle.js
+++ b/src/components/edit/shared/FeatureStyle.js
@@ -21,26 +21,29 @@ const getFields = () => [
         id: FILL,
         label: i18n.t('Fill color'),
         type: FIELD_TYPE_COLOR,
-        default: 'transparent',
+        defaultValue: 'transparent',
         allowTransparent: true,
     },
     {
         id: STROKE_COLOR,
         label: i18n.t('Line/stroke color'),
         type: FIELD_TYPE_COLOR,
-        default: '#333333',
+        defaultValue: '#333333',
     },
     {
         id: STROKE_WIDTH,
         label: i18n.t('Line/stroke width'),
         type: FIELD_TYPE_NUMBER,
-        default: 1,
+        defaultValue: 1,
+        min: 0,
+        max: 10,
+        helpText: i18n.t('Line/stroke width must be between 0-10.'),
     },
     {
         id: POINT_SIZE,
         label: i18n.t('Point size'),
         type: FIELD_TYPE_NUMBER,
-        default: 5,
+        defaultValue: 5,
     },
 ]
 
@@ -64,42 +67,69 @@ const FeatureStyle = ({ style, onChange }) => {
 
     return (
         <>
-            {fields.map(({ id, label, type, allowTransparent }) =>
-                type === FIELD_TYPE_COLOR ? (
-                    <div key={id}>
-                        {allowTransparent && (
-                            <Checkbox
-                                label={label}
-                                checked={style[id] !== FILL_TRANSPARENT}
-                                onChange={(isChecked) =>
-                                    onChange({
-                                        [id]: isChecked
-                                            ? defaultNoTransparentFillColor
-                                            : FILL_TRANSPARENT,
-                                    })
+            {fields.map(
+                ({
+                    id,
+                    label,
+                    type,
+                    allowTransparent,
+                    min,
+                    max,
+                    defaultValue,
+                    helpText,
+                }) =>
+                    type === FIELD_TYPE_COLOR ? (
+                        <div key={id}>
+                            {allowTransparent && (
+                                <Checkbox
+                                    label={label}
+                                    checked={style[id] !== FILL_TRANSPARENT}
+                                    onChange={(isChecked) =>
+                                        onChange({
+                                            [id]: isChecked
+                                                ? defaultNoTransparentFillColor
+                                                : FILL_TRANSPARENT,
+                                        })
+                                    }
+                                />
+                            )}
+                            {style[id] !== FILL_TRANSPARENT && (
+                                <ColorPicker
+                                    label={allowTransparent ? '' : label}
+                                    color={style[id]}
+                                    onChange={(color) =>
+                                        onChange({ [id]: color })
+                                    }
+                                    className={styles.narrowField}
+                                />
+                            )}
+                        </div>
+                    ) : (
+                        <NumberField
+                            key={id}
+                            label={label}
+                            value={style[id]}
+                            onChange={(value) => {
+                                let val = parseInt(value)
+                                if (min || max) {
+                                    if (val < min || Number.isNaN(val)) {
+                                        val = min
+                                    }
+                                    if (val > max) {
+                                        val = max
+                                    }
                                 }
-                            />
-                        )}
-                        {style[id] !== FILL_TRANSPARENT && (
-                            <ColorPicker
-                                label={allowTransparent ? '' : label}
-                                color={style[id]}
-                                onChange={(color) => onChange({ [id]: color })}
-                                className={styles.narrowField}
-                            />
-                        )}
-                    </div>
-                ) : (
-                    <NumberField
-                        key={id}
-                        label={label}
-                        value={style[id]}
-                        onChange={(value) =>
-                            onChange({ [id]: parseInt(value) })
-                        }
-                        className={styles.narrowField}
-                    />
-                )
+                                if (Number.isNaN(val)) {
+                                    val = defaultValue
+                                }
+                                onChange({ [id]: parseInt(val) })
+                            }}
+                            inputWidth={'120px'}
+                            min={min}
+                            max={max}
+                            helpText={helpText}
+                        />
+                    )
             )}
         </>
     )

--- a/src/components/edit/shared/FeatureStyle.js
+++ b/src/components/edit/shared/FeatureStyle.js
@@ -44,6 +44,7 @@ const getFields = () => [
         label: i18n.t('Point radius'),
         type: FIELD_TYPE_NUMBER,
         defaultValue: 5,
+        min: 1,
     },
 ]
 

--- a/src/components/edit/shared/FeatureStyle.js
+++ b/src/components/edit/shared/FeatureStyle.js
@@ -41,7 +41,7 @@ const getFields = () => [
     },
     {
         id: POINT_SIZE,
-        label: i18n.t('Point size'),
+        label: i18n.t('Point radius'),
         type: FIELD_TYPE_NUMBER,
         defaultValue: 5,
     },

--- a/src/components/layers/overlays/OverlayCard.js
+++ b/src/components/layers/overlays/OverlayCard.js
@@ -73,7 +73,7 @@ const OverlayCard = ({
                     className={styles.noticebox}
                 >
                     <NoticeBox error title={i18n.t('Failed to load layer')}>
-                        <p>{loadError.message}</p>
+                        <p>{loadError}</p>
                     </NoticeBox>
                 </div>
             )

--- a/src/components/legend/LegendItem.js
+++ b/src/components/legend/LegendItem.js
@@ -6,6 +6,7 @@ import PolygonSymbol from './PolygonSymbol.js'
 import styles from './styles/LegendItem.module.css'
 
 const maxRadius = 15
+const maxLineWeight = 5
 
 const LegendItem = ({
     type,
@@ -41,17 +42,19 @@ const LegendItem = ({
         symbol.borderRadius = '50%'
     }
 
+    const lineWeight = weight ? Math.min(weight, maxLineWeight) : null
+
     return (
         <tr className={styles.legendItem} data-test="layerlegend-item">
             <th>
                 {weight ? (
                     type === 'LineString' ? (
-                        <LineSymbol color={color} weight={weight} />
+                        <LineSymbol color={color} weight={lineWeight} />
                     ) : (
                         <PolygonSymbol
                             color={strokeColor || color}
                             fill={fillColor}
-                            weight={weight}
+                            weight={lineWeight}
                         />
                     )
                 ) : (

--- a/src/components/loaders/GeoJsonUrlLoader.js
+++ b/src/components/loaders/GeoJsonUrlLoader.js
@@ -19,14 +19,11 @@ const GeoJsonUrlLoader = ({ config, onLoad }) => {
         geoJsonUrlLoader(config, engine, instanceBaseUrl).then((data) => {
             if (data.loadError) {
                 loadFailedAlert.show({
-                    msg: i18n.t(
-                        'Failed to load layer "{{layername}}": {{message}}',
-                        {
-                            layername: data.name,
-                            message: data.loadError.message || data.loadError,
-                            nsSeparator: '^^',
-                        }
-                    ),
+                    msg: i18n.t('{{layername}}: {{message}}', {
+                        layername: data.name,
+                        message: data.loadError,
+                        nsSeparator: '^^',
+                    }),
                 })
             }
             return onLoad(data)

--- a/src/components/map/layers/GeoJsonLayer.js
+++ b/src/components/map/layers/GeoJsonLayer.js
@@ -27,8 +27,11 @@ class GeoJsonLayer extends Layer {
 
         const style =
             Object.keys(featureStyle).length > 0
-                ? featureStyle
-                : config.featureStyle
+                ? { ...featureStyle, radius: featureStyle.pointSize }
+                : {
+                      ...config.featureStyle,
+                      radius: config.featureStyle?.pointSize,
+                  }
 
         this.layer = map.createLayer({
             type: GEOJSON_LAYER,

--- a/src/components/map/layers/GeoJsonLayer.js
+++ b/src/components/map/layers/GeoJsonLayer.js
@@ -53,7 +53,9 @@ class GeoJsonLayer extends Layer {
     }
 
     onFeatureClick(evt) {
-        const feature = this.props.data.find((d) => d.id === evt.feature.id)
+        const feature = this.props.data.find(
+            (d) => d.properties.id === evt.feature.properties.id
+        )
 
         const data = getGeojsonDisplayData(feature).reduce(
             (acc, { dataKey, value }) => {

--- a/src/loaders/geoJsonUrlLoader.js
+++ b/src/loaders/geoJsonUrlLoader.js
@@ -12,7 +12,7 @@ const fetchData = async (url, engine, instanceBaseUrl) => {
         // API route, use engine
         const routesIndex = url.indexOf('routes')
         if (routesIndex === -1) {
-            throw new Error(i18n.t('Url to geojson is invalid.'))
+            throw new Error()
         }
 
         return engine
@@ -27,19 +27,19 @@ const fetchData = async (url, engine, instanceBaseUrl) => {
                     : data.geojson
             )
             .catch(() => {
-                throw new Error('Error')
+                throw new Error()
             })
     } else {
         // External route, use fetch
         return fetch(url)
             .then((response) => {
                 if (!response.ok) {
-                    throw new Error('Error')
+                    throw new Error()
                 }
                 return response.json()
             })
             .catch(() => {
-                throw new Error('Error')
+                throw new Error()
             })
     }
 }

--- a/src/loaders/geoJsonUrlLoader.js
+++ b/src/loaders/geoJsonUrlLoader.js
@@ -26,49 +26,20 @@ const fetchData = async (url, engine, instanceBaseUrl) => {
                     ? JSON.parse(await data.geojson.text()) // TODO - remove once Blob fix implemented in app-runtime (LIBS-542)
                     : data.geojson
             )
-            .catch((e) => {
-                if (typeof e === 'object' && e.details?.message) {
-                    if (
-                        e.details.message.toLowerCase().includes('jwt expired')
-                    ) {
-                        throw new Error(
-                            i18n.t('Layer authorization is no longer valid.')
-                        )
-                    } else if (
-                        e.details.message.toLowerCase().includes('not found')
-                    ) {
-                        throw new Error(i18n.t('Url to geojson was not found.'))
-                    }
-
-                    throw new Error(e.details.message)
-                }
-
-                throw new Error(e)
+            .catch(() => {
+                throw new Error('Error')
             })
     } else {
         // External route, use fetch
         return fetch(url)
             .then((response) => {
                 if (!response.ok) {
-                    if (response.status === 404) {
-                        throw new Error(i18n.t('Url to geojson was not found.'))
-                    }
-                    if (response.status === 400) {
-                        throw new Error(
-                            i18n.t('The request for geojson was invalid.')
-                        )
-                    }
-
-                    throw new Error(
-                        i18n.t(
-                            'Unknown error occurred while requesting geojson.'
-                        )
-                    )
+                    throw new Error('Error')
                 }
                 return response.json()
             })
-            .catch((error) => {
-                throw new Error(error)
+            .catch(() => {
+                throw new Error('Error')
             })
     }
 }
@@ -95,8 +66,10 @@ const geoJsonUrlLoader = async (layer, engine, instanceBaseUrl) => {
 
     try {
         geoJson = await fetchData(newConfig.url, engine, instanceBaseUrl)
-    } catch (err) {
-        loadError = err
+    } catch (e) {
+        loadError = i18n.t(
+            'There was a problem with this layer. Contact a system administrator.'
+        )
     }
 
     let data = []

--- a/src/util/__tests__/geojson.spec.js
+++ b/src/util/__tests__/geojson.spec.js
@@ -407,23 +407,97 @@ describe('geojson utils', () => {
                 ],
             }
 
-            const result = buildGeoJsonFeatures(geoJson)
-            expect(result[0].type).toEqual('Feature')
-            expect(result[0].geometry).toEqual(geoJson.features[0].geometry)
-            expect(result[0].properties).toEqual({
+            const { featureCollection, types } = buildGeoJsonFeatures(geoJson)
+            expect(types).toEqual(['Point', 'LineString'])
+            expect(featureCollection[0].type).toEqual('Feature')
+            expect(featureCollection[0].geometry).toEqual(
+                geoJson.features[0].geometry
+            )
+            expect(featureCollection[0].properties).toEqual({
                 name: 'Dinagat Islands',
                 id: '__dhis2propertyid__0',
             })
-            expect(result[0].id).toEqual('33')
+            expect(featureCollection[0].id).toEqual('33')
 
-            expect(result[1].type).toEqual('Feature')
-            expect(result[1].geometry).toEqual(geoJson.features[1].geometry)
-            expect(result[1].properties).toEqual({
+            expect(featureCollection[1].type).toEqual('Feature')
+            expect(featureCollection[1].geometry).toEqual(
+                geoJson.features[1].geometry
+            )
+            expect(featureCollection[1].properties).toEqual({
                 name: 'Surigao del Norte',
                 id: '__dhis2propertyid__1',
             })
-            expect(result[1].id).toEqual('44')
+            expect(featureCollection[1].id).toEqual('44')
         })
+
+        it('should handle a FeatureCollection with multi geometry types', () => {
+            const geoJson = {
+                type: 'FeatureCollection',
+                features: [
+                    {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'Point',
+                        },
+                        properties: {
+                            id: 'thefeature100',
+                        },
+                    },
+                    {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'LineString',
+                        },
+                        properties: {
+                            id: 'thefeature101',
+                        },
+                    },
+                    {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'Polygon',
+                        },
+                        properties: {
+                            id: 'thefeature102',
+                        },
+                    },
+                    {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'MultiPoint',
+                        },
+                        properties: {
+                            id: 'thefeature103',
+                        },
+                    },
+                    {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'MultiLineString',
+                        },
+                        properties: {
+                            id: 'thefeature104',
+                        },
+                    },
+                    {
+                        type: 'Feature',
+                        geometry: {
+                            type: 'MultiPolygon',
+                        },
+                        properties: {
+                            id: 'thefeature105',
+                        },
+                    },
+                ],
+            }
+
+            const { featureCollection, types } = buildGeoJsonFeatures(geoJson)
+            expect(types).toEqual(['Point', 'LineString', 'Polygon'])
+            expect(featureCollection[5].properties).toEqual({
+                id: 'thefeature105',
+            })
+        })
+
         it('should handle a Feature', () => {
             const geoJson = {
                 type: 'Feature',
@@ -436,15 +510,16 @@ describe('geojson utils', () => {
                 },
             }
 
-            const result = buildGeoJsonFeatures(geoJson)
-            expect(result.length).toEqual(1)
-            expect(result[0].type).toEqual('Feature')
-            expect(result[0].geometry).toEqual(geoJson.geometry)
-            expect(result[0].properties).toEqual({
+            const { featureCollection, types } = buildGeoJsonFeatures(geoJson)
+            expect(types).toEqual(['Point'])
+            expect(featureCollection.length).toEqual(1)
+            expect(featureCollection[0].type).toEqual('Feature')
+            expect(featureCollection[0].geometry).toEqual(geoJson.geometry)
+            expect(featureCollection[0].properties).toEqual({
                 name: 'Dinagat Islands',
                 id: '__dhis2propertyid__0',
             })
-            expect(result[0].id).toBe(undefined)
+            expect(featureCollection[0].id).toBe(undefined)
         })
 
         it('should handle a raw geometry type', () => {
@@ -453,11 +528,14 @@ describe('geojson utils', () => {
                 coordinates: [125.6, 10.1],
             }
 
-            const result = buildGeoJsonFeatures(geoJson)
-            expect(result.length).toEqual(1)
-            expect(result[0].type).toEqual('Feature')
-            expect(result[0].id).toBe(undefined)
-            expect(result[0].properties).toEqual({ id: '__dhis2propertyid__0' })
+            const { featureCollection, types } = buildGeoJsonFeatures(geoJson)
+            expect(types).toEqual(['Point'])
+            expect(featureCollection.length).toEqual(1)
+            expect(featureCollection[0].type).toEqual('Feature')
+            expect(featureCollection[0].id).toBe(undefined)
+            expect(featureCollection[0].properties).toEqual({
+                id: '__dhis2propertyid__0',
+            })
         })
 
         it('should handle a GeometryCollection', () => {
@@ -478,27 +556,32 @@ describe('geojson utils', () => {
                 ],
             }
 
-            const result = buildGeoJsonFeatures(geoJson)
-            expect(result.length).toEqual(2)
+            const { featureCollection, types } = buildGeoJsonFeatures(geoJson)
+            expect(types).toEqual(['Point', 'LineString'])
+            expect(featureCollection.length).toEqual(2)
 
-            expect(result[0].type).toEqual('Feature')
-            expect(result[0].geometry).toEqual({
+            expect(featureCollection[0].type).toEqual('Feature')
+            expect(featureCollection[0].geometry).toEqual({
                 type: 'Point',
                 coordinates: [125.6, 10.1],
             })
-            expect(result[0].properties).toEqual({ id: '__dhis2propertyid__0' })
-            expect(result[0].id).toBe(undefined)
+            expect(featureCollection[0].properties).toEqual({
+                id: '__dhis2propertyid__0',
+            })
+            expect(featureCollection[0].id).toBe(undefined)
 
-            expect(result[1].type).toEqual('Feature')
-            expect(result[1].geometry).toEqual({
+            expect(featureCollection[1].type).toEqual('Feature')
+            expect(featureCollection[1].geometry).toEqual({
                 type: 'LineString',
                 coordinates: [
                     [125.6, 10.1],
                     [125.7, 10.2],
                 ],
             })
-            expect(result[1].properties).toEqual({ id: '__dhis2propertyid__1' })
-            expect(result[1].id).toBe(undefined)
+            expect(featureCollection[1].properties).toEqual({
+                id: '__dhis2propertyid__1',
+            })
+            expect(featureCollection[1].id).toBe(undefined)
         })
 
         it('should add a properties.id property if it does not exist', () => {
@@ -514,13 +597,14 @@ describe('geojson utils', () => {
                 },
             }
 
-            const result = buildGeoJsonFeatures(geoJson)
-            expect(result[0].type).toEqual('Feature')
-            expect(result[0].properties).toEqual({
+            const { featureCollection, types } = buildGeoJsonFeatures(geoJson)
+            expect(types).toEqual(['Point'])
+            expect(featureCollection[0].type).toEqual('Feature')
+            expect(featureCollection[0].properties).toEqual({
                 name: 'Dinagat Islands',
                 id: '__dhis2propertyid__0',
             })
-            expect(result[0].id).toEqual('123')
+            expect(featureCollection[0].id).toEqual('123')
         })
 
         it('should not add ids if they exist already', () => {
@@ -537,13 +621,14 @@ describe('geojson utils', () => {
                 },
             }
 
-            const result = buildGeoJsonFeatures(geoJson)
-            expect(result[0].type).toEqual('Feature')
-            expect(result[0].properties).toEqual({
+            const { featureCollection, types } = buildGeoJsonFeatures(geoJson)
+            expect(types).toEqual(['Point'])
+            expect(featureCollection[0].type).toEqual('Feature')
+            expect(featureCollection[0].properties).toEqual({
                 name: 'Dinagat Islands',
                 id: '123',
             })
-            expect(result[0].id).toEqual(456)
+            expect(featureCollection[0].id).toEqual(456)
         })
     })
 })

--- a/src/util/__tests__/geojson.spec.js
+++ b/src/util/__tests__/geojson.spec.js
@@ -340,8 +340,7 @@ describe('geojson utils', () => {
         it('should remove id property that was added by the app', () => {
             expect(
                 getGeojsonDisplayData({
-                    properties: { id: 1234, a: 1 },
-                    __isDhis2propertyId: true,
+                    properties: { id: '__dhis2propertyid__333', a: 1 },
                 })
             ).toMatchObject([
                 {
@@ -413,19 +412,17 @@ describe('geojson utils', () => {
             expect(result[0].geometry).toEqual(geoJson.features[0].geometry)
             expect(result[0].properties).toEqual({
                 name: 'Dinagat Islands',
-                id: '33',
+                id: '__dhis2propertyid__0',
             })
             expect(result[0].id).toEqual('33')
-            expect(result[0].__isDhis2propertyId).toEqual(true)
 
             expect(result[1].type).toEqual('Feature')
             expect(result[1].geometry).toEqual(geoJson.features[1].geometry)
             expect(result[1].properties).toEqual({
                 name: 'Surigao del Norte',
-                id: '44',
+                id: '__dhis2propertyid__1',
             })
             expect(result[1].id).toEqual('44')
-            expect(result[1].__isDhis2propertyId).toEqual(true)
         })
         it('should handle a Feature', () => {
             const geoJson = {
@@ -445,10 +442,9 @@ describe('geojson utils', () => {
             expect(result[0].geometry).toEqual(geoJson.geometry)
             expect(result[0].properties).toEqual({
                 name: 'Dinagat Islands',
-                id: 1,
+                id: '__dhis2propertyid__0',
             })
-            expect(result[0].id).toEqual(1)
-            expect(result[0].__isDhis2propertyId).toEqual(true)
+            expect(result[0].id).toBe(undefined)
         })
 
         it('should handle a raw geometry type', () => {
@@ -460,9 +456,8 @@ describe('geojson utils', () => {
             const result = buildGeoJsonFeatures(geoJson)
             expect(result.length).toEqual(1)
             expect(result[0].type).toEqual('Feature')
-            expect(result[0].id).toEqual(1)
-            expect(result[0].properties).toEqual({ id: 1 })
-            expect(result[0].__isDhis2propertyId).toEqual(true)
+            expect(result[0].id).toBe(undefined)
+            expect(result[0].properties).toEqual({ id: '__dhis2propertyid__0' })
         })
 
         it('should handle a GeometryCollection', () => {
@@ -491,9 +486,8 @@ describe('geojson utils', () => {
                 type: 'Point',
                 coordinates: [125.6, 10.1],
             })
-            expect(result[0].properties).toEqual({ id: 1 })
-            expect(result[0].id).toEqual(1)
-            expect(result[0].__isDhis2propertyId).toEqual(true)
+            expect(result[0].properties).toEqual({ id: '__dhis2propertyid__0' })
+            expect(result[0].id).toBe(undefined)
 
             expect(result[1].type).toEqual('Feature')
             expect(result[1].geometry).toEqual({
@@ -503,9 +497,8 @@ describe('geojson utils', () => {
                     [125.7, 10.2],
                 ],
             })
-            expect(result[1].properties).toEqual({ id: 2 })
-            expect(result[1].id).toEqual(2)
-            expect(result[1].__isDhis2propertyId).toEqual(true)
+            expect(result[1].properties).toEqual({ id: '__dhis2propertyid__1' })
+            expect(result[1].id).toBe(undefined)
         })
 
         it('should add a properties.id property if it does not exist', () => {
@@ -525,33 +518,9 @@ describe('geojson utils', () => {
             expect(result[0].type).toEqual('Feature')
             expect(result[0].properties).toEqual({
                 name: 'Dinagat Islands',
-                id: '123',
+                id: '__dhis2propertyid__0',
             })
             expect(result[0].id).toEqual('123')
-            expect(result[0].__isDhis2propertyId).toEqual(true)
-        })
-
-        it('should add a feature.id property if it does not exist', () => {
-            const geoJson = {
-                type: 'Feature',
-                geometry: {
-                    type: 'Point',
-                    coordinates: [125.6, 10.1],
-                },
-                properties: {
-                    name: 'Dinagat Islands',
-                    id: '123',
-                },
-            }
-
-            const result = buildGeoJsonFeatures(geoJson)
-            expect(result[0].type).toEqual('Feature')
-            expect(result[0].properties).toEqual({
-                name: 'Dinagat Islands',
-                id: '123',
-            })
-            expect(result[0].id).toEqual('123')
-            expect(result[0].__isDhis2propertyId).toBe(undefined)
         })
 
         it('should not add ids if they exist already', () => {
@@ -575,7 +544,6 @@ describe('geojson utils', () => {
                 id: '123',
             })
             expect(result[0].id).toEqual(456)
-            expect(result[0].__isDhis2propertyId).toBe(undefined)
         })
     })
 })

--- a/src/util/geojson.js
+++ b/src/util/geojson.js
@@ -198,14 +198,18 @@ export const buildGeoJsonFeatures = (geoJson) => {
         }
     }
 
-    // Ensures that all features have an id property and a properties.id property
-    // If id is added, set a flag to indicate this
     const types = []
     const featureCollection = finalGeoJson.features.map((f, i) => {
         const nonMultiType = f.geometry.type.replace('Multi', '')
+        // return list of types in the data (but not Multi* types,
+        // because those should get lumped in with the non-Multi* type for the legend)
         if (!types.includes(nonMultiType)) {
             types.push(nonMultiType)
         }
+
+        // Ensures that all features have a properties.id property
+        // If properties.id is added, prefix it with DHIS2_PROP so that
+        // it can be filtered out of the data table
         if (!f.properties.id) {
             f.properties.id = `${DHIS2_PROP}${i}`
         }


### PR DESCRIPTION
1. Limit stroke width to 0-10
2. Tab length should only take the space of the tab title
![image](https://github.com/dhis2/maps-app/assets/6113918/460e62d5-e177-4fc6-a1e8-be56d3e2c3e1)

3. Switching from invalid to valid layer when data table is open should update the table
https://github.com/dhis2/maps-app/assets/6113918/1389f0c7-b8f8-43a3-ad31-ad6422d86fe5

4. Highlight features when data table has a filter

https://github.com/dhis2/maps-app/assets/6113918/7b35606d-c727-43d4-b0e6-592442e5bd37

5. Improve legend for geojson layers
![image](https://github.com/dhis2/maps-app/assets/6113918/10e235ff-1f72-47cf-a2b8-daeb651ebc9b)

6. Map should show correct point radius for points
25px (green point):
![image](https://github.com/dhis2/maps-app/assets/6113918/9474e510-dbf9-4e81-bece-be254a31390e)
5px (green point):
![image](https://github.com/dhis2/maps-app/assets/6113918/ec191249-566d-4407-ae96-378abb3653e5)

7. Set max line weight in legend to 5
Before:
![image](https://github.com/dhis2/maps-app/assets/6113918/dd4dbc74-90e6-47fa-90f5-7e81e695b407)

After:
![image](https://github.com/dhis2/maps-app/assets/6113918/98bd294b-eaf6-44a5-b938-0537c1eeef4f)


More understandable error messages. Discussed with Joe and we agreed to always output the same simple message. The administrator can then investigate by checking the network tab and learning more about the actual error.
![image](https://github.com/dhis2/maps-app/assets/6113918/073d5cc5-2bb6-4b15-9e0a-80ebbbd91208)
