### PR TITLE
fix: system / user setting for display name not respected in Org Unit tree (DHIS2-15000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "start-server-and-test": "^2.0.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "999.9.9-ouname-alpha.1",
+        "@dhis2/analytics": "^26.6.9",
         "@dhis2/app-runtime": "3.9.4",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-alerts": "3.9.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "start-server-and-test": "^2.0.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.6.5",
+        "@dhis2/analytics": "999.9.9-ouname-alpha.1",
         "@dhis2/app-runtime": "3.9.4",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-alerts": "3.9.4",

--- a/src/components/orgunits/OrgUnitSelect.js
+++ b/src/components/orgunits/OrgUnitSelect.js
@@ -1,4 +1,4 @@
-import { OrgUnitDimension } from '@dhis2/analytics'
+import { OrgUnitDimension, useCachedDataQuery } from '@dhis2/analytics'
 import { CenteredContent, CircularLoader, Help } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -23,6 +23,7 @@ const OrgUnitSelect = ({
     hideGroupSelect = false,
     warning,
 }) => {
+    const { nameProperty } = useCachedDataQuery()
     const { roots, levels, loading, error } = useOrgUnits()
     const rows = useSelector((state) => state.layerEdit.rows)
     const dispatch = useDispatch()
@@ -84,6 +85,7 @@ const OrgUnitSelect = ({
                     hideLevelSelect={hideLevelSelect}
                     hideGroupSelect={hideGroupSelect}
                     warning={!hasOrgUnits ? warning : null}
+                    displayNameProp={nameProperty}
                 />
             </div>
             {!hideAssociatedGeometry && <AssociatedGeometrySelect />}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2016,10 +2016,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@999.9.9-ouname-alpha.1":
-  version "999.9.9-ouname-alpha.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.9.9-ouname-alpha.1.tgz#c2a5f27429e02b762f3344fdcbacb985199f30da"
-  integrity sha512-xFHCM2zPSt/eaOdk+V5uE4m2YxdW5Pn3cK0zJVKctS864tLXMNVCORQ+eDYQfl7lwbWm92Ax05z9L4StizEYtw==
+"@dhis2/analytics@^26.6.9":
+  version "26.6.9"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.6.9.tgz#932847c4bee3dd720d5d0b872c6b11eeae8b260c"
+  integrity sha512-AcU5FKH1Rmi8GdgqdJ1aOPqTKhztLafhzKNvGBdb5rSNR8/KS2djyTxxPhL0fdusu+1Rc04RFSkOLajq3ChVrQ==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2016,10 +2016,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.6.5":
-  version "26.6.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.6.5.tgz#44ee29a279c37f3969096d859bc0f07d953e3f42"
-  integrity sha512-ob6kNEEkIAC50RtKuUZWi8Y04uwsPHK/EiYhzxZkSOdS5wFm8X+88KZrD//fILXQjwMhJvl/4+F/T0qVxOF/jQ==
+"@dhis2/analytics@999.9.9-ouname-alpha.1":
+  version "999.9.9-ouname-alpha.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-999.9.9-ouname-alpha.1.tgz#c2a5f27429e02b762f3344fdcbacb985199f30da"
+  integrity sha512-xFHCM2zPSt/eaOdk+V5uE4m2YxdW5Pn3cK0zJVKctS864tLXMNVCORQ+eDYQfl7lwbWm92Ax05z9L4StizEYtw==
   dependencies:
     "@dhis2/d2-ui-rich-text" "^7.4.1"
     "@dhis2/multi-calendar-dates" "1.0.0"


### PR DESCRIPTION
Implements [DHIS2-15000](https://jira.dhis2.org/browse/DHIS2-15000)

**Requires https://github.com/dhis2/analytics/pull/1664**

---

Levels seem to get the translation, nameProperty not needed.

Settings: database language: Norwegian
displayName: shortName

For the OU tree, short names don't work. OULevels don't have short names.

![ou translated](https://github.com/dhis2/maps-app/assets/6113918/be77ed68-d929-489d-940a-2a7ac9bb64c0)


[DHIS2-15000]: https://dhis2.atlassian.net/browse/DHIS2-15000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ