### PR TITLE
chore: get full version from dhis2 instance in cypress [DHIS2-19491]

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -69,7 +69,7 @@ before(() => {
         url: `${Cypress.env('dhis2BaseUrl')}/api/system/info?fields=version`,
     }).then(({ body: { version } }) => {
         const match = version.match(
-            /^(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?(?:-([\w.]+))?$/
+            /^(\d+)\.(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([\w.]+))?$/
         )
 
         if (!match) {

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -63,6 +63,26 @@ before(() => {
                 JSON.stringify(sessionCookieForBaseUrl)
             )
         })
+
+    cy.request({
+        method: 'GET',
+        url: `${Cypress.env('dhis2BaseUrl')}/api/system/info?fields=version`,
+    }).then(({ body: { version } }) => {
+        const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-(\w+))?$/)
+
+        if (!match) {
+            throw new Error(`Unexpected version format: ${version}`)
+        }
+
+        const [full, major, minor, patch, tag] = match
+        Cypress.env('dhis2InstanceFullVersion', {
+            full,
+            major,
+            minor,
+            patch,
+            tag,
+        })
+    })
 })
 
 beforeEach(() => {

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -68,18 +68,21 @@ before(() => {
         method: 'GET',
         url: `${Cypress.env('dhis2BaseUrl')}/api/system/info?fields=version`,
     }).then(({ body: { version } }) => {
-        const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-(\w+))?$/)
+        const match = version.match(
+            /^(\d+)\.(\d+)\.(\d+)(?:\.(\d+))?(?:-([\w.]+))?$/
+        )
 
         if (!match) {
             throw new Error(`Unexpected version format: ${version}`)
         }
 
-        const [full, major, minor, patch, tag] = match
+        const [full, major, minor, patch, hotfix, tag] = match
         Cypress.env('dhis2InstanceFullVersion', {
             full,
             major,
             minor,
             patch,
+            hotfix,
             tag,
         })
     })

--- a/cypress/support/util.js
+++ b/cypress/support/util.js
@@ -14,3 +14,15 @@ export const getApiBaseUrl = () => {
 
     return baseUrl
 }
+
+export const getDhis2Version = () => {
+    const dhis2Version = Cypress.env('dhis2InstanceFullVersion') || ''
+
+    if (!dhis2Version) {
+        throw new Error(
+            "No 'dhis2InstanceFullVersion' found. Please make sure it was parsed properly from api/system/info'"
+        )
+    }
+
+    return dhis2Version
+}


### PR DESCRIPTION
Implements [DHIS2-19491](https://dhis2.atlassian.net/browse/DHIS2-19491)

### Description

Retrieve full version of dhis2 instance from `api/system/info?fields=version` and store in Cypress env variable `dhis2InstanceFullVersion`.
Give easy access via utility function `getDhis2Version`.

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested N/A
- [ ] Cypress and/or Jest tests added/updated N/A
- [ ] Docs added N/A
- [ ] d2-ci dependencies replaced (analytics or maps-gl link https://github.com/dhis2/[lib]/pull/XXX) N/A
- [ ] Tester approved (Hendrik)

[DHIS2-19491]: https://dhis2.atlassian.net/browse/DHIS2-19491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ