### PR TITLE
fix: data table crashes on columns containing empty values [DHIS2-19267]

### DIFF
--- a/src/components/datatable/useTableData.js
+++ b/src/components/datatable/useTableData.js
@@ -307,26 +307,21 @@ export const useTableData = ({ layer, sortField, sortDirection }) => {
             }
 
             if (a === undefined) {
-                // a goes to end
-                return 1
+                return 1 // a goes to end
             }
 
             if (b === undefined) {
-                // b goes to end
-                return -1
+                return -1 // b goes to end
             }
 
             if (typeof a === TYPE_NUMBER) {
                 return sortDirection === ASCENDING ? a - b : b - a
             }
-            // TODO: Make sure sorting works across different locales
-            if (a !== undefined) {
-                return sortDirection === ASCENDING
-                    ? a.localeCompare(b)
-                    : b.localeCompare(a)
-            }
 
-            return 0
+            // TODO: Make sure sorting works across different locales
+            return sortDirection === ASCENDING
+                ? a.localeCompare(b)
+                : b.localeCompare(a)
         })
 
         return filteredData.map((item) =>

--- a/src/components/datatable/useTableData.js
+++ b/src/components/datatable/useTableData.js
@@ -301,6 +301,21 @@ export const useTableData = ({ layer, sortField, sortDirection }) => {
             a = a[sortField]
             b = b[sortField]
 
+            // All undefined values should be sorted to the end
+            if (a === undefined && b === undefined) {
+                return 0
+            }
+
+            if (a === undefined) {
+                // a goes to end
+                return 1
+            }
+
+            if (b === undefined) {
+                // b goes to end
+                return -1
+            }
+
             if (typeof a === TYPE_NUMBER) {
                 return sortDirection === ASCENDING ? a - b : b - a
             }


### PR DESCRIPTION
Implements [DHIS2-19267](https://dhis2.atlassian.net/browse/DHIS2-19267)

### Description

Ensure values are  not undefined before sorting them. Undefined values are put at the bottom of the table.

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [ ] Docs added N/A
- [ ] d2-ci dependencies replaced (analytics or maps-gl link https://github.com/dhis2/[lib]/pull/XXX) N/A
- [x] Tester approved (BR)

---


[DHIS2-19267]: https://dhis2.atlassian.net/browse/DHIS2-19267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ