### PR TITLE
chore: do not run release step if the head commit is a chore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,8 @@ jobs:
             ${{ !github.event.push.repository.fork &&
             github.actor != 'dependabot[bot]' &&
             !contains(github.event.head_commit.message, '[skip ci]') &&
-            !contains(github.event.head_commit.message, '[skip release]') }}
+            !contains(github.event.head_commit.message, '[skip release]') &&
+            !startsWith(github.event.head_commit.message, 'chore') }}
         steps:
             - uses: actions/checkout@v3
               with:


### PR DESCRIPTION
The release step is working, in that the build is successfully released to github and app hub.

But in the case of `chore` commits, the semantic-release step concludes without building since there isn't a release, while apphub still tries to release, and fails. 

This change is merely to avoid the red "failures" (that are not actually failures) in the actions results:
![image](https://github.com/user-attachments/assets/d7b289b8-6b25-4b8a-85ad-6ffd0d2bc541)

If you look at the detail, you'll see that semantic-release concludes that there should not be a release, while apphub still tries to run:
![image](https://github.com/user-attachments/assets/ab5075c8-979f-4c03-9d8e-ffd5e2e39817)
