### PR TITLE
fix: upgrade analytics with fix for flashing interpretation panel and thread [DHIS2-15825]

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "start-server-and-test": "^2.0.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.3.0",
+        "@dhis2/analytics": "^26.6.0",
         "@dhis2/app-runtime": "3.9.4",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-alerts": "3.9.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2016,10 +2016,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.3.0":
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.3.0.tgz#ada2fe27442f19704fa704e334546416c85ea1d6"
-  integrity sha512-B/pUh8K8wyivL4yBiwqPoQ94pMWwCqh0xu3Uak4jmJqS+jO0slUlyDLtAmXU/jqRlRgRg1nR4u18npjd511Q7A==
+"@dhis2/analytics@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.6.0.tgz#1d70463fca8a4d5f5838928e9ab6c5c07873715f"
+  integrity sha512-fO8ozVfnTulXQptPcT3W/y+Ru6sN/Qjhr6dWHL4LsG2siL1v8QOWKcnM/yScClJtRZvsbEnQ6vX47c7ujRsGUA==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-16392

The upgrade of analytics from 26.3.0 to 26.6.0 fixes the flashing/re-rendering of the interpretations panel and thread in modal when liking and unliking an interpretation.