### PR TITLE
chore: run the bot message jobs on the first master commit

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -148,7 +148,7 @@ jobs:
             failure() &&
             !cancelled() &&
             github.ref == 'refs/heads/master' &&
-            contains(github.event.head_commit.message, 'chore(release)')
+            ${{ !contains(github.event.head_commit.message, 'chore(release)') }}
         steps:
             - name: Checkout code
               uses: actions/checkout@master
@@ -185,7 +185,7 @@ jobs:
             success() &&
             !cancelled() &&
             github.ref == 'refs/heads/master' &&
-            contains(github.event.head_commit.message, 'chore(release)')
+            ${{ !contains(github.event.head_commit.message, 'chore(release)') }}
         steps:
             - name: Checkout code
               uses: actions/checkout@master


### PR DESCRIPTION
During the release process, there are 2 commits to master:
1. the merge of the feature/fix PR
2. the github commit of the updated package.json and changelog ("[skip release]"

Since it is the first commit (the merge) that triggers the release, it is this commit that should report release success or failure.