### PR TITLE
chore: replace analytics CachedDataQueryProvider by maps CachedDataProvider

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,17 +5,11 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-06-16T11:57:46.814Z\n"
-"PO-Revision-Date: 2025-06-16T11:57:46.814Z\n"
+"POT-Creation-Date: 2025-06-17T09:10:19.191Z\n"
+"PO-Revision-Date: 2025-06-17T09:10:19.191Z\n"
 
 msgid "2020"
 msgstr "2020"
-
-msgid "This app could not retrieve required data."
-msgstr "This app could not retrieve required data."
-
-msgid "Network error"
-msgstr "Network error"
 
 msgid "Untitled map, {{date}}"
 msgstr "Untitled map, {{date}}"
@@ -31,6 +25,12 @@ msgstr "Rename failed"
 
 msgid "Rename successful"
 msgstr "Rename successful"
+
+msgid "This app could not retrieve required data."
+msgstr "This app could not retrieve required data."
+
+msgid "Network error"
+msgstr "Network error"
 
 msgid "Calculation"
 msgstr "Calculation"

--- a/src/AppWrapper.js
+++ b/src/AppWrapper.js
@@ -5,7 +5,7 @@ import queryString from 'query-string'
 import React from 'react'
 import { Provider as ReduxProvider } from 'react-redux'
 import App from './components/app/App.js'
-import { AppDataProvider } from './components/app/AppDataProvider.js'
+import { CachedDataProvider } from './components/cachedDataProvider/CachedDataProvider.js'
 import OrgUnitsProvider from './components/OrgUnitsProvider.js'
 import WindowDimensionsProvider from './components/WindowDimensionsProvider.js'
 import store from './store/index.js'
@@ -59,7 +59,7 @@ const AppWrapper = () => {
     return (
         <ReduxProvider store={store}>
             <DataStoreProvider namespace={USER_DATASTORE_NAMESPACE}>
-                <AppDataProvider
+                <CachedDataProvider
                     query={appQueries}
                     dataTransformation={providerDataTransformation}
                 >
@@ -69,7 +69,7 @@ const AppWrapper = () => {
                             <App />
                         </OrgUnitsProvider>
                     </WindowDimensionsProvider>
-                </AppDataProvider>
+                </CachedDataProvider>
             </DataStoreProvider>
         </ReduxProvider>
     )

--- a/src/components/app/FileMenu.js
+++ b/src/components/app/FileMenu.js
@@ -26,7 +26,7 @@ import {
     fetchMapNameDesc,
     fetchMapSubscribers,
 } from '../../util/requests.js'
-import { useAppData } from './AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 
 const updateMapMutation = {
     resource: 'maps',
@@ -67,7 +67,7 @@ const FileMenu = ({ onFileMenuAction }) => {
     const map = useSelector((state) => state.map)
     const dispatch = useDispatch()
     const engine = useDataEngine()
-    const { systemSettings, currentUser } = useAppData()
+    const { systemSettings, currentUser } = useCachedData()
     const defaultBasemap = systemSettings.keyDefaultBaseMap
     //alerts
     const saveAlert = useAlert(ALERT_MESSAGE_DYNAMIC, ALERT_OPTIONS_DYNAMIC)

--- a/src/components/app/useLoadMap.js
+++ b/src/components/app/useLoadMap.js
@@ -15,14 +15,14 @@ import history, {
     defaultHashUrlParams,
 } from '../../util/history.js'
 import { fetchMap } from '../../util/requests.js'
-import { useAppData } from './AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 
 // Used to avoid repeating `history` listener calls -- see below
 let lastLocation
 
 export const useLoadMap = () => {
     const previousParamsRef = useRef(defaultHashUrlParams)
-    const { systemSettings, basemaps } = useAppData()
+    const { systemSettings, basemaps } = useCachedData()
     const defaultBasemap = systemSettings.keyDefaultBaseMap
     const engine = useDataEngine()
     const dispatch = useDispatch()

--- a/src/components/cachedDataProvider/CachedDataProvider.js
+++ b/src/components/cachedDataProvider/CachedDataProvider.js
@@ -4,9 +4,9 @@ import { Layer, CenteredContent, CircularLoader, NoticeBox } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { createContext, useContext, useEffect, useState } from 'react'
 
-const AppDataCtx = createContext({})
+const CachedDataCtx = createContext({})
 
-const AppDataProvider = ({
+const CachedDataProvider = ({
     query,
     dataTransformation,
     children,
@@ -69,19 +69,19 @@ const AppDataProvider = ({
     }
 
     return (
-        <AppDataCtx.Provider value={transformedData}>
+        <CachedDataCtx.Provider value={transformedData}>
             {children}
-        </AppDataCtx.Provider>
+        </CachedDataCtx.Provider>
     )
 }
 
-AppDataProvider.propTypes = {
+CachedDataProvider.propTypes = {
     children: PropTypes.node.isRequired,
     query: PropTypes.object.isRequired,
     dataTransformation: PropTypes.func,
     translucent: PropTypes.bool,
 }
 
-const useAppData = () => useContext(AppDataCtx)
+const useCachedData = () => useContext(CachedDataCtx)
 
-export { AppDataProvider, useAppData }
+export { CachedDataProvider, useCachedData }

--- a/src/components/calculations/CalculationSelect.js
+++ b/src/components/calculations/CalculationSelect.js
@@ -2,7 +2,7 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { SelectField, Help } from '../core/index.js'
 import styles from './styles/CalculationSelect.module.css'
 
@@ -19,7 +19,7 @@ const CALCULATIONS_QUERY = {
 }
 
 const CalculationSelect = ({ calculation, className, errorText, onChange }) => {
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
     const { loading, error, data } = useDataQuery(CALCULATIONS_QUERY, {
         variables: { nameProperty },
     })

--- a/src/components/dataElement/DataElementGroupSelect.js
+++ b/src/components/dataElement/DataElementGroupSelect.js
@@ -2,7 +2,7 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { SelectField } from '../core/index.js'
 
 // Load all data element groups
@@ -22,7 +22,7 @@ const DataElementGroupSelect = ({
     className,
     errorText,
 }) => {
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
     const { loading, error, data } = useDataQuery(DATA_ELEMENT_GROUPS_QUERY, {
         variables: { nameProperty },
     })

--- a/src/components/dataElement/DataElementOperandSelect.js
+++ b/src/components/dataElement/DataElementOperandSelect.js
@@ -2,7 +2,7 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { SelectField } from '../core/index.js'
 
 // Load all data elements within a group
@@ -24,7 +24,7 @@ const DataElementOperandSelect = ({
     className,
     errorText,
 }) => {
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
     const { loading, error, data, refetch } = useDataQuery(
         DATA_ELEMENT_OPERAND_QUERY,
         {

--- a/src/components/dataElement/DataElementSelect.js
+++ b/src/components/dataElement/DataElementSelect.js
@@ -2,7 +2,7 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { SelectField } from '../core/index.js'
 
 // Load all data elements within a group
@@ -28,7 +28,7 @@ const DataElementSelect = ({
     className,
     errorText,
 }) => {
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
     const { loading, error, data, refetch } = useDataQuery(
         DATA_ELEMENTS_QUERY,
         {

--- a/src/components/dataItem/EventDataItemSelect.js
+++ b/src/components/dataItem/EventDataItemSelect.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import { useProgramTrackedEntityAttributes } from '../../hooks/useProgramTrackedEntityAttributes.js'
 import { combineDataItems } from '../../util/analytics.js'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { SelectField } from '../core/index.js'
 
 const excludeValueTypes = [
@@ -39,7 +39,7 @@ const EventDataItemSelect = ({
     className,
     errorText,
 }) => {
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
     const { programAttributes } = useProgramTrackedEntityAttributes({
         programId: program?.id,
     })

--- a/src/components/dataSets/DataSetsSelect.js
+++ b/src/components/dataSets/DataSetsSelect.js
@@ -2,7 +2,7 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { SelectField } from '../core/index.js'
 
 // Load all data sets (reporting rates)
@@ -21,7 +21,7 @@ const DATA_SETS_QUERY = {
 }
 
 const DataSetsSelect = ({ dataSet, onChange, className, errorText }) => {
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
     const { loading, error, data } = useDataQuery(DATA_SETS_QUERY, {
         variables: { nameProperty },
     })

--- a/src/components/dimensions/DimensionItemsSelect.js
+++ b/src/components/dimensions/DimensionItemsSelect.js
@@ -2,7 +2,7 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { SelectField } from '../core/index.js'
 import styles from './styles/DimensionItemsSelect.module.css'
 
@@ -20,7 +20,7 @@ const DIMENSION_ITEMS_QUERY = {
 }
 
 const DimensionItemsSelect = ({ dimension, value, onChange }) => {
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
     const { loading, error, data, refetch } = useDataQuery(
         DIMENSION_ITEMS_QUERY,
         {

--- a/src/components/dimensions/DimensionSelect.js
+++ b/src/components/dimensions/DimensionSelect.js
@@ -4,7 +4,7 @@ import i18n from '@dhis2/d2-i18n'
 import { Popover, IconChevronDown24, Help } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useRef, useState } from 'react'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import styles from './styles/DimensionSelect.module.css'
 
 // Include the following dimension types
@@ -29,7 +29,7 @@ const DIMENSIONS_QUERY = {
 
 const DimensionSelect = ({ dimension, onChange }) => {
     const [isOpen, setIsOpen] = useState(false)
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
     const { error, data } = useDataQuery(DIMENSIONS_QUERY, {
         variables: { nameProperty },
     })

--- a/src/components/edit/LayerEdit.js
+++ b/src/components/edit/LayerEdit.js
@@ -13,7 +13,7 @@ import { connect } from 'react-redux'
 import { addLayer, updateLayer, cancelLayer } from '../../actions/layers.js'
 import { EARTH_ENGINE_LAYER } from '../../constants/layers.js'
 import useKeyDown from '../../hooks/useKeyDown.js'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { useOrgUnits } from '../OrgUnitsProvider.js'
 import EarthEngineDialog from './earthEngine/EarthEngineDialog.js'
 import EventDialog from './event/EventDialog.js'
@@ -46,7 +46,7 @@ const getLayerNames = () => ({
 
 const LayerEdit = ({ layer, addLayer, updateLayer, cancelLayer }) => {
     const [isValidLayer, setIsValidLayer] = useState(false)
-    const { systemSettings, periodsSettings } = useAppData()
+    const { systemSettings, periodsSettings } = useCachedData()
     const orgUnits = useOrgUnits()
 
     const onValidateLayer = () => setIsValidLayer(true)

--- a/src/components/groupSet/GroupSetSelect.js
+++ b/src/components/groupSet/GroupSetSelect.js
@@ -2,7 +2,7 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React, { useMemo, useCallback } from 'react'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { SelectField } from '../core/index.js'
 
 // Load org unit group sets
@@ -24,7 +24,7 @@ const GroupSetSelect = ({
     errorText,
     className,
 }) => {
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
     const { loading, error, data } = useDataQuery(ORG_UNIT_GROUP_SETS_QUERY, {
         variables: { nameProperty },
     })

--- a/src/components/indicator/IndicatorSelect.js
+++ b/src/components/indicator/IndicatorSelect.js
@@ -2,7 +2,7 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { SelectField } from '../core/index.js'
 
 // Load all indicators within a group
@@ -24,7 +24,7 @@ const IndicatorSelect = ({
     className,
     errorText,
 }) => {
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
     const { loading, error, data, refetch } = useDataQuery(INDICATORS_QUERY, {
         lazy: true,
     })

--- a/src/components/interpretations/InterpretationsPanel.js
+++ b/src/components/interpretations/InterpretationsPanel.js
@@ -8,7 +8,7 @@ import queryString from 'query-string'
 import React, { useRef, useCallback } from 'react'
 import { useSelector } from 'react-redux'
 import history, { getHashUrlParams } from '../../util/history.js'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import Drawer from '../core/Drawer.js'
 import InterpretationMap from './InterpretationMap.js'
 
@@ -26,7 +26,7 @@ const closeInterpretationModal = () => {
 }
 
 const InterpretationsPanel = ({ renderCount }) => {
-    const { currentUser } = useAppData()
+    const { currentUser } = useCachedData()
     const interpretationsUnitRef = useRef()
     const map = useSelector((state) => state.map)
     const interpretationId = useSelector((state) => state.interpretation?.id)

--- a/src/components/layerSources/ManageLayerSourcesButton.js
+++ b/src/components/layerSources/ManageLayerSourcesButton.js
@@ -3,11 +3,11 @@ import { Button } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { MAPS_ADMIN_AUTHORITY_ID } from '../../constants/settings.js'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import styles from './styles/ManageLayerSourcesButton.module.css'
 
 const ManageLayerSourcesButton = ({ onClick }) => {
-    const { currentUser } = useAppData()
+    const { currentUser } = useCachedData()
     const isMapsAdmin = currentUser.authorities.has(MAPS_ADMIN_AUTHORITY_ID)
 
     if (!isMapsAdmin) {

--- a/src/components/layers/basemaps/BasemapList.js
+++ b/src/components/layers/basemaps/BasemapList.js
@@ -1,11 +1,11 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { useAppData } from '../../app/AppDataProvider.js'
+import { useCachedData } from '../../cachedDataProvider/CachedDataProvider.js'
 import Basemap from './Basemap.js'
 import styles from './styles/BasemapList.module.css'
 
 const BasemapList = ({ selectedID, selectBasemap }) => {
-    const { basemaps } = useAppData()
+    const { basemaps } = useCachedData()
     return (
         <div className={styles.basemapList} data-test="basemaplist">
             {basemaps.map((basemap, index) => (

--- a/src/components/layers/download/DataDownloadDialog.js
+++ b/src/components/layers/download/DataDownloadDialog.js
@@ -12,14 +12,14 @@ import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { EVENT_LAYER } from '../../../constants/layers.js'
 import { getFormatOptions, downloadData } from '../../../util/dataDownload.js'
-import { useAppData } from '../../app/AppDataProvider.js'
+import { useCachedData } from '../../cachedDataProvider/CachedDataProvider.js'
 import { SelectField, Checkbox, Help } from '../../core/index.js'
 import DataDownloadDialogActions from './DataDownloadDialogActions.js'
 import styles from './styles/DataDownloadDialog.module.css'
 
 const DataDownloadDialog = ({ layer, onCloseDialog }) => {
     const engine = useDataEngine()
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
     const formatOptions = getFormatOptions()
     const [selectedFormat, setSelectedFormat] = useState(formatOptions[2])
     const [humanReadable, setHumanReadable] = useState(true)

--- a/src/components/layers/overlays/AddLayerPopover.js
+++ b/src/components/layers/overlays/AddLayerPopover.js
@@ -8,7 +8,7 @@ import { EXTERNAL_LAYER } from '../../../constants/layers.js'
 import useKeyDown from '../../../hooks/useKeyDown.js'
 import useManagedLayerSourcesStore from '../../../hooks/useManagedLayerSourcesStore.js'
 import { isSplitViewMap } from '../../../util/helpers.js'
-import { useAppData } from '../../app/AppDataProvider.js'
+import { useCachedData } from '../../cachedDataProvider/CachedDataProvider.js'
 import ManageLayerSourcesButton from '../../layerSources/ManageLayerSourcesButton.js'
 import LayerList from './LayerList.js'
 
@@ -32,7 +32,7 @@ const AddLayerPopover = ({ anchorEl, onClose, onManaging }) => {
         isSplitViewMap(state.map.mapViews)
     )
     const dispatch = useDispatch()
-    const { defaultLayerSources } = useAppData()
+    const { defaultLayerSources } = useCachedData()
     const { managedLayerSources } = useManagedLayerSourcesStore()
     const layerSources = includeEarthEngineLayers(
         defaultLayerSources,

--- a/src/components/map/MapView.js
+++ b/src/components/map/MapView.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
 import { getSplitViewLayer } from '../../util/helpers.js'
 import { getMapControls } from '../../util/mapControls.js'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import Map from './Map.js'
 import SplitView from './SplitView.js'
 
@@ -28,7 +28,7 @@ const MapView = (props) => {
 
     const { baseUrl } = useConfig()
     const engine = useDataEngine()
-    const { currentUser } = useAppData()
+    const { currentUser } = useCachedData()
     const nameProperty = currentUser.keyAnalysisDisplayProperty
 
     const splitViewLayer = getSplitViewLayer(layers)

--- a/src/components/orgunits/OrgUnitSelect.js
+++ b/src/components/orgunits/OrgUnitSelect.js
@@ -6,7 +6,7 @@ import React, { useCallback } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { setOrgUnits } from '../../actions/layerEdit.js'
 import { translateOrgUnitLevels } from '../../util/orgUnits.js'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { useOrgUnits } from '../OrgUnitsProvider.js'
 import AssociatedGeometrySelect from './AssociatedGeometrySelect.js'
 import OrgUnitSelectMode from './OrgUnitSelectMode.js'
@@ -24,7 +24,7 @@ const OrgUnitSelect = ({
     hideGroupSelect = false,
     warning,
 }) => {
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
     const { roots, levels, loading, error } = useOrgUnits()
     const rows = useSelector((state) => state.layerEdit.rows)
     const dispatch = useDispatch()

--- a/src/components/periods/RelativePeriodSelect.js
+++ b/src/components/periods/RelativePeriodSelect.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
 import { START_END_DATES } from '../../constants/periods.js'
 import { getRelativePeriods } from '../../util/periods.js'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { SelectField } from '../core/index.js'
 
 const RelativePeriodSelect = ({
@@ -13,7 +13,7 @@ const RelativePeriodSelect = ({
     className,
     errorText,
 }) => {
-    const { systemSettings } = useAppData()
+    const { systemSettings } = useCachedData()
     const hiddenPeriods = systemSettings.hiddenPeriods
 
     const periods = useMemo(

--- a/src/components/plugin/LayerLoader.js
+++ b/src/components/plugin/LayerLoader.js
@@ -10,7 +10,7 @@ import geoJsonUrlLoader from '../../loaders/geoJsonUrlLoader.js'
 import orgUnitLoader from '../../loaders/orgUnitLoader.js'
 import thematicLoader from '../../loaders/thematicLoader.js'
 import trackedEntityLoader from '../../loaders/trackedEntityLoader.js'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 
 const loaders = {
     earthEngine: earthEngineLoader,
@@ -27,7 +27,7 @@ const LayerLoader = ({ config, onLoad }) => {
     const { baseUrl, serverVersion } = useConfig()
     const engine = useDataEngine()
     const [analyticsEngine] = useState(() => Analytics.getAnalytics(engine))
-    const { currentUser } = useAppData()
+    const { currentUser } = useCachedData()
     const { keyAnalysisDisplayProperty, id: userId } = currentUser
 
     useEffect(() => {

--- a/src/components/plugin/MapContainer.js
+++ b/src/components/plugin/MapContainer.js
@@ -5,14 +5,14 @@ import React, { useState, useEffect } from 'react'
 import { getConfigFromNonMapConfig } from '../../util/getConfigFromNonMapConfig.js'
 import { getMigratedMapConfig } from '../../util/getMigratedMapConfig.js'
 import { fetchMap } from '../../util/requests.js'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import getBasemapConfig from './getBasemapConfig.js'
 import LoadingMask from './LoadingMask.js'
 import Map from './Map.js'
 
 const MapContainer = ({ visualization }) => {
     const engine = useDataEngine()
-    const { systemSettings } = useAppData()
+    const { systemSettings } = useCachedData()
     const [config, setConfig] = useState(null)
 
     useEffect(() => {

--- a/src/components/plugin/Plugin.js
+++ b/src/components/plugin/Plugin.js
@@ -5,7 +5,7 @@ import {
     SYSTEM_SETTINGS,
 } from '../../constants/settings.js'
 import { getHiddenPeriods } from '../../util/periods.js'
-import { AppDataProvider } from '../app/AppDataProvider.js'
+import { CachedDataProvider } from '../cachedDataProvider/CachedDataProvider.js'
 import MapContainer from './MapContainer.js'
 
 const query = {
@@ -50,7 +50,7 @@ const providerDataTransformation = ({ systemSettings, currentUser }) => {
 
 export const Plugin = ({ visualization, displayProperty }) => {
     return (
-        <AppDataProvider
+        <CachedDataProvider
             query={query}
             dataTransformation={providerDataTransformation}
             translucent={false}
@@ -59,7 +59,7 @@ export const Plugin = ({ visualization, displayProperty }) => {
                 visualization={visualization}
                 displayProperty={displayProperty}
             />
-        </AppDataProvider>
+        </CachedDataProvider>
     )
 }
 

--- a/src/components/program/ProgramIndicatorSelect.js
+++ b/src/components/program/ProgramIndicatorSelect.js
@@ -3,7 +3,7 @@ import i18n from '@dhis2/d2-i18n'
 import { sortBy } from 'lodash/fp'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { SelectField } from '../core/index.js'
 
 // Load program indicators for one program
@@ -25,7 +25,7 @@ const ProgramIndicatorSelect = ({
     className,
     errorText,
 }) => {
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
 
     const { data, loading, error, refetch } = useDataQuery(
         PROGRAM_INDICATORS_QUERY,

--- a/src/components/program/ProgramSelect.js
+++ b/src/components/program/ProgramSelect.js
@@ -2,7 +2,7 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { useAppData } from '../app/AppDataProvider.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.js'
 import { SelectField } from '../core/index.js'
 
 const allProgramsItem = {
@@ -32,7 +32,7 @@ const ProgramSelect = ({
     errorText,
     onChange,
 }) => {
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
     const { loading, error, data } = useDataQuery(PROGRAMS_QUERY, {
         variables: { nameProperty },
     })

--- a/src/hooks/useBasemapConfig.js
+++ b/src/hooks/useBasemapConfig.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useAppData } from '../components/app/AppDataProvider.js'
+import { useCachedData } from '../components/cachedDataProvider/CachedDataProvider.js'
 import { getFallbackBasemap } from '../constants/basemaps.js'
 import { defaultBasemapState } from '../reducers/map.js'
 
@@ -7,7 +7,7 @@ const emptyBasemap = { config: {} }
 
 function useBasemapConfig(selected) {
     const [basemap, setBasemap] = useState(emptyBasemap)
-    const { systemSettings, basemaps } = useAppData()
+    const { systemSettings, basemaps } = useCachedData()
     const defaultBasemap = systemSettings.keyDefaultBaseMap
 
     useEffect(() => {

--- a/src/hooks/useLayersLoader.js
+++ b/src/hooks/useLayersLoader.js
@@ -4,7 +4,7 @@ import { useAlert } from '@dhis2/app-service-alerts'
 import { useState, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { setLayerLoading, updateLayer } from '../actions/layers.js'
-import { useAppData } from '../components/app/AppDataProvider.js'
+import { useCachedData } from '../components/cachedDataProvider/CachedDataProvider.js'
 import useLoaderAlerts from '../components/loaders/useLoaderAlerts.js'
 import { EVENT_LAYER } from '../constants/layers.js'
 import earthEngineLoader from '../loaders/earthEngineLoader.js'
@@ -31,7 +31,7 @@ export const useLayersLoader = () => {
     const { baseUrl, serverVersion } = useConfig()
     const engine = useDataEngine()
     const [analyticsEngine] = useState(() => Analytics.getAnalytics(engine))
-    const { currentUser } = useAppData()
+    const { currentUser } = useCachedData()
     const { showAlerts } = useLoaderAlerts()
     const allLayers = useSelector((state) => state.map.mapViews)
     const dataTable = useSelector((state) => state.dataTable)

--- a/src/hooks/useProgramStageDataElements.js
+++ b/src/hooks/useProgramStageDataElements.js
@@ -1,6 +1,6 @@
 import { useDataQuery } from '@dhis2/app-runtime'
 import { useState, useEffect } from 'react'
-import { useAppData } from '../components/app/AppDataProvider.js'
+import { useCachedData } from '../components/cachedDataProvider/CachedDataProvider.js'
 import { getValidDataItems } from '../util/helpers.js'
 
 const PROGRAM_STAGE_DATA_ELEMENTS_QUERY = {
@@ -19,7 +19,7 @@ const PROGRAM_STAGE_DATA_ELEMENTS_QUERY = {
 }
 export const useProgramStageDataElements = ({ programStageId }) => {
     const [dataElements, setDataElements] = useState(null)
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
 
     const { refetch, loading } = useDataQuery(
         PROGRAM_STAGE_DATA_ELEMENTS_QUERY,

--- a/src/hooks/useProgramTrackedEntityAttributes.js
+++ b/src/hooks/useProgramTrackedEntityAttributes.js
@@ -1,6 +1,6 @@
 import { useDataQuery } from '@dhis2/app-runtime'
 import { useState, useEffect } from 'react'
-import { useAppData } from '../components/app/AppDataProvider.js'
+import { useCachedData } from '../components/cachedDataProvider/CachedDataProvider.js'
 import { getValidDataItems } from '../util/helpers.js'
 
 const PROGRAM_TRACKED_ENTITY_ATTRIBUTES_QUERY = {
@@ -21,7 +21,7 @@ const PROGRAM_TRACKED_ENTITY_ATTRIBUTES_QUERY = {
 export const useProgramTrackedEntityAttributes = ({ programId }) => {
     const [programAttributes, setProgramAttributes] = useState(null)
     const [trackedEntityType, setTrackedEntityType] = useState(null)
-    const { nameProperty } = useAppData()
+    const { nameProperty } = useCachedData()
 
     const { refetch, loading } = useDataQuery(
         PROGRAM_TRACKED_ENTITY_ATTRIBUTES_QUERY,


### PR DESCRIPTION
### Description

Replace @dhis2/analytics `CachedDataQueryProvider` with maps-app specific `AppDataProvider` that supports async `dataTransformation`.

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested
- [ ] Cypress and/or Jest tests added/updated _N/A_
- [ ] Docs added _N/A_
- [ ] d2-ci dependencies replaced (analytics or maps-gl link https://github.com/dhis2/[lib]/pull/XXX) _N/A_
- [x] Tester approved (JJA)