### PR TITLE
fix: prevent app crash when switching event layer to start/end dates [DHIS2-19204]

### DIFF
--- a/src/components/edit/event/EventDialog.js
+++ b/src/components/edit/event/EventDialog.js
@@ -121,6 +121,7 @@ class EventDialog extends Component {
             setPeriod,
             setBackupPeriodsDates,
             setOrgUnits,
+            backupPeriodsDates,
         } = this.props
 
         const period = getPeriodFromFilters(filters)
@@ -139,6 +140,10 @@ class EventDialog extends Component {
             setPeriod({
                 id: defaultPeriod,
             })
+        }
+
+        // Set default backup dates
+        if (!backupPeriodsDates) {
             const defaultDates = getDefaultDatesInCalendar()
             setBackupPeriodsDates(defaultDates)
         }


### PR DESCRIPTION
Implements [DHIS2-19204](https://dhis2.atlassian.net/browse/DHIS2-19204)

---

### Description

Set default values for start/end dates backup to be restored when switching. 

### TODO

- [ ] Dashboard tested N/A
- [ ] Tests added (Cypress and/or Jest) N/A
- [ ] Docs added N/A
- [ ] Strings generated N/A
- [ ] d2-ci dependency replaced N/A


[DHIS2-19204]: https://dhis2.atlassian.net/browse/DHIS2-19204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ