### PR TITLE
fix: support "week", "bi-week" and months in period translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "start-server-and-test": "^2.0.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.7.0",
+        "@dhis2/analytics": "^26.7.5",
         "@dhis2/app-runtime": "3.9.4",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-alerts": "3.9.4",

--- a/src/components/edit/LayerEdit.js
+++ b/src/components/edit/LayerEdit.js
@@ -45,7 +45,7 @@ const getLayerNames = () => ({
 
 const LayerEdit = ({ layer, addLayer, updateLayer, cancelLayer }) => {
     const [isValidLayer, setIsValidLayer] = useState(false)
-    const { systemSettings } = useCachedDataQuery()
+    const { systemSettings, periodsSettings } = useCachedDataQuery()
     const orgUnits = useOrgUnits()
 
     const onValidateLayer = () => setIsValidLayer(true)
@@ -101,6 +101,7 @@ const LayerEdit = ({ layer, addLayer, updateLayer, cancelLayer }) => {
                     <LayerDialog
                         {...layer}
                         systemSettings={systemSettings}
+                        periodsSettings={periodsSettings}
                         orgUnits={orgUnits}
                         validateLayer={isValidLayer}
                         onLayerValidation={onLayerValidation}

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -93,6 +93,7 @@ class ThematicDialog extends Component {
         operand: PropTypes.bool,
         orgUnits: PropTypes.object,
         periodType: PropTypes.string,
+        periodsSettings: PropTypes.object,
         program: PropTypes.object,
         radiusHigh: PropTypes.number,
         radiusLow: PropTypes.number,
@@ -100,7 +101,6 @@ class ThematicDialog extends Component {
         rows: PropTypes.array,
         startDate: PropTypes.string,
         systemSettings: PropTypes.object,
-        periodsSettings: PropTypes.object,
         thematicMapType: PropTypes.string,
         valueType: PropTypes.string,
     }

--- a/src/components/edit/thematic/ThematicDialog.js
+++ b/src/components/edit/thematic/ThematicDialog.js
@@ -100,6 +100,7 @@ class ThematicDialog extends Component {
         rows: PropTypes.array,
         startDate: PropTypes.string,
         systemSettings: PropTypes.object,
+        periodsSettings: PropTypes.object,
         thematicMapType: PropTypes.string,
         valueType: PropTypes.string,
     }
@@ -231,6 +232,7 @@ class ThematicDialog extends Component {
             valueType,
             thematicMapType,
             systemSettings,
+            periodsSettings,
         } = this.props
 
         const {
@@ -439,6 +441,7 @@ class ThematicDialog extends Component {
                                 (!periodType && id)) && (
                                 <PeriodSelect
                                     periodType={periodType}
+                                    periodsSettings={periodsSettings}
                                     period={period}
                                     onChange={setPeriod}
                                     className={styles.periodSelect}

--- a/src/components/periods/PeriodSelect.js
+++ b/src/components/periods/PeriodSelect.js
@@ -26,6 +26,7 @@ class PeriodSelect extends Component {
             startDate: PropTypes.string,
         }),
         periodType: PropTypes.string,
+        periodsSettings: PropTypes.object,
     }
 
     state = {
@@ -104,12 +105,12 @@ class PeriodSelect extends Component {
     }
 
     setPeriods() {
-        const { periodType, period } = this.props
+        const { periodType, period, periodsSettings } = this.props
         const year = this.state.year || getYear(period && period.startDate)
         let periods
 
         if (periodType) {
-            periods = getFixedPeriodsByType(periodType, year)
+            periods = getFixedPeriodsByType(periodType, year, periodsSettings)
         } else if (period) {
             periods = [period] // If period is loaded in favorite
         }
@@ -126,12 +127,12 @@ class PeriodSelect extends Component {
     }
 
     changeYear = (change) => {
-        const { periodType } = this.props
+        const { periodType, periodsSettings } = this.props
         const year = this.state.year + change
 
         this.setState({
             year,
-            periods: getFixedPeriodsByType(periodType, year),
+            periods: getFixedPeriodsByType(periodType, year, periodsSettings),
         })
     }
 }

--- a/src/util/__tests__/app.spec.js
+++ b/src/util/__tests__/app.spec.js
@@ -143,11 +143,19 @@ describe('utils/app', () => {
             keyHideDailyPeriods: false,
             keyHideWeeklyPeriods: false,
         }
+        const userSettings = {
+            keyUiLocale: 'en',
+        }
+        const systemInfo = {
+            calendar: 'gregory',
+        }
 
         const cfg = providerDataTransformation({
             currentUser,
             systemSettings,
             externalMapLayers,
+            userSettings,
+            systemInfo,
         })
 
         expect(cfg.basemaps).toHaveLength(5)

--- a/src/util/__tests__/app.spec.js
+++ b/src/util/__tests__/app.spec.js
@@ -87,11 +87,19 @@ describe('utils/app', () => {
             keyBingMapsApiKey: 'bing_maps_api_key',
             keyHideWeeklyPeriods: false,
         }
+        const userSettings = {
+            keyUiLocale: 'en',
+        }
+        const systemInfo = {
+            calendar: 'gregory',
+        }
 
         const cfg = providerDataTransformation({
             currentUser,
             systemSettings,
             externalMapLayers,
+            userSettings,
+            systemInfo,
         })
 
         expect(cfg.basemaps).toHaveLength(9)

--- a/src/util/app.js
+++ b/src/util/app.js
@@ -27,6 +27,15 @@ export const appQueries = {
             key: SYSTEM_SETTINGS,
         },
     },
+    systemInfo: {
+        resource: 'system/info',
+    },
+    userSettings: {
+        resource: 'userSettings',
+        params: {
+            key: ['keyUiLocale'],
+        },
+    },
     externalMapLayers: fetchExternalLayersQuery,
 }
 
@@ -70,6 +79,8 @@ const getLayerTypes = (externalMapLayers) => {
 export const providerDataTransformation = ({
     currentUser,
     systemSettings,
+    systemInfo,
+    userSettings,
     externalMapLayers,
 }) => ({
     currentUser: {
@@ -85,6 +96,10 @@ export const providerDataTransformation = ({
     systemSettings: Object.assign({}, DEFAULT_SYSTEM_SETTINGS, systemSettings, {
         hiddenPeriods: getHiddenPeriods(systemSettings),
     }),
+    periodsSettings: {
+        locale: userSettings.keyUiLocale,
+        calendar: systemInfo.calendar,
+    },
     basemaps: getBasemapList(
         externalMapLayers.externalMapLayers,
         systemSettings

--- a/src/util/app.js
+++ b/src/util/app.js
@@ -29,6 +29,9 @@ export const appQueries = {
     },
     systemInfo: {
         resource: 'system/info',
+        params: {
+            fields: 'calendar',
+        },
     },
     userSettings: {
         resource: 'userSettings',

--- a/src/util/periods.js
+++ b/src/util/periods.js
@@ -9,9 +9,8 @@ const getYearOffsetFromNow = (year) => year - new Date(Date.now()).getFullYear()
 export const getPeriodTypes = (hiddenPeriods = []) =>
     periodTypes().filter(({ group }) => !hiddenPeriods.includes(group))
 
-export const getFixedPeriodsByType = (periodType, year) => {
-    const period = getFixedPeriodsOptionsById(periodType)
-
+export const getFixedPeriodsByType = (periodType, year, periodsSettings) => {
+    const period = getFixedPeriodsOptionsById(periodType, periodsSettings)
     const forceDescendingForYearTypes = !!periodType.match(/^FY|YEARLY/)
     const offset = getYearOffsetFromNow(year)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2016,12 +2016,12 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.7.0":
-  version "26.7.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.7.0.tgz#12d314ad2a84423612ff0eb0e32c191552bd8db8"
-  integrity sha512-7ocy+Ke9fYG40rHsICuH35UgIH+ahAgba9xFea0UbRYUhGavMW90mSVpgCNjE+PlefjR0xuHXB2UHYlTjhEIQw==
+"@dhis2/analytics@^26.7.5":
+  version "26.7.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.7.5.tgz#b85a35ba0adb971b237c814d1d384e10e3ec5ca1"
+  integrity sha512-YLkCOXWGm8JFlpq0AZhWsMxA6lJeRTixHDeMqdyZQeYPYCvZJiUAp0TtC+uSRK1uV1yIHRj4OjQytMWTsvUUnQ==
   dependencies:
-    "@dhis2/multi-calendar-dates" "1.0.0"
+    "@dhis2/multi-calendar-dates" "^1.2.2"
     "@dnd-kit/core" "^6.0.7"
     "@dnd-kit/sortable" "^7.0.2"
     "@dnd-kit/utilities" "^3.2.1"
@@ -2254,20 +2254,21 @@
     suggestions "^1.7.1"
     uuid "^9.0.0"
 
-"@dhis2/multi-calendar-dates@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.0.tgz#bf7f49aecdffa9781837a5d60d56a094b74ab4df"
-  integrity sha512-IB9a+feuS6yE4lpZj/eZ9uBmpYI7Hxitl2Op0JjoRL4tP+p6uw4ns9cjoSdUeIU9sOAxVZV7oQqSyIw+9P6YjQ==
-  dependencies:
-    "@js-temporal/polyfill" "^0.4.2"
-    classnames "^2.3.2"
-
 "@dhis2/multi-calendar-dates@1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.2.tgz#e54dc85e512aba93fceef3004e67e199077f3ba8"
   integrity sha512-oQZ7PFMwHFpt4ygDN9DmAeYO3g07L7AHJW6diZ37mzpkEF/DyMafhsZHnJWNlTH5HDp8nYuO3EjBiM7fZN6C0g==
   dependencies:
     "@js-temporal/polyfill" "^0.4.2"
+    classnames "^2.3.2"
+
+"@dhis2/multi-calendar-dates@^1.2.2":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.2.3.tgz#ef36bc80b34eaaa7f7cefa51b443528c019ff2d2"
+  integrity sha512-K3E9yAH/SPXi1O7RWuK7bznYTa1v3x4Ys0ihpMWnKH++OLMx76yK/1H1m9v7NgQvMry29ATQMJh0n/vJSg+EpA==
+  dependencies:
+    "@dhis2/d2-i18n" "^1.1.3"
+    "@js-temporal/polyfill" "0.4.3"
     classnames "^2.3.2"
 
 "@dhis2/prop-types@^3.1.2":
@@ -2753,7 +2754,7 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
-"@js-temporal/polyfill@^0.4.2":
+"@js-temporal/polyfill@0.4.3", "@js-temporal/polyfill@^0.4.2":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@js-temporal/polyfill/-/polyfill-0.4.3.tgz#e8f8cf86745eb5050679c46a5ebedb9a9cc1f09b"
   integrity sha512-6Fmjo/HlkyVCmJzAPnvtEWlcbQUSRhi8qlN9EtJA/wP7FqXsevLLrlojR44kzNzrRkpf7eDJ+z7b4xQD/Ycypw==


### PR DESCRIPTION
Part of the fix for [DHIS2-16904](https://jira.dhis2.org/browse/DHIS2-16904)

Requires https://github.com/dhis2/analytics/pull/1685

--------------

## Key features
- bump analytics dependency
- pass periodsSettings to @dhis2/analytics utility function: `getFixedPeriodsOptionsById`

-------------

## Description

The actual fix is in @dhis2/multi-calendar-dates which is a dependency of analytics and it's used in the PeriodSelector component the analytics apps use.
See also the PR in analytics.

For maps-app, the locale and calendar specs where not passed to the @dhis2/analytics utility function, so this was implemented as well.
_Note: this has not been implemented for selectors limited to years._

-------------

## Screenshots
Translations don't work for week/bi-week:
Pending

Before / After

[DHIS2-16904]: https://dhis2.atlassian.net/browse/DHIS2-16904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ