### PR TITLE
chore: report release job of release workflow needs output from the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,6 @@ env:
     GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
     D2_APP_HUB_TOKEN: ${{secrets.DHIS2_BOT_APPHUB_TOKEN}}
     CI: true
-    build_exists: false
 
 jobs:
     release:
@@ -21,6 +20,8 @@ jobs:
         if: >
             ${{ !github.event.push.repository.fork &&
             github.actor != 'dependabot[bot]' }}
+        outputs:
+            build_exists: ${{ steps.check_build.outputs.build_exists }}
         steps:
             - uses: actions/checkout@v4
               with:
@@ -39,17 +40,17 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
 
-            - name: Set build_exists env var
+            - name: Set build_exists output
               id: check_build
               run: |
                   if ls build/bundle/maps-*.zip 1> /dev/null 2>&1; then
-                      echo "build_exists=true" >> $GITHUB_ENV
+                      echo "build_exists=yes" >> $GITHUB_OUTPUT
                   else
-                      echo "build_exists=false" >> $GITHUB_ENV
+                      echo "build_exists=no" >> $GITHUB_OUTPUT
                   fi
 
             - name: Publish to AppHub
-              if: env.build_exists == 'true'
+              if: ${{ steps.check_build.outputs.build_exists == 'yes' }}
               run: yarn run d2-app-scripts publish
 
     report-release-result:
@@ -58,19 +59,19 @@ jobs:
         needs: release
         steps:
             - name: Checkout code
-              if: ${{ env.build_exists == 'true' && success() }}
+              if: ${{ needs.release.outputs.build_exists == 'yes' && success() }}
               uses: actions/checkout@v4
               with:
                   ref: master
                   fetch-depth: 0
 
             - name: Extract version
-              if: ${{ env.build_exists == 'true' && success() }}
+              if: ${{ needs.release.outputs.build_exists == 'yes' && success() }}
               id: extract_version
               uses: Saionaro/extract-package-version@v1.3.0
 
             - name: Send success message to analytics-internal-bot slack channel
-              if: ${{ env.build_exists == 'true' && success() }}
+              if: ${{ needs.release.outputs.build_exists == 'yes' && success() }}
               id: slack_success
               uses: slackapi/slack-github-action@v1.27.0
               with:

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -104,6 +104,7 @@ context('Thematic Layers', () => {
             .selectIndicatorGroup('Stock')
             .selectIndicator('BCG Stock PHU')
             .selectTab('Period')
+            .selectPeriodType('Start/end dates')
             .typeStartDate(`${CURRENT_YEAR}-11-01`)
             .typeEndDate(`${CURRENT_YEAR}-11-30`)
             .selectTab('Style')

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -104,7 +104,8 @@ context('Thematic Layers', () => {
             .selectIndicatorGroup('Stock')
             .selectIndicator('BCG Stock PHU')
             .selectTab('Period')
-            .selectRelativePeriod('This month')
+            .typeStartDate(`${CURRENT_YEAR}-11-01`)
+            .typeEndDate(`${CURRENT_YEAR}-11-30`)
             .selectTab('Style')
             .selectIncludeNoDataOU()
             .selectTab('Org Units')
@@ -138,7 +139,7 @@ context('Thematic Layers', () => {
         cy.get('#dhis2-map-container')
             .findByDataTest('dhis2-uicore-componentcover', EXTENDED_TIMEOUT)
             .should('not.exist')
-        cy.get('.dhis2-map').click('center') //Click somewhere on the map
+        cy.get('.dhis2-map').click('center') //Click in the middle of the map
 
         cy.get('.maplibregl-popup').contains('Value: 0').should('be.visible')
 
@@ -159,7 +160,7 @@ context('Thematic Layers', () => {
         cy.get('#dhis2-map-container')
             .findByDataTest('dhis2-uicore-componentcover', EXTENDED_TIMEOUT)
             .should('not.exist')
-        cy.get('.dhis2-map').click('center') //Click somewhere on the map
+        cy.get('.dhis2-map').click('center') //Click in the middle of the map
 
         cy.get('.maplibregl-popup')
             .contains('Value: No data')


### PR DESCRIPTION
Setting environment variables doesn't persist between jobs, so use output instead to record whether a build was successful.

Also fixed a test that started to fail when "This month" became December rather than November. Choosing fixed dates should fix this problem.