### PR TITLE
chore: add e2e test to assert push-analytics prerequisites [DHIS2-19123]

### DIFF
--- a/cypress/integration/pushAnalytics.cy.js
+++ b/cypress/integration/pushAnalytics.cy.js
@@ -13,6 +13,6 @@ describe('push-analytics', () => {
         })
     })
     /* The Push Analytics service produces a map artefact using the exact
-     * same process as is veriefied in `mapDownload.cy.js`, so no further
+     * same process as is verified in `mapDownload.cy.js`, so no further
      * tests are required here. */
 })

--- a/cypress/integration/pushAnalytics.cy.js
+++ b/cypress/integration/pushAnalytics.cy.js
@@ -1,4 +1,4 @@
-import { EXTENDED_TIMEOUT } from '../support/util'
+import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 describe('push-analytics', () => {
     it(['>=41'], 'has a push-analytics.json file', () => {

--- a/cypress/integration/pushAnalytics.cy.js
+++ b/cypress/integration/pushAnalytics.cy.js
@@ -1,3 +1,5 @@
+import { EXTENDED_TIMEOUT } from '../support/util'
+
 describe('push-analytics', () => {
     it(['>=41'], 'has a push-analytics.json file', () => {
         cy.visit('/')
@@ -12,7 +14,51 @@ describe('push-analytics', () => {
             expect(response.body).to.have.property('clearVisualization')
         })
     })
-    /* The Push Analytics service produces a map artefact using the exact
-     * same process as is verified in `mapDownload.cy.js`, so no further
-     * tests are required here. */
+    it(
+        ['>=41'],
+        'can download a file using the instructions in the push-analytics.json',
+        () => {
+            /* This is a simplified version of the tests in `mapDownload.cy.js`.
+             * This test will start failing when the file download mechanism is
+             * updated. Once this happens an update to the `push-analytics.json`
+             * file is required and if the new file download mechanism is not
+             * yet supported by the push-analytics service, this will need to
+             * be updated as well. */
+            const mapWithThematicLayer = {
+                id: 'eDlFx0jTtV9',
+                name: 'ANC: LLITN Cov Chiefdom this year',
+                downloadFileName: 'ANC LLITN Cov Chiefdom this year.png',
+                cardTitle: 'ANC LLITN coverage',
+            }
+            cy.task('emptyDownloadsFolder')
+
+            cy.visit(`/#/${mapWithThematicLayer.id}`, EXTENDED_TIMEOUT)
+
+            cy.getByDataTest('dhis2-analytics-hovermenubar')
+                .find('button')
+                .contains('Download')
+                .should('be.visible')
+                .click()
+
+            cy.getByDataTest('download-settings')
+                .find('button')
+                .contains('Download')
+                .click()
+
+            cy.wait(3000) // eslint-disable-line cypress/no-unnecessary-waiting
+            cy.waitUntil(
+                () =>
+                    cy.task('getLastDownloadFilePath').then((result) => result),
+                { timeout: 3000, interval: 100 }
+            ).then((filePath) => {
+                expect(filePath).to.include(
+                    mapWithThematicLayer.downloadFileName
+                )
+
+                cy.readFile(filePath, EXTENDED_TIMEOUT).should((buffer) =>
+                    expect(buffer.length).to.be.gt(10000)
+                )
+            })
+        }
+    )
 })

--- a/cypress/integration/pushAnalytics.cy.js
+++ b/cypress/integration/pushAnalytics.cy.js
@@ -1,0 +1,18 @@
+describe('push-analytics', () => {
+    it(['>=41'], 'has a push-analytics.json file', () => {
+        cy.visit('/')
+        cy.request('push-analytics.json').as('file')
+
+        cy.get('@file').should((response) => {
+            expect(response.status).to.equal(200)
+            expect(response.body).to.have.property('version')
+            expect(response.body).to.have.property('showVisualization')
+            expect(response.body).to.have.property('triggerDownload')
+            expect(response.body).to.have.property('obtainDownloadArtifact')
+            expect(response.body).to.have.property('clearVisualization')
+        })
+    })
+    /* The Push Analytics service produces a map artefact using the exact
+     * same process as is veriefied in `mapDownload.cy.js`, so no further
+     * tests are required here. */
+})


### PR DESCRIPTION
Implements [DHIS2-19123](https://dhis2.atlassian.net/browse/DHIS2-19123)

Similar to https://github.com/dhis2/line-listing-app/pull/655 and https://github.com/dhis2/data-visualizer-app/pull/3356.

The push analytics service uses Puppeteer to generate a map-artefact using the steps outlined in the `push-analytics.json`. This test is a contract test of sorts: when a change in the codebase causes this test to start failing, it is a sign that the instructions in `push-analytics.json` need to be updated, and possibly the push-analytics service itself as well.

[DHIS2-19123]: https://dhis2.atlassian.net/browse/DHIS2-19123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ