### PR TITLE
chore: checkout the latest commit to use for the bot message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,10 @@ jobs:
             !contains(github.event.head_commit.message, '[skip release]') }}
         steps:
             - name: Checkout code
-              uses: actions/checkout@master
+              uses: actions/checkout@v4
+              with:
+                  ref: master
+                  fetch-depth: 0
 
             - name: Extract version
               if: success()


### PR DESCRIPTION
The actions/checkout action defaults to using the reference/SHA commit that triggered the workflow. Since a new commit is pushed (updating package.json and CHANGELOG.md) during the release job, we need to instead get that new commit in order to generate the bot message with the correct version and CHANGELOG info.