### PR TITLE
fix: update 'No data' handling

### DIFF
--- a/cypress/elements/thematic_layer.js
+++ b/cypress/elements/thematic_layer.js
@@ -48,9 +48,22 @@ export class ThematicLayer extends Layer {
         return this
     }
 
+    selectRelativePeriod(period) {
+        cy.get('[data-test="relative-period-select"]').click()
+        cy.contains(period).click()
+
+        return this
+    }
+
     selectPeriodType(periodType) {
         cy.get('[data-test="periodtypeselect"]').click()
         cy.contains(periodType).click()
+
+        return this
+    }
+
+    selectIncludeNoDataOU() {
+        cy.contains('Include org units with no data').click()
 
         return this
     }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@dhis2/app-runtime": "^3.11.2",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",
-        "@dhis2/maps-gl": "git+https://github.com/d2-ci/maps-gl.git#fix/DHIS2-18427",
+        "@dhis2/maps-gl": "git+https://github.com/d2-ci/maps-gl.git#3460b2d47f50e9e4307df415658a2a3e4234ad68",
         "@dhis2/ui": "^9.13.0",
         "@krakenjs/post-robot": "^11.0.0",
         "@reportportal/agent-js-cypress": "git+https://github.com/dhis2/agent-js-cypress.git#develop",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@dhis2/app-runtime": "^3.11.2",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",
-        "@dhis2/maps-gl": "^4.0.0",
+        "@dhis2/maps-gl": "git+https://github.com/d2-ci/maps-gl.git#fix/DHIS2-18427",
         "@dhis2/ui": "^9.13.0",
         "@krakenjs/post-robot": "^11.0.0",
         "@reportportal/agent-js-cypress": "git+https://github.com/dhis2/agent-js-cypress.git#develop",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@dhis2/app-runtime": "^3.11.2",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",
-        "@dhis2/maps-gl": "git+https://github.com/d2-ci/maps-gl.git#3460b2d47f50e9e4307df415658a2a3e4234ad68",
+        "@dhis2/maps-gl": "git+https://github.com/d2-ci/maps-gl.git#1b235a8e3fc0a7cb9b207b2353236c4e2952bffe",
         "@dhis2/ui": "^9.13.0",
         "@krakenjs/post-robot": "^11.0.0",
         "@reportportal/agent-js-cypress": "git+https://github.com/dhis2/agent-js-cypress.git#develop",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@dhis2/app-runtime": "^3.11.2",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",
-        "@dhis2/maps-gl": "git+https://github.com/d2-ci/maps-gl.git#1b235a8e3fc0a7cb9b207b2353236c4e2952bffe",
+        "@dhis2/maps-gl": "^4.0.1",
         "@dhis2/ui": "^9.13.0",
         "@krakenjs/post-robot": "^11.0.0",
         "@reportportal/agent-js-cypress": "git+https://github.com/dhis2/agent-js-cypress.git#develop",

--- a/src/components/map/layers/ThematicLayer.js
+++ b/src/components/map/layers/ThematicLayer.js
@@ -179,7 +179,7 @@ class ThematicLayer extends Layer {
                 <div>{indicator}</div>
                 <div>{periodName}</div>
                 <div>
-                    {i18n.t('Value')}: {value ? value : i18n.t('No data')}
+                    {i18n.t('Value')}: {value ?? i18n.t('No data')}
                 </div>
                 {aggregationType && aggregationType !== 'DEFAULT' && (
                     <div>{aggregationType}</div>

--- a/src/util/labels.js
+++ b/src/util/labels.js
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n'
 import {
     LABEL_FONT_SIZE,
     LABEL_FONT_STYLE,
@@ -20,5 +21,6 @@ export const getLabelStyle = ({
         lineHeight: parseInt(fontSize, 10) * 1.2 + 'px',
         color: cssColor(labelFontColor) || LABEL_FONT_COLOR,
         paddingTop: '10px',
+        labelNoData: i18n.t('No data'),
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2246,9 +2246,9 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/maps-gl@git+https://github.com/d2-ci/maps-gl.git#3460b2d47f50e9e4307df415658a2a3e4234ad68":
+"@dhis2/maps-gl@git+https://github.com/d2-ci/maps-gl.git#1b235a8e3fc0a7cb9b207b2353236c4e2952bffe":
   version "4.0.0"
-  resolved "git+https://github.com/d2-ci/maps-gl.git#3460b2d47f50e9e4307df415658a2a3e4234ad68"
+  resolved "git+https://github.com/d2-ci/maps-gl.git#1b235a8e3fc0a7cb9b207b2353236c4e2952bffe"
   dependencies:
     "@mapbox/sphericalmercator" "^1.2.0"
     "@turf/area" "^6.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2246,9 +2246,10 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/maps-gl@git+https://github.com/d2-ci/maps-gl.git#1b235a8e3fc0a7cb9b207b2353236c4e2952bffe":
-  version "4.0.0"
-  resolved "git+https://github.com/d2-ci/maps-gl.git#1b235a8e3fc0a7cb9b207b2353236c4e2952bffe"
+"@dhis2/maps-gl@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-4.0.1.tgz#227a856c9a5dd0a38a8a3ea0ebd6327872850f3e"
+  integrity sha512-4Q9zxzPhV81zSZyWYyX7iOufUvSfqHWjXkpYUqgPq8uxhpCNj9vVwb6l5FaU/0ZbWC+wusiYeMAkLvsUpoR51g==
   dependencies:
     "@mapbox/sphericalmercator" "^1.2.0"
     "@turf/area" "^6.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2246,9 +2246,9 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/maps-gl@git+https://github.com/d2-ci/maps-gl.git#fix/DHIS2-18427":
+"@dhis2/maps-gl@git+https://github.com/d2-ci/maps-gl.git#3460b2d47f50e9e4307df415658a2a3e4234ad68":
   version "4.0.0"
-  resolved "git+https://github.com/d2-ci/maps-gl.git#8fb383383fd18d18f9d8b5551f95328d9cb592c3"
+  resolved "git+https://github.com/d2-ci/maps-gl.git#3460b2d47f50e9e4307df415658a2a3e4234ad68"
   dependencies:
     "@mapbox/sphericalmercator" "^1.2.0"
     "@turf/area" "^6.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2246,10 +2246,9 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/maps-gl@^4.0.0":
+"@dhis2/maps-gl@git+https://github.com/d2-ci/maps-gl.git#fix/DHIS2-18427":
   version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-4.0.0.tgz#e97df2fbc78f787a0916224d7d54fb96b9c376db"
-  integrity sha512-TDEIBT6rFuEZGXnBxAqKhSmCXk3wtuCf/OrVZBKxT1qk0kHau71f3lzAXbWhYAuop8t6/DyJaIcQrUYMi1Xy3w==
+  resolved "git+https://github.com/d2-ci/maps-gl.git#8fb383383fd18d18f9d8b5551f95328d9cb592c3"
   dependencies:
     "@mapbox/sphericalmercator" "^1.2.0"
     "@turf/area" "^6.5.0"


### PR DESCRIPTION
Implement [DHIS2-18427](https://dhis2.atlassian.net/browse/DHIS2-18427)
Linked maps-gl PR: https://github.com/dhis2/maps-gl/pull/596
Backport to v39 PR: https://github.com/dhis2/maps-app/pull/3415

---

- Bump maps-gl dependency to get fix on tooltip 'No data' logic and labelSource to support labelNoData for "name and value" and "value" labels.
- Update getLabelStyle to return labelNoData for labelSource in maps-gl: https://github.com/dhis2/maps-app/blob/cf9cd47dc0e998b4ced68c7c4345fd06035e44aa/src/util/labels.js#L16-L23
- Update pop-up 'No data' logic: https://github.com/dhis2/maps-app/blob/cf9cd47dc0e998b4ced68c7c4345fd06035e44aa/src/components/map/layers/ThematicLayer.js#L182

---

Checklist:
- [x] <del>Jest tests added</del>
- [x] Cypress tests added
- [x] Manual testing complete
- [x] Dashboard tested
- [x] Update maps-gl dependency (to not point to d2-ci)

---

Before:
![image](https://github.com/user-attachments/assets/54ecda5d-c1d5-4357-af40-8121c09d4213)

After:
![image](https://github.com/user-attachments/assets/13531f6a-cc9a-4cb3-a1df-454fb915bc8f)

[DHIS2-18427]: https://dhis2.atlassian.net/browse/DHIS2-18427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ