### PR TITLE
fix: header bar visibility issues in download mode [DHIS2-19279] [DHIS2-19279]

### DIFF
--- a/cypress/elements/map_canvas.js
+++ b/cypress/elements/map_canvas.js
@@ -1,3 +1,17 @@
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
+export const MENU_HEIGHT = 32
+export const IFRAME_HEADER_HEIGHT = 48
+export const GLOBAL_HEADER_HEIGHT = 40
+export const DOWNLOAD_HEADER_HEIGHT = 48
+export const DOWNLOAD_BORDER = 24
+
 export const getMaps = () => cy.get('.dhis2-map canvas', EXTENDED_TIMEOUT)
+
+export const assertMapPosition = (expectedBottoms, expectedHeights) => {
+    getMaps().then(($canvas) => {
+        const boundingRect = $canvas[0].getBoundingClientRect()
+        expect(expectedBottoms).to.include(boundingRect.bottom)
+        expect(expectedHeights).to.include(boundingRect.height)
+    })
+}

--- a/cypress/elements/map_canvas.js
+++ b/cypress/elements/map_canvas.js
@@ -8,17 +8,23 @@ export const DOWNLOAD_BORDER = 24
 
 export const getMaps = () => cy.get('.dhis2-map canvas', EXTENDED_TIMEOUT)
 
-export const assertMapPosition = (expectedBottoms, expectedHeights) => {
+export const assertMapPosition = (
+    expectedBottoms,
+    expectedHeights,
+    tolerance = 0
+) => {
     getMaps().then(($canvas) => {
         const boundingRect = $canvas[0].getBoundingClientRect()
         expect(
             expectedBottoms.some(
-                (expected) => Math.abs(expected - boundingRect.bottom) <= 2
+                (expected) =>
+                    Math.abs(expected - boundingRect.bottom) <= tolerance
             )
         ).to.be.true
         expect(
             expectedHeights.some(
-                (expected) => Math.abs(expected - boundingRect.height) <= 2
+                (expected) =>
+                    Math.abs(expected - boundingRect.height) <= tolerance
             )
         ).to.be.true
     })

--- a/cypress/elements/map_canvas.js
+++ b/cypress/elements/map_canvas.js
@@ -13,12 +13,12 @@ export const assertMapPosition = (expectedBottoms, expectedHeights) => {
         const boundingRect = $canvas[0].getBoundingClientRect()
         expect(
             expectedBottoms.some(
-                (expected) => Math.abs(expected - boundingRect.bottom) <= 1
+                (expected) => Math.abs(expected - boundingRect.bottom) <= 2
             )
         ).to.be.true
         expect(
             expectedHeights.some(
-                (expected) => Math.abs(expected - boundingRect.height) <= 1
+                (expected) => Math.abs(expected - boundingRect.height) <= 2
             )
         ).to.be.true
     })

--- a/cypress/elements/map_canvas.js
+++ b/cypress/elements/map_canvas.js
@@ -11,7 +11,15 @@ export const getMaps = () => cy.get('.dhis2-map canvas', EXTENDED_TIMEOUT)
 export const assertMapPosition = (expectedBottoms, expectedHeights) => {
     getMaps().then(($canvas) => {
         const boundingRect = $canvas[0].getBoundingClientRect()
-        expect(expectedBottoms).to.include(boundingRect.bottom)
-        expect(expectedHeights).to.include(boundingRect.height)
+        expect(
+            expectedBottoms.some(
+                (expected) => Math.abs(expected - boundingRect.bottom) <= 1
+            )
+        ).to.be.true
+        expect(
+            expectedHeights.some(
+                (expected) => Math.abs(expected - boundingRect.height) <= 1
+            )
+        ).to.be.true
     })
 }

--- a/cypress/integration/dataTable.cy.js
+++ b/cypress/integration/dataTable.cy.js
@@ -1,4 +1,10 @@
 import { EventLayer } from '../elements/event_layer.js'
+import {
+    MENU_HEIGHT,
+    IFRAME_HEADER_HEIGHT,
+    GLOBAL_HEADER_HEIGHT,
+    assertMapPosition,
+} from '../elements/map_canvas.js'
 import { CURRENT_YEAR, EXTENDED_TIMEOUT } from '../support/util.js'
 
 Cypress.on('uncaught:exception', (err) => {
@@ -20,8 +26,18 @@ const map = {
 
 describe('data table', () => {
     it('opens data table and filters and sorts', () => {
+        const viewportHeight = Cypress.config('viewportHeight')
+        const expectedBottoms1 = [viewportHeight]
+        const expectedHeights1 = [
+            GLOBAL_HEADER_HEIGHT,
+            IFRAME_HEADER_HEIGHT,
+        ].map((h) => viewportHeight - h - MENU_HEIGHT)
+
         cy.visit(`/#/${map.id}`, EXTENDED_TIMEOUT)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
+
+        //check that the map resizes properly
+        assertMapPosition(expectedBottoms1, expectedHeights1)
 
         cy.getByDataTest('moremenubutton').first().click()
 
@@ -37,6 +53,18 @@ describe('data table', () => {
 
         //check that the bottom panel is present
         cy.getByDataTest('bottom-panel').should('be.visible')
+
+        //check that the map resizes properly
+        cy.getByDataTest('bottom-panel')
+            .invoke('height')
+            .then((height) => {
+                const expectedBottoms2 = [viewportHeight - height]
+                const expectedHeights2 = [
+                    GLOBAL_HEADER_HEIGHT,
+                    IFRAME_HEADER_HEIGHT,
+                ].map((h) => viewportHeight - h - MENU_HEIGHT - height)
+                assertMapPosition(expectedBottoms2, expectedHeights2)
+            })
 
         // check number of columns
         cy.getByDataTest('bottom-panel')
@@ -131,6 +159,19 @@ describe('data table', () => {
 
         // check that the org unit profile drawer is opened
         cy.getByDataTest('org-unit-profile').should('be.visible')
+
+        // close the datatable
+        cy.getByDataTest('moremenubutton').first().click()
+        cy.getByDataTest('more-menu')
+            .find('li')
+            .contains('Hide data table')
+            .click()
+
+        //check that the bottom panel is closed
+        cy.getByDataTest('bottom-panel').should('not.exist')
+
+        //check that the map resizes properly
+        assertMapPosition(expectedBottoms1, expectedHeights1)
     })
 
     it('opens the data table for an Event layer', () => {

--- a/cypress/integration/mapDownload.cy.js
+++ b/cypress/integration/mapDownload.cy.js
@@ -1,3 +1,11 @@
+import {
+    MENU_HEIGHT,
+    IFRAME_HEADER_HEIGHT,
+    GLOBAL_HEADER_HEIGHT,
+    DOWNLOAD_HEADER_HEIGHT,
+    DOWNLOAD_BORDER,
+    assertMapPosition,
+} from '../elements/map_canvas.js'
 import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 const mapWithThematicLayer = {
@@ -29,8 +37,21 @@ describe('Map Download', () => {
     })
 
     it('downloads a map', () => {
+        const viewportHeight = Cypress.config('viewportHeight')
+        const expectedBottoms1 = [viewportHeight]
+        const expectedHeights1 = [
+            GLOBAL_HEADER_HEIGHT,
+            IFRAME_HEADER_HEIGHT,
+        ].map((h) => viewportHeight - h - MENU_HEIGHT)
+        const expectedBottoms2 = [viewportHeight - DOWNLOAD_BORDER]
+        const expectedHeights2 = [
+            viewportHeight - DOWNLOAD_HEADER_HEIGHT - 2 * DOWNLOAD_BORDER,
+        ]
+
         cy.visit(`/#/${mapWithThematicLayer.id}`, EXTENDED_TIMEOUT)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
+
+        assertMapPosition(expectedBottoms1, expectedHeights1)
 
         cy.get('[data-test="layercard"]')
             .find('h2')
@@ -43,6 +64,9 @@ describe('Map Download', () => {
 
         cy.log('confirm that download page is open')
         cy.getByDataTest('headerbar-title').should('not.be.visible')
+
+        assertMapPosition(expectedBottoms2, expectedHeights2)
+
         cy.getByDataTest('download-settings').should('be.visible')
         cy.get('canvas.maplibregl-canvas').should('be.visible')
         cy.get('button').contains('Exit download mode').should('be.visible')
@@ -106,6 +130,9 @@ describe('Map Download', () => {
         cy.url().should('contain', `/#/${mapWithThematicLayer.id}`)
         cy.url().should('not.contain', '/download')
         cy.getByDataTest('headerbar-title').should('be.visible')
+
+        assertMapPosition(expectedBottoms1, expectedHeights1)
+
         cy.getByDataTest('download-settings').should('not.exist')
         cy.get('[data-test="layercard"]')
             .find('h2')

--- a/cypress/integration/mapDownload.cy.js
+++ b/cypress/integration/mapDownload.cy.js
@@ -65,7 +65,7 @@ describe('Map Download', () => {
         cy.log('confirm that download page is open')
         cy.getByDataTest('headerbar-title').should('not.be.visible')
 
-        assertMapPosition(expectedBottoms2, expectedHeights2)
+        assertMapPosition(expectedBottoms2, expectedHeights2, 2)
 
         cy.getByDataTest('download-settings').should('be.visible')
         cy.get('canvas.maplibregl-canvas').should('be.visible')
@@ -130,6 +130,8 @@ describe('Map Download', () => {
         cy.url().should('contain', `/#/${mapWithThematicLayer.id}`)
         cy.url().should('not.contain', '/download')
         cy.getByDataTest('headerbar-title').should('be.visible')
+
+        cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
 
         assertMapPosition(expectedBottoms1, expectedHeights1)
 

--- a/cypress/integration/mapDownload.cy.js
+++ b/cypress/integration/mapDownload.cy.js
@@ -42,6 +42,7 @@ describe('Map Download', () => {
             .click()
 
         cy.log('confirm that download page is open')
+        cy.getByDataTest('headerbar-title').should('not.be.visible')
         cy.getByDataTest('download-settings').should('be.visible')
         cy.get('canvas.maplibregl-canvas').should('be.visible')
         cy.get('button').contains('Exit download mode').should('be.visible')
@@ -104,6 +105,7 @@ describe('Map Download', () => {
         cy.get('button').contains('Exit download mode').click()
         cy.url().should('contain', `/#/${mapWithThematicLayer.id}`)
         cy.url().should('not.contain', '/download')
+        cy.getByDataTest('headerbar-title').should('be.visible')
         cy.getByDataTest('download-settings').should('not.exist')
         cy.get('[data-test="layercard"]')
             .find('h2')

--- a/src/components/app/App.css
+++ b/src/components/app/App.css
@@ -4,4 +4,5 @@
 
     --header-height: 48px;
     --toolbar-height: 32px;
+    --downloadheader-height: 48px;
 }

--- a/src/components/app/styles/App.module.css
+++ b/src/components/app/styles/App.module.css
@@ -38,8 +38,8 @@
 }
 
 .downloadContent {
-    margin-top: var(--header-height);
-    height: calc(100vh - var(--header-height));
+    margin-top: var(--downloadheader-height);
+    height: calc(100vh - var(--downloadheader-height));
 }
 
 .appMapAndTable {

--- a/src/components/datatable/BottomPanel.js
+++ b/src/components/datatable/BottomPanel.js
@@ -3,12 +3,11 @@ import React, { useRef, useCallback } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { closeDataTable, resizeDataTable } from '../../actions/dataTable.js'
 import {
-    APP_MENU_HEIGHT,
     LAYERS_PANEL_WIDTH,
     RIGHT_PANEL_WIDTH,
 } from '../../constants/layout.js'
 import useKeyDown from '../../hooks/useKeyDown.js'
-import { getHeaderHeight } from '../../util/helpers.js'
+import { getCssVar } from '../../util/helpers.js'
 import { useWindowDimensions } from '../WindowDimensionsProvider.js'
 import DataTable from './DataTable.js'
 import ErrorBoundary from './ErrorBoundary.js'
@@ -30,8 +29,8 @@ const BottomPanel = () => {
         [panelRef]
     )
 
-    const headerHeight = getHeaderHeight()
-    const maxHeight = height - headerHeight - APP_MENU_HEIGHT
+    const maxHeight =
+        height - getCssVar('--header-height') - getCssVar('--toolbar-height')
     const tableHeight =
         dataTableHeight < maxHeight ? dataTableHeight : maxHeight
     const layersWidth = layersPanelOpen ? LAYERS_PANEL_WIDTH : 0

--- a/src/components/download/DownloadMenubar.js
+++ b/src/components/download/DownloadMenubar.js
@@ -2,14 +2,14 @@ import i18n from '@dhis2/d2-i18n'
 import { Button, IconChevronLeft24, colors } from '@dhis2/ui'
 import React, { useEffect } from 'react'
 import { closeDownloadMode } from '../../util/history.js'
+import { setHeaderbarVisible } from '../../util/setHeaderbarVisible.js'
 import styles from './styles/DownloadMenubar.module.css'
 
 const DownloadMenubar = () => {
     useEffect(() => {
-        const header = document.getElementsByTagName('header')[0]
-        header.style.display = 'none'
+        setHeaderbarVisible(false)
         return () => {
-            header.style.display = 'block'
+            setHeaderbarVisible(true)
         }
     }, [])
 

--- a/src/components/download/styles/DownloadMenubar.module.css
+++ b/src/components/download/styles/DownloadMenubar.module.css
@@ -3,7 +3,7 @@
     position: absolute;
     align-items: center;
     width: 100%;
-    height: var(--header-height);
+    height: var(--downloadheader-height);
     z-index: 1200;
     background-color: var(--colors-grey600);
     left: 0;

--- a/src/components/map/MapPosition.js
+++ b/src/components/map/MapPosition.js
@@ -1,8 +1,7 @@
 import cx from 'classnames'
 import React, { useState, useEffect } from 'react'
 import { useSelector } from 'react-redux'
-import { APP_MENU_HEIGHT } from '../../constants/layout.js'
-import { getSplitViewLayer, getHeaderHeight } from '../../util/helpers.js'
+import { getSplitViewLayer } from '../../util/helpers.js'
 import DownloadMapInfo from '../download/DownloadMapInfo.js'
 import NorthArrow from '../download/NorthArrow.js'
 import MapContainer from '../map/MapContainer.js'
@@ -23,16 +22,6 @@ const MapPosition = () => {
     const { downloadMode, layersPanelOpen, rightPanelOpen, dataTableHeight } =
         useSelector((state) => state.ui)
     const dataTableOpen = useSelector((state) => !!state.dataTable)
-
-    const headerHeight = getHeaderHeight()
-    let mapHeight = `calc(100vh - ${headerHeight}px)`
-    if (!downloadMode) {
-        if (dataTableOpen) {
-            mapHeight = `calc(100vh - ${headerHeight}px - ${APP_MENU_HEIGHT}px - ${dataTableHeight}px)`
-        } else {
-            mapHeight = `calc(100vh - ${headerHeight}px - ${APP_MENU_HEIGHT}px)`
-        }
-    }
 
     const downloadMapInfoOpen =
         downloadMode &&
@@ -87,39 +76,44 @@ const MapPosition = () => {
     }, [map, downloadMode])
 
     return (
-        <div className={styles.mapPosition} style={{ height: mapHeight }}>
+        <div
+            className={cx(styles.mapDefault, {
+                [styles.mapDownload]: downloadMode,
+                [styles.downloadMapInfoOpen]: downloadMapInfoOpen,
+            })}
+            style={
+                dataTableOpen
+                    ? {
+                          height: `calc(100vh - var(--header-height) - var(--toolbar-height) - ${dataTableHeight}px)`,
+                      }
+                    : {}
+            }
+        >
             <div
-                className={cx({
-                    [styles.mapDownload]: downloadMode,
-                    [styles.downloadMapInfoOpen]: downloadMapInfoOpen,
+                id="dhis2-map-container"
+                className={cx(styles.mapContainer, {
+                    [styles.download]: downloadMode,
+                    'dhis2-map-download': downloadMode,
+                    'dhis2-map-new': !mapId,
                 })}
             >
-                <div
-                    id="dhis2-map-container"
-                    className={cx(styles.mapContainer, {
-                        [styles.download]: downloadMode,
-                        'dhis2-map-download': downloadMode,
-                        'dhis2-map-new': !mapId,
-                    })}
-                >
-                    <MapContainer resizeCount={resizeCount} setMap={setMap} />
-                    {downloadMode && map && (
-                        <>
-                            {downloadMapInfoOpen && (
-                                <DownloadMapInfo
-                                    map={map.getMapGL()}
-                                    isSplitView={isSplitView}
-                                />
-                            )}
-                            {showNorthArrow && !isSplitView && (
-                                <NorthArrow
-                                    map={map.getMapGL()}
-                                    downloadMapInfoOpen={downloadMapInfoOpen}
-                                />
-                            )}
-                        </>
-                    )}
-                </div>
+                <MapContainer resizeCount={resizeCount} setMap={setMap} />
+                {downloadMode && map && (
+                    <>
+                        {downloadMapInfoOpen && (
+                            <DownloadMapInfo
+                                map={map.getMapGL()}
+                                isSplitView={isSplitView}
+                            />
+                        )}
+                        {showNorthArrow && !isSplitView && (
+                            <NorthArrow
+                                map={map.getMapGL()}
+                                downloadMapInfoOpen={downloadMapInfoOpen}
+                            />
+                        )}
+                    </>
+                )}
             </div>
         </div>
     )

--- a/src/components/map/styles/MapPosition.module.css
+++ b/src/components/map/styles/MapPosition.module.css
@@ -28,7 +28,12 @@
     flex: auto;
 }
 
+.mapDefault {
+    height: calc(100vh - var(--header-height) - var(--toolbar-height));
+}
+
 .mapDownload {
+    height: calc(100vh - var(--downloadheader-height));
     border: var(--spacers-dp24) solid #fff;
     background-color: var(--colors-white);
 }

--- a/src/constants/layout.js
+++ b/src/constants/layout.js
@@ -1,3 +1,2 @@
-export const APP_MENU_HEIGHT = 32
 export const LAYERS_PANEL_WIDTH = 300
 export const RIGHT_PANEL_WIDTH = 380

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -144,10 +144,10 @@ export const sumObjectValues = (obj) =>
         return sum
     }, 0)
 
-// Get the header height for height calculations
-export const getHeaderHeight = () =>
+// Get value given a css var name
+export const getCssVar = (cssVar) =>
     Number(
         getComputedStyle(document.documentElement)
-            .getPropertyValue('--header-height')
+            .getPropertyValue(cssVar)
             .replace('px', '')
     )

--- a/src/util/setHeaderbarVisible.js
+++ b/src/util/setHeaderbarVisible.js
@@ -1,0 +1,19 @@
+export const setHeaderbarVisible = (show) => {
+    // Header provided by the global shell
+    const globalShellHeader = window.top.document.querySelector(
+        '.global-shell-header'
+    )
+    // Header in the current iframe
+    const iframeHeader = document.querySelector('header')
+    const header = globalShellHeader ? globalShellHeader : iframeHeader
+
+    const setHeaderStyle = (ref, value) => {
+        ref.style.display = value
+    }
+
+    if (show) {
+        setHeaderStyle(header, 'block')
+    } else {
+        setHeaderStyle(header, 'none')
+    }
+}


### PR DESCRIPTION
Implements [DHIS2-19279](https://dhis2.atlassian.net/browse/DHIS2-19279)

---

### Description

- Detect if header is in global shell or same iframe and hide accordingly when in download mode.
- Streamline the use of css variables / constants to represent: 
  - toolbar height (`--toolbar-height`)
  - download mode header height (`--downloadheader-height`)

### TODO

- [x] Dashboard tested
- [x] Tests added (Cypress and/or Jest)
- [x] Tested with and without the global shell enabled
- [ ] Docs added N/A
- [ ] Strings generated N/A
- [ ] d2-ci dependency replaced N/A

---

### Screenshots

Entering download mode:
![image](https://github.com/user-attachments/assets/6601744f-26d6-4952-bfb5-8cddd498a67b)

Leaving download mode:
![image](https://github.com/user-attachments/assets/3d34edcb-ec1e-4406-b150-78ea21d09a0b)



[DHIS2-19279]: https://dhis2.atlassian.net/browse/DHIS2-19279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ