### PR TITLE
fix: replace empty values with 'Not set' in EventPopup [DHIS2-18851] [v39]

### DIFF
--- a/src/components/map/layers/EventPopup.js
+++ b/src/components/map/layers/EventPopup.js
@@ -44,10 +44,10 @@ const getDataRows = (displayElements, dataValues, styleDataItem, value) => {
 
         if (valueType === 'COORDINATE' && value) {
             formattedValue = formatCoordinate(value);
-        } else if (options) {
-            formattedValue = options[value];
         } else if (!hasValue(value)) {
             formattedValue = i18n.t('Not set');
+        } else if (options) {
+            formattedValue = options[value];
         }
 
         dataRows.push(

--- a/src/components/map/layers/EventPopup.js
+++ b/src/components/map/layers/EventPopup.js
@@ -7,7 +7,7 @@ import { formatTime, formatCoordinate } from '../../../util/helpers';
 import { EVENT_ID_FIELD } from '../../../util/geojson';
 
 // Returns true if value is not undefined or null;
-const hasValue = value => value !== undefined || value !== null;
+const hasValue = value => value !== undefined && value !== null;
 
 // Loads event data for the selected feature
 const loadEventData = async feature => {


### PR DESCRIPTION
Implements [DHIS2-18851](https://dhis2.atlassian.net/browse/DHIS2-18851)

---

### Description

Properly handle display "Not set" for missing values in event popup.

Backport bug fixes introduced with https://github.com/dhis2/maps-app/pull/3346 and https://github.com/dhis2/maps-app/pull/3407

### TODO

- [ ] Dashboard tested N/A
- [ ] Tests added (Cypress and/or Jest) N/A
- [ ] Docs added N/A
- [ ] d2-ci dependency replaced N/A
- [x] Tester approved (Jennifer)

---

### Screenshots

![image](https://github.com/user-attachments/assets/8385b725-e6d4-4ff4-8fbd-f6211845c142)


[DHIS2-18851]: https://dhis2.atlassian.net/browse/DHIS2-18851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15796]: https://dhis2.atlassian.net/browse/DHIS2-15796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ