### PR TITLE
fix: upgrade libs containing fixes for hyperlinks in global shell

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ _description text_
 - [ ] Dashboard tested
 - [ ] Tests added (Cypress and/or Jest)
 - [ ] Docs added
-- [ ] Strings generated
+- [ ] tested with and without global shell
 - [ ] d2-ci dependency replaced
 - [ ] _todo_
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "postinstall": "patch-package"
     },
     "devDependencies": {
-        "@dhis2/cli-app-scripts": "^11.8.1",
+        "@dhis2/cli-app-scripts": "^11.8.2",
         "@dhis2/cli-style": "^10.7.5",
         "@dhis2/cypress-commands": "^10.0.6",
         "@dhis2/cypress-plugins": "^10.0.6",
@@ -42,7 +42,7 @@
         "start-server-and-test": "^2.0.10"
     },
     "dependencies": {
-        "@dhis2/analytics": "^26.12.0",
+        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#599205999e91350516b6ee3510e1ea26d3133caf",
         "@dhis2/app-runtime": "^3.13.2",
         "@dhis2/app-runtime-adapter-d2": "^1.1.0",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,10 +2031,9 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^26.12.0":
-  version "26.12.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-26.12.0.tgz#5c153048fcd76fee13bfb297af3d344f4069dc2f"
-  integrity sha512-Ou1lH1iDxnpzOliGu9OkbRKOmxcqsojTa0zq8HlccJbMjtHmpdnp8deWJ7KgQFz+A7dpuHgsPbvcaMROBIxyrg==
+"@dhis2/analytics@git+https://github.com/d2-ci/analytics.git#599205999e91350516b6ee3510e1ea26d3133caf":
+  version "26.13.2"
+  resolved "git+https://github.com/d2-ci/analytics.git#599205999e91350516b6ee3510e1ea26d3133caf"
   dependencies:
     "@dhis2/multi-calendar-dates" "^1.2.2"
     "@dnd-kit/core" "^6.0.7"
@@ -2052,12 +2051,12 @@
     react-beautiful-dnd "^10.1.1"
     resize-observer-polyfill "^1.5.1"
 
-"@dhis2/app-adapter@11.8.1":
-  version "11.8.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-11.8.1.tgz#625055ef9a6749da400d51251b7f0883da5fcf4e"
-  integrity sha512-x1gnWMGy3JTU7zx4TWQ5IZ7jbV0cxIxQHqImg35bwe+r/twAq0Q92J9WaVaCce6POaHjgJkiLpgPtZyqsQZyQg==
+"@dhis2/app-adapter@11.8.2":
+  version "11.8.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-adapter/-/app-adapter-11.8.2.tgz#18538c647358d8450999a2769a39a34e357101c6"
+  integrity sha512-rfZjSXhjLVsfbb2DwHiAqx85/l71ngZIn9CN4jph30mGksCCcNwA9jJx0cW9ZVEK3FfFk18wPo2PKAW2DU6MTg==
   dependencies:
-    "@dhis2/pwa" "11.8.1"
+    "@dhis2/pwa" "11.8.2"
     moment "^2.24.0"
 
 "@dhis2/app-runtime-adapter-d2@^1.1.0":
@@ -2122,15 +2121,15 @@
   dependencies:
     post-robot "^10.0.46"
 
-"@dhis2/app-shell@11.8.1":
-  version "11.8.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-11.8.1.tgz#b3b020aa7b9d8e9fb916f74a7340a6e7d82302b5"
-  integrity sha512-PS6XFK/o0lNUKzYDHv5T383MbVH/X8hQG3bYAYd8cmlyuEr8nm1V4Glb4YdHDMbUe+7ErzYk0LqF9/qcP8lXfg==
+"@dhis2/app-shell@11.8.2":
+  version "11.8.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-shell/-/app-shell-11.8.2.tgz#fa05d8964980e45a276a271b54ba2f4e16ef5131"
+  integrity sha512-iGz4p4PY44k8E+HOUpc2kCr9+fk4HNq7dUrD0YsfOpnJfxf1/2aArNSBqz89dDOBzjYaBxrUg8byyrhxbYuI2w==
   dependencies:
-    "@dhis2/app-adapter" "11.8.1"
+    "@dhis2/app-adapter" "11.8.2"
     "@dhis2/app-runtime" "^3.10.6"
     "@dhis2/d2-i18n" "^1.1.1"
-    "@dhis2/pwa" "11.8.1"
+    "@dhis2/pwa" "11.8.2"
     "@dhis2/ui" "^9.8.9"
     classnames "^2.2.6"
     moment "^2.29.1"
@@ -2144,10 +2143,10 @@
     typeface-roboto "^0.0.75"
     typescript "^5.6.3"
 
-"@dhis2/cli-app-scripts@^11.8.1":
-  version "11.8.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-11.8.1.tgz#136b98401b7d941d5d4dc02b381f4bf21e7ef7be"
-  integrity sha512-8RpxfQfkZuvu/0f7xeDg9CPs2LF0l3VrtR7fLxyy1CX8X699RTp+QyQwgbNyP08jKZh6ZC71hpQFeioXYBIl7Q==
+"@dhis2/cli-app-scripts@^11.8.2":
+  version "11.8.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-app-scripts/-/cli-app-scripts-11.8.2.tgz#669f73bdcdb272f0c619f495bced1740dc009093"
+  integrity sha512-rn+vqY9CZqK9bDjO4sEdSbUoI63hsvY8LSehzcvqAgqlM2lXViuYfU2H99b5bCo2WSZiBl5yNYS+pcYwH4/JjA==
   dependencies:
     "@babel/core" "^7.6.2"
     "@babel/plugin-proposal-class-properties" "^7.8.3"
@@ -2157,7 +2156,7 @@
     "@babel/preset-env" "^7.14.7"
     "@babel/preset-react" "^7.0.0"
     "@babel/preset-typescript" "^7.6.0"
-    "@dhis2/app-shell" "11.8.1"
+    "@dhis2/app-shell" "11.8.2"
     "@dhis2/cli-helpers-engine" "^3.2.0"
     "@jest/core" "^27.0.6"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.5.4"
@@ -2301,10 +2300,10 @@
   resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-3.1.2.tgz#65b8ad2da8cd2f72bc8b951049a6c9d1b97af3e9"
   integrity sha512-eM0jjLOWvtXWqSFp5YC4DHFpkP8Y1D2eUwGV7MBWjni+o27oesVan+oT7WHeOeLdlAd4acRJrnaaAyB4Ck1wGQ==
 
-"@dhis2/pwa@11.8.1":
-  version "11.8.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-11.8.1.tgz#d7feef92ac2308a246015628bc67af6c0f8d7b62"
-  integrity sha512-33mtGqCUrSzxT+54ys7JMhk9CQemvxq52S8PYxFqBt2J+j/3xzNeMbIf/MGlQ0IcLrRjkMdzWXBJIhK0EQFM1w==
+"@dhis2/pwa@11.8.2":
+  version "11.8.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/pwa/-/pwa-11.8.2.tgz#9fe027cff6588d73916289843547ecbc42bc8f1a"
+  integrity sha512-3BGCLp42Bt3f/flTt0OU44HL9vMsR9W1mj9MloQRnw0Fos6qibW0hUlyj6dzZhIStCDo90Vebb54cC22Eb6M/A==
   dependencies:
     idb "^6.0.0"
     workbox-core "^6.1.5"


### PR DESCRIPTION
Implements [DHIS2-19274](https://dhis2.atlassian.net/browse/DHIS2-19274)

Requires: https://github.com/dhis2/analytics/pull/1770

---

### Description

Hyperlinks in the Map description as well as interpretations were not opening if the global shell (42.0 feature) was enabled. This also includes the "Get link" file menu option.

### TODO

- [ ] Dashboard tested
- [ ] Tests added (Cypress and/or Jest) N/A
- [ ] Docs added N/A
- [ ] Tested with and without the global shell
- [ ] d2-ci dependency replaced

App and plugin can be tested on https://test.e2e.dhis2.org/analytics-42dev (build: 
999.99.0-hyperlinks-fixes.14-37)

[DHIS2-19274]: https://dhis2.atlassian.net/browse/DHIS2-19274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ