### PR TITLE
fix: Timeline not showning in dashboard

### DIFF
--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -153,6 +153,7 @@ class Map extends Component {
             openContextMenu,
             setAggregations,
             setFeatureProfile,
+            resizeCount,
         } = this.props
         const { map } = this.state
 
@@ -179,6 +180,7 @@ class Map extends Component {
                                     setFeatureProfile={setFeatureProfile}
                                     engine={engine}
                                     nameProperty={nameProperty}
+                                    resizeCount={resizeCount}
                                     {...config}
                                 />
                             )

--- a/src/components/map/layers/ThematicLayer.js
+++ b/src/components/map/layers/ThematicLayer.js
@@ -204,7 +204,7 @@ class ThematicLayer extends Layer {
     }
 
     render() {
-        const { periods, renderingStrategy, filters } = this.props
+        const { periods, renderingStrategy, filters, resizeCount } = this.props
         const { period, popup } = this.state
         const { id } = getPeriodFromFilters(filters) || {}
 
@@ -225,6 +225,7 @@ class ThematicLayer extends Layer {
                                     period={period}
                                     periods={periods}
                                     onChange={this.onPeriodChange}
+                                    resizeCount={resizeCount}
                                 />
                             </ThematicLayerContext.Provider>
                         </Fragment>

--- a/src/components/periods/Timeline.js
+++ b/src/components/periods/Timeline.js
@@ -4,7 +4,6 @@ import { scaleTime } from 'd3-scale'
 import { select } from 'd3-selection'
 import PropTypes from 'prop-types'
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
-import { useSelector } from 'react-redux'
 import {
     addPeriodsDetails,
     sortPeriodsByLevelAndStartDate,
@@ -23,8 +22,7 @@ const DELAY = 1500
 const MODE_PLAY = 'play'
 const MODE_PAUSE = 'pause'
 
-const Timeline = ({ period, periods, onChange }) => {
-    const { layersPanelOpen, rightPanelOpen } = useSelector((state) => state.ui)
+const Timeline = ({ period, periods, onChange, resizeCount }) => {
     const [width, setWidth] = useState(null)
     const [mode, setMode] = useState('start')
     const [currentPeriod, setCurrentPeriod] = useState(period)
@@ -49,7 +47,7 @@ const Timeline = ({ period, periods, onChange }) => {
         window.addEventListener('resize', updateWidth)
         updateWidth()
         return () => window.removeEventListener('resize', updateWidth)
-    }, [updateWidth, layersPanelOpen, rightPanelOpen])
+    }, [updateWidth, resizeCount])
 
     const { periodsWithTypeLevelAndRank, distinctLevelsCount } = useMemo(
         () => addPeriodsDetails(periods),
@@ -194,6 +192,7 @@ Timeline.propTypes = {
     period: PropTypes.object.isRequired,
     periods: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
+    resizeCount: PropTypes.number,
 }
 
 export default Timeline


### PR DESCRIPTION
Implement: [DHIS2-18985](https://dhis2.atlassian.net/browse/DHIS2-18985)

---

Timeline component to recieve and use `resizeCount` from parent to trigger resize instead of getting `ui.layersPanelOpen` and  `ui.rightPanelOpen` from redux store (not available in plugin).

---

Before:
![image](https://github.com/user-attachments/assets/39942bd4-0ec9-44a7-bae8-68b106945b09)

After:
![image](https://github.com/user-attachments/assets/77be3507-984a-4762-813e-46c21841e262)


[DHIS2-18985]: https://dhis2.atlassian.net/browse/DHIS2-18985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ