### PR TITLE
fix: plugin crashes for Earth Engine layers in the dashboard

### DIFF
--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -84,8 +84,8 @@ const earthEngineLoader = async (config) => {
         // From database as favorite
         layerConfig = JSON.parse(config.config)
 
-        // Backward compability for layers with periods saved before 2.36
         if (layerConfig.image) {
+            // Backward compability for layers with periods saved before 2.36
             const filter = layerConfig.filter?.[0]
 
             if (filter) {
@@ -107,10 +107,9 @@ const earthEngineLoader = async (config) => {
             delete layerConfig.filter
         }
 
-        // Backward compability for layers saved before v100.6.0
         if (layerConfig.params) {
+            // Backward compability for layers saved before v100.6.0
             layerConfig.style = layerConfig.params
-            // Backward compability for layers saved before 2.40
             if (typeof layerConfig.params.palette === 'string') {
                 layerConfig.style.palette =
                     layerConfig.params.palette.split(',')
@@ -125,7 +124,9 @@ const earthEngineLoader = async (config) => {
         }
 
         delete config.config
-        delete config.filters // Backend returns empty filters array
+        // Remove the always empty filters array from saved map layer object
+        // so as not to overwrite the filters array from the layer config
+        delete config.filters
     } else {
         dataset = getEarthEngineLayer(layerConfig.id)
     }

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -139,7 +139,7 @@ const earthEngineLoader = async (config) => {
     const {
         unit,
         period,
-        filters = [],
+        filters,
         description,
         source,
         sourceUrl,

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -90,18 +90,13 @@ const earthEngineLoader = async (config) => {
 
             if (filter) {
                 const id = filter.arguments?.[1]
-                let name = String(layerConfig.image)
-                let year
+                const name = String(layerConfig.image)
+                const year =
+                    typeof id === 'string' && id.length > 4
+                        ? parseInt(id.substring(0, 4), 10)
+                        : undefined
 
-                if (typeof id === 'string' && id.length > 4) {
-                    year = id.substring(0, 4)
-                }
-
-                layerConfig.period = {
-                    id,
-                    name,
-                    year: parseInt(year, 10),
-                }
+                layerConfig.period = { id, name, year }
 
                 delete layerConfig.filter
             }

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -149,7 +149,7 @@ const earthEngineLoader = async (config) => {
     const {
         unit,
         period,
-        filters,
+        filters = [],
         description,
         source,
         sourceUrl,

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -84,48 +84,43 @@ const earthEngineLoader = async (config) => {
         // From database as favorite
         layerConfig = JSON.parse(config.config)
 
-        const { filter, params } = layerConfig
-
-        // Backward compability for layers saved before 2.41
-        if (filter) {
-            layerConfig.period = getPeriodFromFilter(filter, layerConfig.id)
-            delete layerConfig.filter
-        }
-
-        // Backward compability for layers saved before 2.41
-        if (params) {
-            layerConfig.style = params
-            if (params.palette) {
-                layerConfig.style.palette = params.palette.split(',')
-            }
-            delete layerConfig.params
-        }
-
         // Backward compability for layers with periods saved before 2.36
-        // (could also be fixed in a db update script)
         if (layerConfig.image) {
             const filter = layerConfig.filter?.[0]
 
             if (filter) {
-                const period = filter.arguments?.[1]
+                const id = filter.arguments?.[1]
                 let name = String(layerConfig.image)
+                let year
 
-                if (typeof period === 'string' && period.length > 4) {
-                    const year = period.substring(0, 4)
-                    filter.year = parseInt(year, 10)
-
-                    if (name.slice(-4) === year) {
-                        name = name.slice(0, -4)
-                    }
+                if (typeof id === 'string' && id.length > 4) {
+                    year = id.substring(0, 4)
                 }
 
-                filter.name = name
+                layerConfig.period = {
+                    id,
+                    name,
+                    year: parseInt(year, 10),
+                }
+
+                delete layerConfig.filter
             }
+            delete layerConfig.image
+        } else if (layerConfig.filter) {
+            // Backward compability for layers saved before v100.6.0
+            layerConfig.period = getPeriodFromFilter(filter, layerConfig.id)
+            delete layerConfig.filter
         }
 
-        // Backward compability for layers saved before 2.40
-        if (typeof layerConfig.params?.palette === 'string') {
-            layerConfig.params.palette = layerConfig.params.palette.split(',')
+        // Backward compability for layers saved before v100.6.0
+        if (layerConfig.params) {
+            layerConfig.style = layerConfig.params
+            // Backward compability for layers saved before 2.40
+            if (typeof layerConfig.params.palette === 'string') {
+                layerConfig.style.palette =
+                    layerConfig.params.palette.split(',')
+            }
+            delete layerConfig.params
         }
 
         dataset = getEarthEngineLayer(layerConfig.id)

--- a/src/util/__tests__/pluginHelper.spec.js
+++ b/src/util/__tests__/pluginHelper.spec.js
@@ -76,4 +76,16 @@ describe('didViewsChange', () => {
         ]
         expect(didViewsChange(oldViews, newViews)).toEqual(false)
     })
+
+    it('should always return false for earth engine layer', () => {
+        const oldViews = [{ layer: 'earthEngine', rows: [] }]
+        const newViews = [
+            {
+                layer: 'earthEngine',
+                filters: [],
+                rows: [],
+            },
+        ]
+        expect(didViewsChange(oldViews, newViews)).toEqual(false)
+    })
 })

--- a/src/util/pluginHelper.js
+++ b/src/util/pluginHelper.js
@@ -2,15 +2,16 @@ const didViewsChange = (oldViews, newViews) => {
     return newViews.some((newView, i) => {
         const oldView = oldViews[i]
 
+        // EE layers don't have filters
         if (
-            oldView.filters.length !== newView.filters.length ||
+            oldView.filters?.length !== newView?.filters.length ||
             oldView.rows.length !== newView.rows.length
         ) {
             return true
         }
 
         if (
-            newView.filters.some((filter, j) => {
+            newView.filters?.some((filter, j) => {
                 const oldItemIds = oldView.filters[j].items.map(
                     (item) => item.id
                 )

--- a/src/util/pluginHelper.js
+++ b/src/util/pluginHelper.js
@@ -1,17 +1,23 @@
+import { EARTH_ENGINE_LAYER } from '../constants/layers.js'
+
 const didViewsChange = (oldViews, newViews) => {
     return newViews.some((newView, i) => {
         const oldView = oldViews[i]
 
         // EE layers don't have filters
+        if (oldView.layer === EARTH_ENGINE_LAYER) {
+            return false
+        }
+
         if (
-            oldView.filters?.length !== newView?.filters.length ||
+            oldView.filters.length !== newView.filters.length ||
             oldView.rows.length !== newView.rows.length
         ) {
             return true
         }
 
         if (
-            newView.filters?.some((filter, j) => {
+            newView.filters.some((filter, j) => {
                 const oldItemIds = oldView.filters[j].items.map(
                     (item) => item.id
                 )


### PR DESCRIPTION
Maps plugin is crashing in the dasboard for EE maps due to a missing `filters` prop.  It also fixes issues with backward compatibility issues with older maps with EE layers. 

With this fix EE layers load on Dashboard: 

![Screenshot 2024-08-14 at 14 04 51](https://github.com/user-attachments/assets/2d59b3fe-7d59-4014-82f0-51f6b5bd8f39)

Thematic layers added to the same map respects the dashboard filters: 

![Screenshot 2024-08-14 at 14 04 39](https://github.com/user-attachments/assets/b164e0e3-4c65-4282-8f4f-f87861709fff)

