### PR TITLE
chore: use PR task list format recognized by gh action task list checker

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,8 @@ _description text_
 - [ ] Dashboard tested
 - [ ] Tests added (Cypress and/or Jest)
 - [ ] Docs added
-- [ ] Update dependencies to not point to d2-ci
+- [ ] Strings generated
+- [ ] d2-ci dependency replaced
 - [ ] _todo_
 
 ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,17 +10,17 @@ _description text_
 
 ### TODO
 
--   [ ] Dashboard tested
--   [ ] Tests added (Cypress and/or Jest)
--   [ ] Docs added
--   [ ] Update dependencies to not point to d2-ci
--   [ ] _todo_
+- [ ] Dashboard tested
+- [ ] Tests added (Cypress and/or Jest)
+- [ ] Docs added
+- [ ] Update dependencies to not point to d2-ci
+- [ ] _todo_
 
 ---
 
 ### Known issues
 
--   [ ] _issue_
+- [ ] _issue_
 
 ---
 

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -4,7 +4,7 @@ module.exports = {
     ...require(config.prettier),
     overrides: [
         {
-            files: '*.md',
+            files: 'pull_request_template.md',
             options: {
                 tabWidth: 2,
             },

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,4 +2,12 @@ const { config } = require('@dhis2/cli-style')
 
 module.exports = {
     ...require(config.prettier),
+    overrides: [
+        {
+            files: '*.md',
+            options: {
+                tabWidth: 2,
+            },
+        },
+    ],
 }


### PR DESCRIPTION
### Description

The task list checker requires only a single space between the hyphen and the opening bracket of a task

### TODO

- [ ] Dashboard tested N/A
- [x] Tests added (Cypress and/or Jest)
- [x] Docs added
- [x] Update dependencies to not point to d2-ci
