### PR TITLE
fix: prevent TE layer from becoming exclusive of last day on save [DHIS2-19224]

### DIFF
--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -39,7 +39,7 @@ import {
     addAssociatedGeometries,
 } from '../util/orgUnits.js'
 import { LEGEND_SET_QUERY } from '../util/requests.js'
-import { formatStartEndDate, getDateArray } from '../util/time.js'
+import { trimTime, formatStartEndDate, getDateArray } from '../util/time.js'
 
 const thematicLoader = async ({ config, engine, nameProperty, userId }) => {
     const {
@@ -387,8 +387,8 @@ const loadData = async (config, nameProperty, userId) => {
                       presetPeriods.map((pe) => pe.id)
                   )
                 : analyticsRequest
-                      .withStartDate(startDate.slice(0, 10))
-                      .withEndDate(endDate.slice(0, 10))
+                      .withStartDate(trimTime(startDate))
+                      .withEndDate(trimTime(endDate))
     }
 
     if (dimensions) {

--- a/src/loaders/trackedEntityLoader.js
+++ b/src/loaders/trackedEntityLoader.js
@@ -18,7 +18,7 @@ import {
     GEO_TYPE_FEATURE,
 } from '../util/geojson.js'
 import { getDataWithRelationships } from '../util/teiRelationshipsParser.js'
-import { formatStartEndDate, getDateArray } from '../util/time.js'
+import { trimTime, formatStartEndDate, getDateArray } from '../util/time.js'
 
 const fields = ['trackedEntity~rename(id)', 'geometry']
 
@@ -136,15 +136,13 @@ const trackedEntityLoader = async (config, serverVersion) => {
     }
 
     if (periodType === 'program') {
-        url += `&enrollmentEnrolledAfter=${startDate.slice(
-            0,
-            10
-        )}&enrollmentEnrolledBefore=${endDate.slice(0, 10)}`
+        url += `&enrollmentEnrolledAfter=${trimTime(
+            startDate
+        )}&enrollmentEnrolledBefore=${trimTime(endDate)}`
     } else {
-        url += `&updatedAfter=${startDate.slice(
-            0,
-            10
-        )}&updatedBefore=${endDate.slice(0, 10)}`
+        url += `&updatedAfter=${trimTime(startDate)}&updatedBefore=${trimTime(
+            endDate
+        )}`
     }
 
     const primaryData = await apiFetch(url)

--- a/src/loaders/trackedEntityLoader.js
+++ b/src/loaders/trackedEntityLoader.js
@@ -136,9 +136,15 @@ const trackedEntityLoader = async (config, serverVersion) => {
     }
 
     if (periodType === 'program') {
-        url += `&enrollmentEnrolledAfter=${startDate}&enrollmentEnrolledBefore=${endDate}`
+        url += `&enrollmentEnrolledAfter=${startDate.slice(
+            0,
+            10
+        )}&enrollmentEnrolledBefore=${endDate.slice(0, 10)}`
     } else {
-        url += `&updatedAfter=${startDate}&updatedBefore=${endDate}`
+        url += `&updatedAfter=${startDate.slice(
+            0,
+            10
+        )}&updatedBefore=${endDate.slice(0, 10)}`
     }
 
     const primaryData = await apiFetch(url)

--- a/src/util/__tests__/time.spec.js
+++ b/src/util/__tests__/time.spec.js
@@ -5,6 +5,7 @@ import {
     getStartEndDateError,
     getYear,
     getDateArray,
+    trimTime,
 } from '../time.js'
 
 const validDateString = '2018-12-17T12:00:00'
@@ -77,5 +78,11 @@ describe('time utils', () => {
 
     it('getDateArray returns array from date string', () => {
         expect(getDateArray('2018-12-17')).toEqual([2018, 11, 17])
+    })
+
+    it('trimTime should return the date part from an ISO date-time string', () => {
+        expect(trimTime('2025-04-30T15:30:45')).toBe('2025-04-30')
+        expect(trimTime('2025-04-30T15:30:45.123Z')).toBe('2025-04-30')
+        expect(trimTime('2020-01-01')).toBe('2020-01-01')
     })
 })

--- a/src/util/event.js
+++ b/src/util/event.js
@@ -5,6 +5,7 @@ import {
 } from '../constants/layers.js'
 import { getOrgUnitsFromRows, getPeriodFromFilters } from './analytics.js'
 import { addStyleDataItem, createEventFeatures } from './geojson.js'
+import { trimTime } from './time.js'
 
 export const EVENT_PROGRAM_STAGE_DATA_ELEMENTS_QUERY = {
     programStage: {
@@ -103,8 +104,8 @@ export const getAnalyticsRequest = async (
     analyticsRequest = period
         ? analyticsRequest.addPeriodFilter(period.id)
         : analyticsRequest
-              .withStartDate(startDate.slice(0, 10))
-              .withEndDate(endDate.slice(0, 10))
+              .withStartDate(trimTime(startDate))
+              .withEndDate(trimTime(endDate))
 
     if (relativePeriodDate) {
         analyticsRequest =

--- a/src/util/event.js
+++ b/src/util/event.js
@@ -102,7 +102,9 @@ export const getAnalyticsRequest = async (
 
     analyticsRequest = period
         ? analyticsRequest.addPeriodFilter(period.id)
-        : analyticsRequest.withStartDate(startDate).withEndDate(endDate)
+        : analyticsRequest
+              .withStartDate(startDate.slice(0, 10))
+              .withEndDate(endDate.slice(0, 10))
 
     if (relativePeriodDate) {
         analyticsRequest =

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -7,6 +7,14 @@ const dateLocale = (locale) =>
     locale && locale.includes('_') ? locale.replace('_', '-') : locale
 
 /**
+ * Trims the time part from an ISO date-time string, returning only the date (YYYY-MM-DD).
+ * Assumes input is always a valid ISO date or date-time string (e.g., 'YYYY-MM-DD' or 'YYYY-MM-DDThh:mm:ss').
+ * @param {String} dateTime
+ * @returns {String}
+ */
+export const trimTime = (dateTime) => dateTime.slice(0, 10)
+
+/**
  * Converts a date string or timestamp to a date object
  * @param {String|Number|Array|Date} date
  * @returns {String}


### PR DESCRIPTION
Implements [DHIS2-19224](https://dhis2.atlassian.net/browse/DHIS2-19224)

### Description

Trim dates to yyyy-mm-dd in Evt and TE loaders requests with utility function.
Use new utility fonction in Thematic loader as well.
Layers dates are configured as simple dates (YYYY-MM-DD) but stored as date-time (YYYY-MM-DDT00:00:00) in the database which was causing a discrepancy between end dates in analytics requests when configured vs when opening a saved map.

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [x] Dashboard tested
- [ ] Cypress and/or Jest tests added/updated N/A
- [ ] Docs added N/A
- [ ] d2-ci dependencies replaced (analytics or maps-gl link https://github.com/dhis2/[lib]/pull/XXX) N/A
- [x] Tester approved (@jenniferarnesen - see testing instructions below)

---

### Screenshots

![image](https://github.com/user-attachments/assets/5eb2a834-7459-42f8-8c8c-f95e4f43dca3)


[DHIS2-19224]: https://dhis2.atlassian.net/browse/DHIS2-19224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

### Testing instructions

1. Add new tracked entity layer:
![image](https://github.com/user-attachments/assets/18f2d112-afa1-4ace-83db-0cd9d4244d69)
![image](https://github.com/user-attachments/assets/96cce6de-dcfb-4fd9-bae6-b286edcb94f5)
![image](https://github.com/user-attachments/assets/395d9855-a928-4675-9ff3-412792671421)

2. Save the map.
3. Open the map.

The events should remain visible after opening the saved map.

Saved map: https://dev.im.dhis2.org/maps-app-test/apps/maps#/a6lCbh2RXGx
Build: [maps-DHIS2-19224.zip](https://github.com/user-attachments/files/19910989/maps-DHIS2-19224.zip)
