### PR TITLE
chore: use anly-e2e-4x format for cypress test instances

### DIFF
--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -82,7 +82,7 @@ jobs:
     call-workflow-e2e-prod:
         if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
         needs: [build, lint, test, setup-matrix]
-        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests-prod.yml@feat/support-hardcoded-dev-version
+        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests-prod.yml@feat/hardcoded-dev-version-minor
         with:
             should_record: ${{ contains(github.event.head_commit.message, '[e2e record]') || contains(join(github.event.pull_request.labels.*.name), 'e2e record')}}
             spec-group: ${{ needs.setup-matrix.outputs.matrix }}


### PR DESCRIPTION
Implements [DHIS2-19609](hhttps://dhis2.atlassian.net/browse/DHIS2-19609)

### Quality checklist

- [ ] Dashboard tested N/A
- [ ] Cypress and/or Jest tests added/updated N/A
- [ ] Docs added N/A
- [ ] d2-ci dependencies replaced N/A
- [ ] Tester approved (name) N/A


[DHIS2-19609]: https://dhis2.atlassian.net/browse/DHIS2-19609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ