### PR TITLE
fix: enable hidding basemap in dashboard

### DIFF
--- a/src/components/plugin/MapContainer.js
+++ b/src/components/plugin/MapContainer.js
@@ -44,6 +44,7 @@ const MapContainer = ({ visualization }) => {
 
             const { basemap } = await getBasemapConfig({
                 basemapId: initialConfig.basemap?.id,
+                basemapVisible: initialConfig.basemap?.isVisible,
                 keyDefaultBaseMap,
                 keyBingMapsApiKey,
                 engine,

--- a/src/components/plugin/getBasemapConfig.js
+++ b/src/components/plugin/getBasemapConfig.js
@@ -30,6 +30,7 @@ async function getBasemaps(basemapId, defaultBasemapId, engine) {
 
 async function getBasemapConfig({
     basemapId,
+    basemapVisible,
     keyDefaultBaseMap,
     keyBingMapsApiKey,
     engine,
@@ -43,6 +44,9 @@ async function getBasemapConfig({
 
     if (basemap.id.substring(0, 4) === 'bing') {
         basemap.config.apiKey = keyBingMapsApiKey
+    }
+    if (basemapVisible === false) {
+        basemap.isVisible = false
     }
     return {
         basemap,

--- a/src/components/plugin/getBasemapConfig.js
+++ b/src/components/plugin/getBasemapConfig.js
@@ -45,8 +45,8 @@ async function getBasemapConfig({
     if (basemap.id.substring(0, 4) === 'bing') {
         basemap.config.apiKey = keyBingMapsApiKey
     }
-    if (basemapVisible === false) {
-        basemap.isVisible = false
+    if (typeof basemapVisible === 'boolean') {
+        basemap.isVisible = basemapVisible
     }
     return {
         basemap,


### PR DESCRIPTION
Implement [DHIS2-16218](https://dhis2.atlassian.net/browse/DHIS2-16218)

--------------

Pass `basemapVisible` prop to plugin's `getBasemapConfig` function.

-------------

Before:
![image](https://github.com/dhis2/maps-app/assets/10115948/732e3c03-8baa-4f2f-90db-edf8148310aa)


After:
![image](https://github.com/dhis2/maps-app/assets/10115948/38983d6d-020a-44c8-b466-68a1b8dc2b58)


[DHIS2-16218]: https://dhis2.atlassian.net/browse/DHIS2-16218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ