### PR TITLE
chore: only push to AppHub if build was created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,14 @@ env:
     GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
     D2_APP_HUB_TOKEN: ${{secrets.DHIS2_BOT_APPHUB_TOKEN}}
     CI: true
+    build_exists: false
 
 jobs:
     release:
         runs-on: ubuntu-latest
         if: >
             ${{ !github.event.push.repository.fork &&
-            github.actor != 'dependabot[bot]' &&
-            !contains(github.event.head_commit.message, '[skip ci]') &&
-            !contains(github.event.head_commit.message, '[skip release]') &&
-            !startsWith(github.event.head_commit.message, 'chore') }}
+            github.actor != 'dependabot[bot]' }}
         steps:
             - uses: actions/checkout@v4
               with:
@@ -41,7 +39,17 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
 
+            - name: Set build_exists env var
+              id: check_build
+              run: |
+                  if ls build/bundle/jennifer-demo-app-*.zip 1> /dev/null 2>&1; then
+                      echo "build_exists=true" >> $GITHUB_ENV
+                  else
+                      echo "build_exists=false" >> $GITHUB_ENV
+                  fi
+
             - name: Publish to AppHub
+              if: env.build_exists == 'true'
               run: yarn run d2-app-scripts publish
 
     report-release-result:
@@ -49,9 +57,7 @@ jobs:
         needs: release
         if: >
             ${{ !github.event.push.repository.fork &&
-            github.actor != 'dependabot[bot]' &&
-            !contains(github.event.head_commit.message, '[skip ci]') &&
-            !contains(github.event.head_commit.message, '[skip release]') }}
+            github.actor != 'dependabot[bot]'  }}
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
             - name: Set build_exists env var
               id: check_build
               run: |
-                  if ls build/bundle/jennifer-demo-app-*.zip 1> /dev/null 2>&1; then
+                  if ls build/bundle/maps-app-*.zip 1> /dev/null 2>&1; then
                       echo "build_exists=true" >> $GITHUB_ENV
                   else
                       echo "build_exists=false" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,24 +54,23 @@ jobs:
 
     report-release-result:
         runs-on: ubuntu-latest
+        if: ${{ always() }}
         needs: release
-        if: >
-            ${{ !github.event.push.repository.fork &&
-            github.actor != 'dependabot[bot]'  }}
         steps:
             - name: Checkout code
+              if: ${{ env.build_exists == 'true' && success() }}
               uses: actions/checkout@v4
               with:
                   ref: master
                   fetch-depth: 0
 
             - name: Extract version
-              if: success()
+              if: ${{ env.build_exists == 'true' && success() }}
               id: extract_version
               uses: Saionaro/extract-package-version@v1.3.0
 
             - name: Send success message to analytics-internal-bot slack channel
-              if: success()
+              if: ${{ env.build_exists == 'true' && success() }}
               id: slack_success
               uses: slackapi/slack-github-action@v1.27.0
               with:

--- a/.releaserc
+++ b/.releaserc
@@ -8,11 +8,11 @@
             {
                 "releaseRules": [
                     {
-                        "message": "skip release",
+                        "message": "[skip release]",
                         "release": false
                     },
                     {
-                        "message": "skip ci",
+                        "message": "[skip ci]",
                         "release": false
                     }
                 ]

--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,21 @@
         "master"
     ],
     "plugins": [
-        "@semantic-release/commit-analyzer",
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "releaseRules": [
+                    {
+                        "message": "skip release",
+                        "release": false
+                    },
+                    {
+                        "message": "skip ci",
+                        "release": false
+                    }
+                ]
+            }
+        ],
         "@semantic-release/release-notes-generator",
         "@semantic-release/changelog",
         "@semantic-release/npm",


### PR DESCRIPTION
There are 2 main improvements to the workflow to help solve all the failing builds:
* Instead of complex if statements in the gh workflow file (they aren't even working anyway!), use commit_analyzer config to prevent release for our [skip release] and [skip ci] PRs.
* publishing to AppHub fails if there is no build file, which there won't be in the case of chores and [skip release]. So add an if statement that checks for an env var. The env var gets set to true if there is a build.

Here's some workflow outputs that demonstrate the above changes in a test repo:

`build_exists` has been set to true and Publish AppHub runs: https://github.com/jenniferarnesen/dhis2-ci-demo/actions/runs/11667460947/job/32484827377

Skip publishing to App hub when [skip release] (even when the commit was a fix or feature): https://github.com/jenniferarnesen/dhis2-ci-demo/actions/runs/11681915720/job/32527955692#step:5:55



