### PR TITLE
fix: update value in popup with period change in timeline [DHIS2-19008]

### DIFF
--- a/src/components/map/layers/ThematicLayer.js
+++ b/src/components/map/layers/ThematicLayer.js
@@ -248,7 +248,32 @@ class ThematicLayer extends Layer {
         )
     }
 
-    onPeriodChange = (period) => this.setState({ period })
+    onPeriodChange = (period) => {
+        this.setState((prevState) => {
+            const { popup } = prevState
+            if (!popup) {
+                return { period }
+            }
+
+            const { valuesByPeriod } = this.props
+            const newValues = valuesByPeriod[period.id] || {}
+            const updatedPopup = {
+                ...popup,
+                feature: {
+                    ...popup.feature,
+                    properties: {
+                        ...popup.feature.properties,
+                        ...newValues[popup.feature.properties.id],
+                    },
+                },
+            }
+
+            return {
+                period,
+                popup: updatedPopup,
+            }
+        })
+    }
 
     onFeatureClick(evt) {
         this.setState({ popup: evt })


### PR DESCRIPTION
Implements [DHIS2-19008](https://dhis2.atlassian.net/browse/DHIS2-19008)

---

### Description

In thematicLayer, `onPeriodChange` if a popup is opened, update the `popup.feature.properties` state to get and display the updated value.

### TODO

- [x] Dashboard tested
- [ ] Tests added (Cypress and/or Jest) N/A
- [ ] Docs added N/A
- [ ] Strings generated N/A
- [ ] d2-ci dependency replaced N/A

---

### Screenshots

![image](https://github.com/user-attachments/assets/07a5cc85-6ee6-48cf-b5d5-815a9abf3aef)


[DHIS2-19008]: https://dhis2.atlassian.net/browse/DHIS2-19008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ