### PR TITLE
fix: ensure some d2 init requests are cached

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -11,7 +11,9 @@ const config = {
     pwa: {
         enabled: true,
         caching: {
-            patternsToOmitFromAppShell: [/.*/],
+            patternsToOmitFromAppShell: [
+                /^(?!.*me\/authorization)(?!.*me\?fields).*$/,
+            ],
             globsToOmitFromPrecache: ['fonts/**', 'images/**'],
         },
     },


### PR DESCRIPTION
Implements _jira issue link_

---

### Description

Two requests made by d2 didn't end up in the app cache, which prevented the Maps app to work offline.
This is a temporary fix until d2 is completely removed from the app.


### TODO

- [ ] Dashboard tested
- [ ] Tests added (Cypress and/or Jest)
- [ ] Docs added
- [ ] Strings generated
- [ ] d2-ci dependency replaced
- [ ] _todo_

---

### Screenshots

_supporting images_
