### PR TITLE
 fix: hide "show long/lat" for splitview maps [v38]

### DIFF
--- a/cypress/elements/map_canvas.js
+++ b/cypress/elements/map_canvas.js
@@ -1,0 +1,3 @@
+import { EXTENDED_TIMEOUT } from '../support/util.js';
+
+export const getMaps = () => cy.get('.dhis2-map canvas', EXTENDED_TIMEOUT);

--- a/cypress/elements/map_context_menu.js
+++ b/cypress/elements/map_context_menu.js
@@ -1,0 +1,51 @@
+import { getMaps } from './map_canvas.js';
+
+export const DRILL_UP = 'context-menu-drill-up';
+export const DRILL_DOWN = 'context-menu-drill-down';
+export const VIEW_PROFILE = 'context-menu-view-profile';
+export const SHOW_LONG_LAT = 'context-menu-show-long-lat';
+
+const ALL_OPTIONS = [DRILL_UP, DRILL_DOWN, VIEW_PROFILE, SHOW_LONG_LAT];
+
+export const expectContextMenuOptions = availableOptions => {
+    getMaps()
+        .first()
+        .then($el => {
+            const xpos = $el.width() / 2;
+            const ypos = $el.height() / 2;
+
+            // right clicking on the center of the map should hit an OU
+            getMaps()
+                .first()
+                .rightclick(xpos, ypos);
+
+            // menu has correct number of items
+            cy.getByDataTest('context-menu')
+                .find('li')
+                .should('have.length', availableOptions.length);
+
+            const unavailableOptions = ALL_OPTIONS.filter(
+                opt => !availableOptions.map(opt => opt.name).includes(opt)
+            );
+
+            unavailableOptions.forEach(name =>
+                cy.getByDataTest(name).should('not.exist')
+            );
+
+            availableOptions.forEach(option => {
+                // check the menu items
+                cy.getByDataTest(option.name).should('be.visible');
+                if (option.disabled) {
+                    cy.getByDataTest(option.name).should(
+                        'have.class',
+                        'disabled'
+                    );
+                } else {
+                    cy.getByDataTest(option.name).should(
+                        'not.have.class',
+                        'disabled'
+                    );
+                }
+            });
+        });
+};

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -1,3 +1,10 @@
+import { getMaps } from '../../elements/map_canvas.js';
+import {
+    DRILL_UP,
+    DRILL_DOWN,
+    VIEW_PROFILE,
+    expectContextMenuOptions,
+} from '../../elements/map_context_menu.js';
 import { ThematicLayer } from '../../elements/thematic_layer';
 import { CURRENT_YEAR } from '../../support/util';
 
@@ -37,8 +44,6 @@ context('Thematic Layers', () => {
 
         Layer.validateDialogClosed(true);
 
-        // TODO: use visual snapshot testing to check the rendering of the map
-
         Layer.validateCardTitle(INDICATOR_NAME);
         // TODO: test this in a way that is not dependent on the date
         // Layer.validateCardItems([
@@ -48,6 +53,8 @@ context('Thematic Layers', () => {
         //     '89.76 - 96.28 (3)',
         //     '96.28 - 102.8 (4)',
         // ]);
+
+        getMaps().should('have.length', 1);
     });
 
     it('adds a thematic layer for OU Bombali', () => {
@@ -63,8 +70,6 @@ context('Thematic Layers', () => {
 
         Layer.validateDialogClosed(true);
 
-        // TODO: use visual snapshot testing to check the rendering of the map
-
         Layer.validateCardTitle(INDICATOR_NAME);
         // TODO: test this in a way that is not dependent on the date
         // Layer.validateCardItems([
@@ -74,6 +79,8 @@ context('Thematic Layers', () => {
         //     '87.32 - 89.46 (0)',
         //     '89.46 - 91.6 (1)',
         // ]);
+
+        getMaps().should('have.length', 1);
     });
 
     it('adds a thematic layer with start and end date', () => {
@@ -91,5 +98,40 @@ context('Thematic Layers', () => {
         Layer.validateCardTitle(INDICATOR_NAME).validateCardPeriod(
             `Feb 1, ${CURRENT_YEAR} - Nov 30, ${CURRENT_YEAR}`
         );
+
+        getMaps().should('have.length', 1);
+    });
+
+    it('adds a thematic layer with split view period', () => {
+        Layer.openDialog('Thematic')
+            .selectIndicatorGroup('ANC')
+            .selectIndicator('ANC 1 Coverage')
+            .selectTab('Period');
+
+        cy.getByDataTest('relative-period-select-content').click();
+        cy.contains('Last 3 months').click();
+
+        cy.get('[type="radio"]').should('have.length', 3);
+        cy.get('[type="radio"]').check('SPLIT_BY_PERIOD');
+
+        cy.getByDataTest('dhis2-uicore-modalactions')
+            .contains('Add layer')
+            .click();
+
+        Layer.validateDialogClosed(true);
+
+        Layer.validateCardTitle('ANC 1 Coverage');
+
+        // check for 3 maps
+        getMaps().should('have.length', 3);
+
+        // wait to make sure the maps are loaded
+        cy.wait(2000); // eslint-disable-line cypress/no-unnecessary-waiting
+
+        expectContextMenuOptions([
+            { name: DRILL_UP, disabled: true },
+            { name: DRILL_DOWN },
+            { name: VIEW_PROFILE },
+        ]);
     });
 });

--- a/src/components/core/Radio.js
+++ b/src/components/core/Radio.js
@@ -21,6 +21,7 @@ const Radio = ({ value, disabled, dense = true, dataTest, label }) => {
             checked={value === radio}
             onChange={onClick}
             dataTest={dataTest}
+            value={value}
         />
     );
 };

--- a/src/components/map/ContextMenu.js
+++ b/src/components/map/ContextMenu.js
@@ -30,6 +30,7 @@ const ContextMenu = props => {
         layerType,
         coordinates,
         earthEngineLayers,
+        isSplitView,
         position,
         offset,
         closeContextMenu,
@@ -123,7 +124,7 @@ const ContextMenu = props => {
                             />
                         )}
 
-                        {coordinates && (
+                        {coordinates && !isSplitView && (
                             <MenuItem
                                 label={i18n.t('Show longitude/latitude')}
                                 icon={<IconLocation16 />}
@@ -155,6 +156,7 @@ ContextMenu.propTypes = {
     layerType: PropTypes.string,
     layerId: PropTypes.string,
     coordinates: PropTypes.array,
+    isSplitView: PropTypes.bool,
     position: PropTypes.array,
     offset: PropTypes.array,
     map: PropTypes.object,


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-15798
Backport of https://github.com/dhis2/maps-app/pull/2945

![image](https://github.com/dhis2/maps-app/assets/6113918/e5ec0469-e72f-4a27-9326-b1b73a2caf86)
