### PR TITLE
fix: allow editing invalid layers

### DIFF
--- a/cypress/elements/layer.js
+++ b/cypress/elements/layer.js
@@ -28,12 +28,37 @@ export class Layer {
         return this
     }
 
+    unselectOu(ouName) {
+        cy.getByDataTest('org-unit-tree').contains(ouName).scrollIntoView()
+
+        cy.getByDataTest('org-unit-tree')
+            .contains(ouName)
+            .find('input')
+            .uncheck()
+
+        return this
+    }
+
     selectOuLevel(level) {
         cy.getByDataTest('org-unit-level-select').click()
 
         cy.getByDataTest('dhis2-uicore-select-menu-menuwrapper')
             .contains(level)
-            .click()
+            .find('input')
+            .check()
+        cy.get('body').click() // Close the modal menu
+
+        return this
+    }
+
+    unselectOuLevel(level) {
+        cy.getByDataTest('org-unit-level-select').click()
+
+        cy.getByDataTest('dhis2-uicore-select-menu-menuwrapper')
+            .contains(level)
+            .find('input')
+            .uncheck()
+
         cy.get('body').click() // Close the modal menu
 
         return this
@@ -61,6 +86,12 @@ export class Layer {
     addToMap() {
         cy.getByDataTest('dhis2-uicore-modalactions')
             .contains('Add layer')
+            .click()
+    }
+
+    updateMap() {
+        cy.getByDataTest('dhis2-uicore-modalactions')
+            .contains('Update layer')
             .click()
     }
 

--- a/cypress/integration/layers/geojsonlayer.cy.js
+++ b/cypress/integration/layers/geojsonlayer.cy.js
@@ -142,7 +142,7 @@ describe('GeoJSON URL Layer', () => {
         cy.getByDataTest('more-menu')
             .find('li')
             .not('.disabled')
-            .should('have.length', 2)
+            .should('have.length', 3) // Edit layer, Remove layer, divider line
 
         cy.getByDataTest('more-menu')
             .find('li')
@@ -207,7 +207,7 @@ describe('GeoJSON URL Layer', () => {
         cy.getByDataTest('more-menu')
             .find('li')
             .not('.disabled')
-            .should('have.length', 2)
+            .should('have.length', 3) // Edit layer, Remove layer, divider line
 
         cy.getByDataTest('more-menu')
             .find('li')

--- a/src/components/layers/LayerCard.js
+++ b/src/components/layers/LayerCard.js
@@ -41,7 +41,6 @@ const LayerCard = ({
                         }
                         onClick={toggleExpand}
                         className={styles.expand}
-                        dataTest="editbutton"
                     >
                         {isExpanded ? (
                             <IconChevronUp24 />

--- a/src/components/layers/toolbar/LayerToolbar.js
+++ b/src/components/layers/toolbar/LayerToolbar.js
@@ -23,11 +23,10 @@ const LayerToolbar = ({
         <div className={styles.toolbar} data-test="layertoolbar">
             {onEdit && (
                 <IconButton
-                    tooltip={!hasError ? i18n.t('Edit') : null}
+                    tooltip={i18n.t('Edit')}
                     onClick={onEdit}
                     className={styles.editButton}
-                    dataTest="editbutton"
-                    disabled={hasError}
+                    dataTest="layer-edit-button"
                 >
                     <IconEdit24 />
                 </IconButton>

--- a/src/components/layers/toolbar/LayerToolbarMoreMenu.js
+++ b/src/components/layers/toolbar/LayerToolbarMoreMenu.js
@@ -115,7 +115,6 @@ const LayerToolbarMoreMenu = ({
                                         setIsOpen(false)
                                         onEdit()
                                     }}
-                                    disabled={hasError}
                                 />
                             )}
                             {onRemove && (

--- a/src/components/layers/toolbar/__tests__/LayerToolbar.spec.js
+++ b/src/components/layers/toolbar/__tests__/LayerToolbar.spec.js
@@ -89,7 +89,7 @@ describe('LayerToolbar', () => {
             onEdit: editFn,
         })
 
-        wrapper.find('[dataTest="editbutton"]').simulate('click')
+        wrapper.find('[dataTest="layer-edit-button"]').simulate('click')
         expect(editFn).toHaveBeenCalled()
         expect(toggleVisibleFn).not.toHaveBeenCalled()
 

--- a/src/components/layers/toolbar/__tests__/LayerToolbarMoreMenu.spec.js
+++ b/src/components/layers/toolbar/__tests__/LayerToolbarMoreMenu.spec.js
@@ -221,4 +221,67 @@ describe('LayerToolbarMoreMenu', () => {
             expect(screen.queryByText('Open as chart')).toBeNull()
         })
     })
+
+    test('renders disabled menu items if there was an error', async () => {
+        const store = {
+            aggregations: {},
+        }
+
+        const layer = {
+            id: 'rainbowdash',
+            data: 'hasdata',
+        }
+
+        render(
+            <Provider store={mockStore(store)}>
+                <LayerToolbarMoreMenu
+                    layer={layer}
+                    toggleDataTable={jest.fn()}
+                    onRemove={jest.fn()}
+                    onEdit={jest.fn()}
+                    downloadData={jest.fn()}
+                    hasError={true}
+                />
+            </Provider>
+        )
+
+        fireEvent.click(screen.getByLabelText('Toggle layer menu'))
+
+        await waitFor(() => {
+            expect(screen.queryByText('Show data table')).toBeTruthy()
+            expect(
+                screen
+                    .queryByText('Show data table')
+                    .closest('li')
+                    .classList.contains('disabled')
+            ).toBe(true)
+
+            expect(screen.queryByText('Download data')).toBeTruthy()
+            expect(
+                screen
+                    .queryByText('Download data')
+                    .closest('li')
+                    .classList.contains('disabled')
+            ).toBe(true)
+            expect(screen.queryByText('Edit layer')).toBeTruthy()
+            expect(
+                screen
+                    .queryByText('Edit layer')
+                    .closest('li')
+                    .classList.contains('disabled')
+            ).toBe(false)
+
+            expect(screen.queryByText('Remove layer')).toBeTruthy()
+            expect(
+                screen
+                    .queryByText('Remove layer')
+                    .closest('li')
+                    .classList.contains('disabled')
+            ).toBe(false)
+            // confirm the divider is present (1 more list item)
+            expect(screen.getByRole('menu').children.length).toEqual(5)
+
+            expect(screen.queryByText('Open as chart')).toBeNull()
+        })
+    })
 })

--- a/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbar.spec.js.snap
+++ b/src/components/layers/toolbar/__tests__/__snapshots__/LayerToolbar.spec.js.snap
@@ -7,7 +7,7 @@ exports[`LayerToolbar Should match toolbar snapshot WITH Edit button 1`] = `
 >
   <IconButton
     className="editButton"
-    dataTest="editbutton"
+    dataTest="layer-edit-button"
     onClick={[Function]}
     tooltip="Edit"
   >

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -276,6 +276,7 @@ const thematicLoader = async ({ config, engine, nameProperty }) => {
         isLoading: false,
         isExpanded: true,
         isVisible: true,
+        loadError,
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,7 +2323,7 @@
   resolved "https://registry.yarnpkg.com/@dhis2/ui-icons/-/ui-icons-9.13.0.tgz#321ffcaadade8e4b29600fe5208e5f07ba1be26b"
   integrity sha512-elFOMwpL4St5cAjdUy8PqSzaSJcfhdlZG8aARvvaAwtA42s2QZp/zXaztOjshjN8iQBFZMqH93XqQh8Dmqb0mA==
 
-"@dhis2/ui@9.13.0", "@dhis2/ui@^9.13.0", "@dhis2/ui@^9.8.9":
+"@dhis2/ui@^9.13.0", "@dhis2/ui@^9.8.9":
   version "9.13.0"
   resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-9.13.0.tgz#191a3e14f3a4874f02e44e94e53cbe1694c69de3"
   integrity sha512-VuqW+jF/tf99ZjnyaFdRmPj1BBeFs22XBEqGFOiClPSTT2d6xIcX7VPY7+vf99WnadijQ4/T2238FhtjIVidXw==


### PR DESCRIPTION
Fixes [DHIS2-18157](https://dhis2.atlassian.net/browse/DHIS2-18157)

If a user configures an invalid layer, it should be possible for them to edit it. For geojson url layers this isn't useful since there's nothing the user can do to fix an invalid geojson url layer. But for thematic layers, the user should be able to fix whatever is wrong most of the time

Checklist
-  [x] Dashboard tested
-  [x] Cypress tests added
-  [x] Manual testing complete

[DHIS2-18157]: https://dhis2.atlassian.net/browse/DHIS2-18157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


Here's what an invalid map looks like in dashboard (hovering over the legend key button)

<img width="644" alt="image" src="https://github.com/user-attachments/assets/43dcb754-dc6a-4370-8c93-ae3682ade0df">

In maps app with the edit button enabled now
<img width="1288" alt="image" src="https://github.com/user-attachments/assets/6dda6cfa-951a-46f9-8609-92a3d5f066eb">

