### PR TITLE
fix: unmask population layers to get correct mean population density

### DIFF
--- a/src/components/map/layers/earthEngine/EarthEngineLayer.js
+++ b/src/components/map/layers/earthEngine/EarthEngineLayer.js
@@ -74,6 +74,7 @@ export default class EarthEngineLayer extends Layer {
             aggregationType,
             areaRadius,
             tileScale,
+            unmaskAggregation,
         } = this.props;
 
         const { map, isPlugin } = this.context;
@@ -102,6 +103,7 @@ export default class EarthEngineLayer extends Layer {
             data,
             aggregationType,
             tileScale,
+            unmaskAggregation,
             preload: !isPlugin && this.hasAggregations(),
             onClick: this.onFeatureClick.bind(this),
             onRightClick: this.onFeatureRightClick.bind(this),

--- a/src/constants/earthEngine.js
+++ b/src/constants/earthEngine.js
@@ -15,6 +15,7 @@ export const earthEngineLayers = () => [
             'https://developers.google.com/earth-engine/datasets/catalog/WorldPop_GP_100m_pop_age_sex_cons_unadj',
         img: 'images/population.png',
         defaultAggregations: ['sum', 'mean'],
+        unmaskAggregation: true,
         periodType: 'Yearly',
         band: 'population',
         filters: ({ id, name, year }) => [
@@ -48,6 +49,7 @@ export const earthEngineLayers = () => [
         img: 'images/population.png',
         periodType: 'Yearly',
         defaultAggregations: ['sum', 'mean'],
+        unmaskAggregation: true,
         bands: [
             {
                 id: 'M_0',


### PR DESCRIPTION
The population layers are "constrained" meaning the pixels without a population is removed from the original dataset. When we are calculating the mean population density we get the wrong result as only pixels with a population in taken into account. This PR will fix this issue for 2.39. 

After this PR the mean should take the full org unit area into account: 

<img width="205" alt="Screenshot 2024-07-31 at 15 23 09" src="https://github.com/user-attachments/assets/d0c98f3a-6f13-4ee0-8f29-ab9f7784e518">
