### PR TITLE
fix: use all layers in map to fit bounds on initial render [DHIS2-19522]

### DIFF
--- a/src/components/map/layers/Layer.js
+++ b/src/components/map/layers/Layer.js
@@ -139,14 +139,14 @@ class Layer extends PureComponent {
     fitBounds(options = {}) {
         const { map } = this.context
         const {
-            all = false,
+            fitToAllLayers = false,
             padding = {},
             duration = DURATION_DEFAULT,
         } = options
 
         if (this.layer.getBounds) {
             map.fitBounds(
-                all ? map.getLayersBounds() : this.layer.getBounds(),
+                fitToAllLayers ? map.getLayersBounds() : this.layer.getBounds(),
                 {
                     padding: { ...PADDING_DEFAULT, ...padding },
                     duration: duration,
@@ -160,7 +160,7 @@ class Layer extends PureComponent {
     // Fit map to layer bounds once (when first created)
     fitBoundsOnce(options) {
         if (!this.isZoomed || this.context.map.getZoom() === undefined) {
-            this.fitBounds({ ...options, all: !this.props.editCounter })
+            this.fitBounds({ ...options, fitToAllLayers: !this.props.editCounter })
             this.isZoomed = true
         }
     }

--- a/src/components/map/layers/Layer.js
+++ b/src/components/map/layers/Layer.js
@@ -160,7 +160,10 @@ class Layer extends PureComponent {
     // Fit map to layer bounds once (when first created)
     fitBoundsOnce(options) {
         if (!this.isZoomed || this.context.map.getZoom() === undefined) {
-            this.fitBounds({ ...options, fitToAllLayers: !this.props.editCounter })
+            this.fitBounds({
+                ...options,
+                fitToAllLayers: !this.props.editCounter,
+            })
             this.isZoomed = true
         }
     }

--- a/src/components/map/layers/Layer.js
+++ b/src/components/map/layers/Layer.js
@@ -138,22 +138,29 @@ class Layer extends PureComponent {
     // Fit map to layer bounds
     fitBounds(options = {}) {
         const { map } = this.context
-        const { padding = {}, duration = DURATION_DEFAULT } = options
+        const {
+            all = false,
+            padding = {},
+            duration = DURATION_DEFAULT,
+        } = options
 
         if (this.layer.getBounds) {
-            map.fitBounds(this.layer.getBounds(), {
-                padding: { ...PADDING_DEFAULT, ...padding },
-                duration: duration,
-                essential: true,
-                bearing: map.getMapGL().getBearing(),
-            })
+            map.fitBounds(
+                all ? map.getLayersBounds() : this.layer.getBounds(),
+                {
+                    padding: { ...PADDING_DEFAULT, ...padding },
+                    duration: duration,
+                    essential: true,
+                    bearing: map.getMapGL().getBearing(),
+                }
+            )
         }
     }
 
     // Fit map to layer bounds once (when first created)
     fitBoundsOnce(options) {
         if (!this.isZoomed || this.context.map.getZoom() === undefined) {
-            this.fitBounds(options)
+            this.fitBounds({ ...options, all: !this.props.editCounter })
             this.isZoomed = true
         }
     }


### PR DESCRIPTION
Implements [DHIS2-19522](https://dhis2.atlassian.net/browse/DHIS2-19522)

### Description

Before layers get edited use all layers in map to fit bounds.
Preserve the behavior to zoom on the layer that has just been edited/added. 

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [x] Dashboard tested
- [ ] Cypress and/or Jest tests added/updated N/A
- [ ] Docs added N/A
- [ ] d2-ci dependencies replaced (analytics or maps-gl link https://github.com/dhis2/[lib]/pull/XXX) N/A
- [x] Tester approved (@jenniferarnesen - see testing instructions below)

---

### Screenshots

![image](https://github.com/user-attachments/assets/c865c317-b2fb-4e87-a3e3-e8fbdaf0cdc1)


[DHIS2-19522]: https://dhis2.atlassian.net/browse/DHIS2-19522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

### Testing instructions

1. Save a map with a couple or more layers showing data for different districts.
2. Open the map.

All layers should be entirely visible.

Saved map: https://dev.im.dhis2.org/maps-app-test/apps/maps#/D1mQ7gCmD5l
Build: [maps-DHIS2-19522.zip](https://github.com/user-attachments/files/19911155/maps-DHIS2-19522.zip)