### PR TITLE
chore: deactivate requestsErrors.cy.js

### DIFF
--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -11,7 +11,7 @@ describe('Error handling check for all layer types', () => {
     beforeEach(() => {
         cy.clearCookies()
         cy.clearLocalStorage()
-        
+
         const username = Cypress.env('dhis2Username')
         const password = Cypress.env('dhis2Password')
         const baseUrl = Cypress.env('dhis2BaseUrl')

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -13,12 +13,11 @@ const clearAndLogin = () => {
     const password = Cypress.env('dhis2Password')
     const baseUrl = Cypress.env('dhis2BaseUrl')
 
-    cy.loginByApi({ username, password, baseUrl }).then(() => {
-        cy.getAllCookies().should((cookies) => {
-            const jsession = cookies.find((c) => c.name === 'JSESSIONID')
-            expect(jsession).to.exist
-        })
-    })
+    cy.loginByApi({ username, password, baseUrl })
+        .its('status')
+        .should('equal', 200)
+
+    cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
 }
 
 const commonTriggerFn = () => {

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -5,7 +5,7 @@ const commonTriggerFn = () => {
     cy.reload(true)
 }
 
-const EXTRA_EXTENDED_TIMEOUT = { timeout: 25000 }
+const EXTRA_EXTENDED_TIMEOUT = { timeout: 30000 }
 
 describe('Error handling check for all layer types', () => {
     beforeEach(() => {
@@ -32,7 +32,7 @@ describe('Error handling check for all layer types', () => {
         })
     })
 
-    it('load thematic layer', () => {
+    it.only('load thematic layer', () => {
         // E2E - Thematic Layer [tFVpGPWj7MJ]
         const id = 'tFVpGPWj7MJ'
 

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -13,11 +13,12 @@ const clearAndLogin = () => {
     const password = Cypress.env('dhis2Password')
     const baseUrl = Cypress.env('dhis2BaseUrl')
 
-    cy.loginByApi({ username, password, baseUrl })
-        .its('status')
-        .should('equal', 200)
-
-    cy.getCookie('JSESSIONID').should('exist')
+    cy.loginByApi({ username, password, baseUrl }).then(() => {
+        cy.getAllCookies().should((cookies) => {
+            const jsession = cookies.find((c) => c.name === 'JSESSIONID')
+            expect(jsession).to.exist
+        })
+    })
 }
 
 const commonTriggerFn = () => {

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -3,7 +3,7 @@ import { assertIntercepts, getDhis2Version } from '../support/util.js'
 
 const EXTRA_EXTENDED_TIMEOUT = { timeout: 60000 }
 
-const commonTriggerFn = () => {
+const clearAndLogin = () => {
     cy.clearCookies()
     cy.clearLocalStorage()
 
@@ -15,6 +15,11 @@ const commonTriggerFn = () => {
         .its('status')
         .should('equal', 200)
 
+    cy.wait(100) // eslint-disable-line cypress/no-unnecessary-waiting
+}
+
+const commonTriggerFn = () => {
+    clearAndLogin()
     cy.reload(true)
 }
 
@@ -229,6 +234,7 @@ describe('Error handling check for all layer types', () => {
                 {
                     ...getRequest('getEventsStandard_Analytics1'),
                     triggerFn: () => {
+                        clearAndLogin()
                         cy.reload(true)
                         cy.wait(10000) // eslint-disable-line cypress/no-unnecessary-waiting
                     },
@@ -247,6 +253,7 @@ describe('Error handling check for all layer types', () => {
                 {
                     ...getRequest('getEventsStandard_Analytics2'),
                     triggerFn: () => {
+                        clearAndLogin()
                         cy.reload(true)
                         cy.getByDataTest('layercard')
                             .find(

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -32,7 +32,7 @@ describe('Error handling check for all layer types', () => {
         assertIntercepts({
             intercepts: [getRequest('getMap', id)],
             commonTriggerFn: () => {
-                cy.visit(`/?id=${id}`)
+                cy.visit(`#/${id}`)
             },
         })
     })
@@ -59,7 +59,7 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
-        cy.visit(`/?id=${id}`)
+        cy.visit(`#/${id}`)
 
         assertIntercepts({
             intercepts: [
@@ -108,7 +108,7 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
-        cy.visit(`/?id=${id}`)
+        cy.visit(`#/${id}`)
 
         assertIntercepts({
             intercepts: [
@@ -226,7 +226,7 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
-        cy.visit(`/?id=${id}`)
+        cy.visit(`#/${id}`)
 
         assertIntercepts({
             intercepts: [
@@ -234,7 +234,7 @@ describe('Error handling check for all layer types', () => {
                     ...getRequest('getEventsStandard_Analytics1'),
                     triggerFn: () => {
                         clearAndLogin()
-                        cy.visit(`/?id=${id}`)
+                        cy.visit(`#/${id}`)
                         cy.wait(10000) // eslint-disable-line cypress/no-unnecessary-waiting
                     },
                     errors: ['network', 409], // !TODO: Improve messages
@@ -253,7 +253,7 @@ describe('Error handling check for all layer types', () => {
                     ...getRequest('getEventsStandard_Analytics2'),
                     triggerFn: () => {
                         clearAndLogin()
-                        cy.visit(`/?id=${id}`)
+                        cy.visit(`#/${id}`)
                         cy.getByDataTest('layercard')
                             .find('[data-test="layerlegend"]', EXTENDED_TIMEOUT)
                             .should('exist')
@@ -301,7 +301,7 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
-        cy.visit(`/?id=${id}`)
+        cy.visit(`#/${id}`)
 
         const serverVersion = getDhis2Version()
         let layerSpecificRequests
@@ -366,7 +366,7 @@ describe('Error handling check for all layer types', () => {
         // E2E - Facilities Layer [kIAUN3dInEz]
         const id = 'kIAUN3dInEz'
 
-        cy.visit(`/?id=${id}`)
+        cy.visit(`#/${id}`)
 
         const commonAssertFn = ({ error }) => {
             const errorMessage = {
@@ -425,7 +425,7 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
-        cy.visit(`/?id=${id}`)
+        cy.visit(`#/${id}`)
 
         assertIntercepts({
             intercepts: [
@@ -473,7 +473,7 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
-        cy.visit(`/?id=${id}`)
+        cy.visit(`#/${id}`)
 
         assertIntercepts({
             intercepts: [

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -62,6 +62,7 @@ describe('Error handling check for all layer types', () => {
                 {
                     ...getRequest('getThematic_Analytics1'),
                     errors: ['network', 409],
+                    skip: true,
                 },
                 {
                     ...getRequest('getThematic_Analytics2'),

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -1,15 +1,18 @@
 import { getRequest } from '../support/requests.js'
-import {
-    assertIntercepts,
-    EXTENDED_TIMEOUT,
-    getDhis2Version,
-} from '../support/util.js'
+import { assertIntercepts, getDhis2Version } from '../support/util.js'
 
 const commonTriggerFn = () => {
     cy.reload(true)
 }
 
+const EXTRA_EXTENDED_TIMEOUT = { timeout: 30000 }
+
 describe('Error handling check for all layer types', () => {
+    beforeEach(() => {
+        cy.clearCookies()
+        cy.clearLocalStorage()
+    })
+
     it.skip('missing map', () => {
         // !TODO: Handle error
         const id = '00000000000'
@@ -31,14 +34,15 @@ describe('Error handling check for all layer types', () => {
                 409: 'Simulated error with status code 409',
             }
 
-            cy.getByDataTest('dhis2-uicore-noticebox', EXTENDED_TIMEOUT).within(
-                () => {
-                    cy.contains('Failed to load layer').should('be.visible')
-                    cy.contains(errorMessage[error]).should('be.visible')
-                }
-            )
+            cy.getByDataTest(
+                'dhis2-uicore-noticebox',
+                EXTRA_EXTENDED_TIMEOUT
+            ).within(() => {
+                cy.contains('Failed to load layer').should('be.visible')
+                cy.contains(errorMessage[error]).should('be.visible')
+            })
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
                 .contains(`Error: ${errorMessage[error]}`)
                 .should('be.visible')
         }
@@ -48,36 +52,8 @@ describe('Error handling check for all layer types', () => {
         assertIntercepts({
             intercepts: [
                 {
-                    intercepts: [
-                        {
-                            ...getRequest('getThematic_Analytics1'),
-                            error: 'network',
-                        },
-                        {
-                            ...getRequest('getThematic_Analytics2'),
-                            error: 'network',
-                        },
-                    ],
-                    alias: 'getThematic_AnalyticsGroup',
-                    assertFn: () => {
-                        commonAssertFn({ error: 'network' })
-                    },
-                },
-                {
-                    intercepts: [
-                        {
-                            ...getRequest('getThematic_Analytics1'),
-                            error: 409,
-                        },
-                        {
-                            ...getRequest('getThematic_Analytics2'),
-                            error: 'network',
-                        },
-                    ],
-                    alias: 'getThematic_AnalyticsGroup',
-                    assertFn: () => {
-                        commonAssertFn({ error: 409 })
-                    },
+                    ...getRequest('getThematic_Analytics1'),
+                    errors: ['network', 409],
                 },
                 {
                     ...getRequest('getThematic_Analytics2'),
@@ -99,6 +75,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
+            timeout: EXTRA_EXTENDED_TIMEOUT,
         })
     })
 
@@ -115,7 +92,7 @@ describe('Error handling check for all layer types', () => {
 
             // !TODO: Display error in layer card
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
                 .contains(errorMessage[error])
                 .should('be.visible')
         }
@@ -138,7 +115,7 @@ describe('Error handling check for all layer types', () => {
                     assertFn: () => {
                         cy.getByDataTest(
                             'dhis2-uicore-alertstack',
-                            EXTENDED_TIMEOUT
+                            EXTRA_EXTENDED_TIMEOUT
                         )
                             .contains('The event filter is not supported')
                             .should('be.visible')
@@ -158,7 +135,7 @@ describe('Error handling check for all layer types', () => {
                     assertFn: () => {
                         cy.getByDataTest(
                             'dhis2-uicore-alertstack',
-                            EXTENDED_TIMEOUT
+                            EXTRA_EXTENDED_TIMEOUT
                         )
                             .contains(
                                 "You don't have access to this layer data"
@@ -218,6 +195,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
+            timeout: EXTRA_EXTENDED_TIMEOUT,
         })
     })
 
@@ -233,7 +211,7 @@ describe('Error handling check for all layer types', () => {
 
             // !TODO: Display error in layer card
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
                 .contains(errorMessage[error])
                 .should('be.visible')
         }
@@ -265,7 +243,10 @@ describe('Error handling check for all layer types', () => {
                     triggerFn: () => {
                         cy.reload(true)
                         cy.getByDataTest('layercard')
-                            .find('[data-test="layerlegend"]', EXTENDED_TIMEOUT)
+                            .find(
+                                '[data-test="layerlegend"]',
+                                EXTRA_EXTENDED_TIMEOUT
+                            )
                             .should('exist')
                         cy.getByDataTest('moremenubutton').first().click()
                         cy.getByDataTest('more-menu')
@@ -280,7 +261,7 @@ describe('Error handling check for all layer types', () => {
                     assertFn: () => {
                         cy.getByDataTest(
                             'dhis2-uicore-noticebox',
-                            EXTENDED_TIMEOUT
+                            EXTRA_EXTENDED_TIMEOUT
                         )
                             .contains('Data download failed.')
                             .should('be.visible')
@@ -290,6 +271,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
+            timeout: EXTRA_EXTENDED_TIMEOUT,
         })
     })
 
@@ -306,7 +288,7 @@ describe('Error handling check for all layer types', () => {
 
             // !TODO: Display error in layer card
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
                 .contains(errorMessage[error])
                 .should('be.visible')
         }
@@ -369,6 +351,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
+            timeout: EXTRA_EXTENDED_TIMEOUT,
         })
     })
 
@@ -386,11 +369,11 @@ describe('Error handling check for all layer types', () => {
 
             // !TODO: Display error in layer card
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
                 .contains(`Error: ${errorMessage[error]}`)
                 .should('be.visible')
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
                 .contains('No coordinates found for selected facilities')
                 .should('be.visible')
         }
@@ -411,7 +394,7 @@ describe('Error handling check for all layer types', () => {
                     assertFn: () => {
                         cy.getByDataTest(
                             'dhis2-uicore-alertbar',
-                            EXTENDED_TIMEOUT
+                            EXTRA_EXTENDED_TIMEOUT
                         )
                             .contains('Symbol not found')
                             .should('be.visible')
@@ -421,6 +404,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
+            timeout: EXTRA_EXTENDED_TIMEOUT,
         })
     })
 
@@ -430,7 +414,7 @@ describe('Error handling check for all layer types', () => {
         const id = 'e2fjmQMtJ0c'
 
         const commonAssertFn = () => {
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
                 .contains('error')
                 .should('be.visible')
         }
@@ -462,6 +446,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
+            timeout: EXTRA_EXTENDED_TIMEOUT,
         })
     })
 
@@ -478,7 +463,7 @@ describe('Error handling check for all layer types', () => {
 
             // !TODO: Display error in layer card
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
                 .contains(`Error: ${errorMessage[error]}`)
                 .should('be.visible')
         }
@@ -508,7 +493,7 @@ describe('Error handling check for all layer types', () => {
 
                         cy.getByDataTest(
                             'dhis2-uicore-alertbar',
-                            EXTENDED_TIMEOUT
+                            EXTRA_EXTENDED_TIMEOUT
                         )
                             .contains(errorMessage[error])
                             .should('be.visible')
@@ -526,7 +511,7 @@ describe('Error handling check for all layer types', () => {
                     assertFn: () => {
                         cy.getByDataTest(
                             'dhis2-uicore-alertbar',
-                            EXTENDED_TIMEOUT
+                            EXTRA_EXTENDED_TIMEOUT
                         )
                             .contains(
                                 'This layer requires a Google Earth Engine account. Check the DHIS2 documentation for more information.'
@@ -542,6 +527,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
+            timeout: EXTRA_EXTENDED_TIMEOUT,
         })
     })
 })

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -20,9 +20,9 @@ const clearAndLogin = () => {
     cy.wait(100) // eslint-disable-line cypress/no-unnecessary-waiting
 }
 
-const commonTriggerFn = () => {
+const commonTriggerFn = (id) => () => {
     clearAndLogin()
-    cy.reload(true)
+    cy.visit(`#/${id}`)
 }
 
 describe('Error handling check for all layer types', () => {
@@ -85,7 +85,7 @@ describe('Error handling check for all layer types', () => {
                     skip: true, // !TODO: Handle errors
                 },
             ],
-            commonTriggerFn,
+            commonTriggerFn: commonTriggerFn(id),
             commonAssertFn,
             timeout: EXTENDED_TIMEOUT,
         })
@@ -205,7 +205,7 @@ describe('Error handling check for all layer types', () => {
                     skip: true, // !TODO: Handle errors
                 },
             ],
-            commonTriggerFn,
+            commonTriggerFn: commonTriggerFn(id),
             commonAssertFn,
             timeout: EXTENDED_TIMEOUT,
         })
@@ -236,7 +236,7 @@ describe('Error handling check for all layer types', () => {
                     ...getRequest('getEventsStandard_Analytics1'),
                     triggerFn: () => {
                         clearAndLogin()
-                        cy.reload(true)
+                        cy.visit(`#/${id}`)
                         cy.wait(10000) // eslint-disable-line cypress/no-unnecessary-waiting
                     },
                     errors: ['network', 409], // !TODO: Improve messages
@@ -255,7 +255,7 @@ describe('Error handling check for all layer types', () => {
                     ...getRequest('getEventsStandard_Analytics2'),
                     triggerFn: () => {
                         clearAndLogin()
-                        cy.reload(true)
+                        cy.visit(`#/${id}`)
                         cy.getByDataTest('layercard')
                             .find('[data-test="layerlegend"]', EXTENDED_TIMEOUT)
                             .should('exist')
@@ -280,7 +280,7 @@ describe('Error handling check for all layer types', () => {
                     errors: ['network', 409],
                 },
             ],
-            commonTriggerFn,
+            commonTriggerFn: commonTriggerFn(id),
             commonAssertFn,
             timeout: EXTENDED_TIMEOUT,
         })
@@ -360,7 +360,7 @@ describe('Error handling check for all layer types', () => {
                     skip: true, // !TODO: Handle errors (layer loads)
                 },
             ],
-            commonTriggerFn,
+            commonTriggerFn: commonTriggerFn(id),
             commonAssertFn,
             timeout: EXTENDED_TIMEOUT,
         })
@@ -413,7 +413,7 @@ describe('Error handling check for all layer types', () => {
                     errors: ['network', 409],
                 },
             ],
-            commonTriggerFn,
+            commonTriggerFn: commonTriggerFn(id),
             commonAssertFn,
             timeout: EXTENDED_TIMEOUT,
         })
@@ -455,7 +455,7 @@ describe('Error handling check for all layer types', () => {
                     skip: true, // !TODO: Handle errors
                 },
             ],
-            commonTriggerFn,
+            commonTriggerFn: commonTriggerFn(id),
             commonAssertFn,
             timeout: EXTENDED_TIMEOUT,
         })
@@ -536,7 +536,7 @@ describe('Error handling check for all layer types', () => {
                     skip: true, // !TODO: Handle errors
                 },
             ],
-            commonTriggerFn,
+            commonTriggerFn: commonTriggerFn(id),
             commonAssertFn,
             timeout: EXTENDED_TIMEOUT,
         })

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -17,7 +17,7 @@ const clearAndLogin = () => {
         .its('status')
         .should('equal', 200)
 
-    cy.wait(500) // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
 }
 
 const commonTriggerFn = () => {

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -17,7 +17,7 @@ const clearAndLogin = () => {
         .its('status')
         .should('equal', 200)
 
-    cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.wait(100) // eslint-disable-line cypress/no-unnecessary-waiting
 }
 
 const commonTriggerFn = () => {
@@ -32,7 +32,6 @@ describe('Error handling check for all layer types', () => {
         assertIntercepts({
             intercepts: [getRequest('getMap', id)],
             commonTriggerFn: () => {
-                clearAndLogin()
                 cy.visit(`#/${id}`)
             },
         })
@@ -60,7 +59,6 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
-        clearAndLogin()
         cy.visit(`#/${id}`)
 
         assertIntercepts({
@@ -111,7 +109,6 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
-        clearAndLogin()
         cy.visit(`#/${id}`)
 
         assertIntercepts({
@@ -231,7 +228,6 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
-        clearAndLogin()
         cy.visit(`#/${id}`)
 
         assertIntercepts({
@@ -308,7 +304,6 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
-        clearAndLogin()
         cy.visit(`#/${id}`)
 
         const serverVersion = getDhis2Version()
@@ -375,7 +370,6 @@ describe('Error handling check for all layer types', () => {
         // E2E - Facilities Layer [kIAUN3dInEz]
         const id = 'kIAUN3dInEz'
 
-        clearAndLogin()
         cy.visit(`#/${id}`)
 
         const commonAssertFn = ({ error }) => {
@@ -436,7 +430,6 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
-        clearAndLogin()
         cy.visit(`#/${id}`)
 
         assertIntercepts({
@@ -486,7 +479,6 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
-        clearAndLogin()
         cy.visit(`#/${id}`)
 
         assertIntercepts({

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -17,7 +17,7 @@ const clearAndLogin = () => {
         .its('status')
         .should('equal', 200)
 
-    cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.getCookie('JSESSIONID').should('exist')
 }
 
 const commonTriggerFn = () => {
@@ -32,6 +32,7 @@ describe('Error handling check for all layer types', () => {
         assertIntercepts({
             intercepts: [getRequest('getMap', id)],
             commonTriggerFn: () => {
+                clearAndLogin()
                 cy.visit(`#/${id}`)
             },
         })
@@ -59,6 +60,7 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
+        clearAndLogin()
         cy.visit(`#/${id}`)
 
         assertIntercepts({
@@ -109,6 +111,7 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
+        clearAndLogin()
         cy.visit(`#/${id}`)
 
         assertIntercepts({
@@ -228,6 +231,7 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
+        clearAndLogin()
         cy.visit(`#/${id}`)
 
         assertIntercepts({
@@ -304,6 +308,7 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
+        clearAndLogin()
         cy.visit(`#/${id}`)
 
         const serverVersion = getDhis2Version()
@@ -370,6 +375,7 @@ describe('Error handling check for all layer types', () => {
         // E2E - Facilities Layer [kIAUN3dInEz]
         const id = 'kIAUN3dInEz'
 
+        clearAndLogin()
         cy.visit(`#/${id}`)
 
         const commonAssertFn = ({ error }) => {
@@ -430,6 +436,7 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
+        clearAndLogin()
         cy.visit(`#/${id}`)
 
         assertIntercepts({
@@ -479,6 +486,7 @@ describe('Error handling check for all layer types', () => {
                 .should('be.visible')
         }
 
+        clearAndLogin()
         cy.visit(`#/${id}`)
 
         assertIntercepts({

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -5,12 +5,20 @@ const commonTriggerFn = () => {
     cy.reload(true)
 }
 
-const EXTRA_EXTENDED_TIMEOUT = { timeout: 30000 }
+const EXTRA_EXTENDED_TIMEOUT = { timeout: 25000 }
 
 describe('Error handling check for all layer types', () => {
     beforeEach(() => {
         cy.clearCookies()
         cy.clearLocalStorage()
+        
+        const username = Cypress.env('dhis2Username')
+        const password = Cypress.env('dhis2Password')
+        const baseUrl = Cypress.env('dhis2BaseUrl')
+
+        cy.loginByApi({ username, password, baseUrl })
+            .its('status')
+            .should('equal', 200)
     })
 
     it.skip('missing map', () => {

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -5,7 +5,7 @@ const commonTriggerFn = () => {
     cy.reload(true)
 }
 
-const EXTRA_EXTENDED_TIMEOUT = { timeout: 30000 }
+const EXTRA_EXTENDED_TIMEOUT = { timeout: 60000 }
 
 describe('Error handling check for all layer types', () => {
     beforeEach(() => {

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -1,7 +1,9 @@
 import { getRequest } from '../support/requests.js'
-import { assertIntercepts, getDhis2Version } from '../support/util.js'
-
-const EXTENDED_TIMEOUT = { timeout: 35000 }
+import {
+    EXTENDED_TIMEOUT,
+    assertIntercepts,
+    getDhis2Version,
+} from '../support/util.js'
 
 const clearAndLogin = () => {
     cy.clearCookies()
@@ -14,35 +16,14 @@ const clearAndLogin = () => {
     cy.loginByApi({ username, password, baseUrl })
         .its('status')
         .should('equal', 200)
+
+    cy.wait(100) // eslint-disable-line cypress/no-unnecessary-waiting
 }
 
 const commonTriggerFn = () => {
-    cy.reload(true)
     clearAndLogin()
     cy.reload(true)
 }
-
-Cypress.on('uncaught:exception', (err) => {
-    if (
-        err.message.includes('Failed to fetch user locale: Error: Unauthorized')
-    ) {
-        return false
-    }
-    if (
-        err.message.includes(
-            'Failed to fetch user locale: Error: An unknown network error occurred'
-        )
-    ) {
-        return false
-    }
-    if (
-        err.message.includes(
-            'Failed to fetch user ID: Error: An unknown network error occurred'
-        )
-    ) {
-        return false
-    }
-})
 
 describe('Error handling check for all layer types', () => {
     it.skip('missing map', () => {
@@ -68,18 +49,13 @@ describe('Error handling check for all layer types', () => {
 
             cy.getByDataTest('dhis2-uicore-noticebox', EXTENDED_TIMEOUT).within(
                 () => {
-                    cy.contains(
-                        'Failed to load layer',
-                        EXTENDED_TIMEOUT
-                    ).should('be.visible')
-                    cy.contains(errorMessage[error], EXTENDED_TIMEOUT).should(
-                        'be.visible'
-                    )
+                    cy.contains('Failed to load layer').should('be.visible')
+                    cy.contains(errorMessage[error]).should('be.visible')
                 }
             )
 
             cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
-                .contains(`Error: ${errorMessage[error]}`, EXTENDED_TIMEOUT)
+                .contains(`Error: ${errorMessage[error]}`)
                 .should('be.visible')
         }
 
@@ -111,7 +87,6 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTENDED_TIMEOUT,
         })
     })
 
@@ -129,7 +104,7 @@ describe('Error handling check for all layer types', () => {
             // !TODO: Display error in layer card
 
             cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
-                .contains(errorMessage[error], EXTENDED_TIMEOUT)
+                .contains(errorMessage[error])
                 .should('be.visible')
         }
 
@@ -153,10 +128,7 @@ describe('Error handling check for all layer types', () => {
                             'dhis2-uicore-alertstack',
                             EXTENDED_TIMEOUT
                         )
-                            .contains(
-                                'The event filter is not supported',
-                                EXTENDED_TIMEOUT
-                            )
+                            .contains('The event filter is not supported')
                             .should('be.visible')
                     },
                 },
@@ -177,8 +149,7 @@ describe('Error handling check for all layer types', () => {
                             EXTENDED_TIMEOUT
                         )
                             .contains(
-                                "You don't have access to this layer data",
-                                EXTENDED_TIMEOUT
+                                "You don't have access to this layer data"
                             )
                             .should('be.visible')
                     },
@@ -235,7 +206,6 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTENDED_TIMEOUT,
         })
     })
 
@@ -252,7 +222,7 @@ describe('Error handling check for all layer types', () => {
             // !TODO: Display error in layer card
 
             cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
-                .contains(errorMessage[error], EXTENDED_TIMEOUT)
+                .contains(errorMessage[error])
                 .should('be.visible')
         }
 
@@ -284,7 +254,7 @@ describe('Error handling check for all layer types', () => {
                     triggerFn: () => {
                         clearAndLogin()
                         cy.visit(`/?id=${id}`)
-                        cy.getByDataTest('layercard', EXTENDED_TIMEOUT)
+                        cy.getByDataTest('layercard')
                             .find('[data-test="layerlegend"]', EXTENDED_TIMEOUT)
                             .should('exist')
                         cy.getByDataTest('moremenubutton').first().click()
@@ -302,7 +272,7 @@ describe('Error handling check for all layer types', () => {
                             'dhis2-uicore-noticebox',
                             EXTENDED_TIMEOUT
                         )
-                            .contains('Data download failed.', EXTENDED_TIMEOUT)
+                            .contains('Data download failed.')
                             .should('be.visible')
                     },
                     errors: ['network', 409],
@@ -310,7 +280,6 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTENDED_TIMEOUT,
         })
     })
 
@@ -328,7 +297,7 @@ describe('Error handling check for all layer types', () => {
             // !TODO: Display error in layer card
 
             cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
-                .contains(errorMessage[error], EXTENDED_TIMEOUT)
+                .contains(errorMessage[error])
                 .should('be.visible')
         }
 
@@ -390,7 +359,6 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTENDED_TIMEOUT,
         })
     })
 
@@ -409,14 +377,11 @@ describe('Error handling check for all layer types', () => {
             // !TODO: Display error in layer card
 
             cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
-                .contains(`Error: ${errorMessage[error]}`, EXTENDED_TIMEOUT)
+                .contains(`Error: ${errorMessage[error]}`)
                 .should('be.visible')
 
             cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
-                .contains(
-                    'No coordinates found for selected facilities',
-                    EXTENDED_TIMEOUT
-                )
+                .contains('No coordinates found for selected facilities')
                 .should('be.visible')
         }
 
@@ -438,7 +403,7 @@ describe('Error handling check for all layer types', () => {
                             'dhis2-uicore-alertbar',
                             EXTENDED_TIMEOUT
                         )
-                            .contains('Symbol not found', EXTENDED_TIMEOUT)
+                            .contains('Symbol not found')
                             .should('be.visible')
                     },
                     errors: ['network', 409],
@@ -446,7 +411,6 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTENDED_TIMEOUT,
         })
     })
 
@@ -457,7 +421,7 @@ describe('Error handling check for all layer types', () => {
 
         const commonAssertFn = () => {
             cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
-                .contains('error', EXTENDED_TIMEOUT)
+                .contains('error')
                 .should('be.visible')
         }
 
@@ -488,7 +452,6 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTENDED_TIMEOUT,
         })
     })
 
@@ -506,7 +469,7 @@ describe('Error handling check for all layer types', () => {
             // !TODO: Display error in layer card
 
             cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
-                .contains(`Error: ${errorMessage[error]}`, EXTENDED_TIMEOUT)
+                .contains(`Error: ${errorMessage[error]}`)
                 .should('be.visible')
         }
 
@@ -537,7 +500,7 @@ describe('Error handling check for all layer types', () => {
                             'dhis2-uicore-alertbar',
                             EXTENDED_TIMEOUT
                         )
-                            .contains(errorMessage[error], EXTENDED_TIMEOUT)
+                            .contains(errorMessage[error])
                             .should('be.visible')
                     },
                 },
@@ -556,8 +519,7 @@ describe('Error handling check for all layer types', () => {
                             EXTENDED_TIMEOUT
                         )
                             .contains(
-                                'This layer requires a Google Earth Engine account. Check the DHIS2 documentation for more information.',
-                                EXTENDED_TIMEOUT
+                                'This layer requires a Google Earth Engine account. Check the DHIS2 documentation for more information.'
                             )
                             .should('be.visible')
                     },
@@ -570,7 +532,6 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTENDED_TIMEOUT,
         })
     })
 })

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -5,6 +5,14 @@ import {
     EXTENDED_TIMEOUT,
 } from '../support/util.js'
 
+const SESSION_COOKIE_NAME = 'JSESSIONID'
+
+// '2.39' or 39?
+const computeEnvVariableName = (instanceVersion) =>
+    typeof instanceVersion === 'number'
+        ? `${SESSION_COOKIE_NAME}_${instanceVersion}`
+        : `${SESSION_COOKIE_NAME}_${instanceVersion.split('.').pop()}`
+
 const clearAndLogin = () => {
     cy.clearCookies()
     cy.clearLocalStorage()
@@ -12,12 +20,16 @@ const clearAndLogin = () => {
     const username = Cypress.env('dhis2Username')
     const password = Cypress.env('dhis2Password')
     const baseUrl = Cypress.env('dhis2BaseUrl')
+    const instanceVersion = Cypress.env('dhis2InstanceVersion')
+    const envVariableName = computeEnvVariableName(instanceVersion)
 
     cy.loginByApi({ username, password, baseUrl })
         .its('status')
         .should('equal', 200)
 
-    cy.wait(100) // eslint-disable-line cypress/no-unnecessary-waiting
+    const { name, value, ...options } = JSON.parse(Cypress.env(envVariableName))
+    localStorage.setItem('DHIS2_BASE_URL', baseUrl)
+    cy.setCookie(name, value, options)
 }
 
 const commonTriggerFn = (id) => () => {

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -1,7 +1,9 @@
 import { getRequest } from '../support/requests.js'
-import { assertIntercepts, getDhis2Version } from '../support/util.js'
-
-const EXTRA_EXTENDED_TIMEOUT = { timeout: 60000 }
+import {
+    assertIntercepts,
+    getDhis2Version,
+    EXTENDED_TIMEOUT,
+} from '../support/util.js'
 
 const clearAndLogin = () => {
     cy.clearCookies()
@@ -15,7 +17,7 @@ const clearAndLogin = () => {
         .its('status')
         .should('equal', 200)
 
-    cy.wait(100) // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.wait(500) // eslint-disable-line cypress/no-unnecessary-waiting
 }
 
 const commonTriggerFn = () => {
@@ -45,15 +47,14 @@ describe('Error handling check for all layer types', () => {
                 409: 'Simulated error with status code 409',
             }
 
-            cy.getByDataTest(
-                'dhis2-uicore-noticebox',
-                EXTRA_EXTENDED_TIMEOUT
-            ).within(() => {
-                cy.contains('Failed to load layer').should('be.visible')
-                cy.contains(errorMessage[error]).should('be.visible')
-            })
+            cy.getByDataTest('dhis2-uicore-noticebox', EXTENDED_TIMEOUT).within(
+                () => {
+                    cy.contains('Failed to load layer').should('be.visible')
+                    cy.contains(errorMessage[error]).should('be.visible')
+                }
+            )
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
                 .contains(`Error: ${errorMessage[error]}`)
                 .should('be.visible')
         }
@@ -86,7 +87,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTRA_EXTENDED_TIMEOUT,
+            timeout: EXTENDED_TIMEOUT,
         })
     })
 
@@ -103,7 +104,7 @@ describe('Error handling check for all layer types', () => {
 
             // !TODO: Display error in layer card
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
                 .contains(errorMessage[error])
                 .should('be.visible')
         }
@@ -126,7 +127,7 @@ describe('Error handling check for all layer types', () => {
                     assertFn: () => {
                         cy.getByDataTest(
                             'dhis2-uicore-alertstack',
-                            EXTRA_EXTENDED_TIMEOUT
+                            EXTENDED_TIMEOUT
                         )
                             .contains('The event filter is not supported')
                             .should('be.visible')
@@ -146,7 +147,7 @@ describe('Error handling check for all layer types', () => {
                     assertFn: () => {
                         cy.getByDataTest(
                             'dhis2-uicore-alertstack',
-                            EXTRA_EXTENDED_TIMEOUT
+                            EXTENDED_TIMEOUT
                         )
                             .contains(
                                 "You don't have access to this layer data"
@@ -206,7 +207,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTRA_EXTENDED_TIMEOUT,
+            timeout: EXTENDED_TIMEOUT,
         })
     })
 
@@ -222,7 +223,7 @@ describe('Error handling check for all layer types', () => {
 
             // !TODO: Display error in layer card
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
                 .contains(errorMessage[error])
                 .should('be.visible')
         }
@@ -256,10 +257,7 @@ describe('Error handling check for all layer types', () => {
                         clearAndLogin()
                         cy.reload(true)
                         cy.getByDataTest('layercard')
-                            .find(
-                                '[data-test="layerlegend"]',
-                                EXTRA_EXTENDED_TIMEOUT
-                            )
+                            .find('[data-test="layerlegend"]', EXTENDED_TIMEOUT)
                             .should('exist')
                         cy.getByDataTest('moremenubutton').first().click()
                         cy.getByDataTest('more-menu')
@@ -274,7 +272,7 @@ describe('Error handling check for all layer types', () => {
                     assertFn: () => {
                         cy.getByDataTest(
                             'dhis2-uicore-noticebox',
-                            EXTRA_EXTENDED_TIMEOUT
+                            EXTENDED_TIMEOUT
                         )
                             .contains('Data download failed.')
                             .should('be.visible')
@@ -284,7 +282,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTRA_EXTENDED_TIMEOUT,
+            timeout: EXTENDED_TIMEOUT,
         })
     })
 
@@ -301,7 +299,7 @@ describe('Error handling check for all layer types', () => {
 
             // !TODO: Display error in layer card
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
                 .contains(errorMessage[error])
                 .should('be.visible')
         }
@@ -364,7 +362,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTRA_EXTENDED_TIMEOUT,
+            timeout: EXTENDED_TIMEOUT,
         })
     })
 
@@ -382,11 +380,11 @@ describe('Error handling check for all layer types', () => {
 
             // !TODO: Display error in layer card
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
                 .contains(`Error: ${errorMessage[error]}`)
                 .should('be.visible')
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
                 .contains('No coordinates found for selected facilities')
                 .should('be.visible')
         }
@@ -407,7 +405,7 @@ describe('Error handling check for all layer types', () => {
                     assertFn: () => {
                         cy.getByDataTest(
                             'dhis2-uicore-alertbar',
-                            EXTRA_EXTENDED_TIMEOUT
+                            EXTENDED_TIMEOUT
                         )
                             .contains('Symbol not found')
                             .should('be.visible')
@@ -417,7 +415,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTRA_EXTENDED_TIMEOUT,
+            timeout: EXTENDED_TIMEOUT,
         })
     })
 
@@ -427,7 +425,7 @@ describe('Error handling check for all layer types', () => {
         const id = 'e2fjmQMtJ0c'
 
         const commonAssertFn = () => {
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
                 .contains('error')
                 .should('be.visible')
         }
@@ -459,7 +457,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTRA_EXTENDED_TIMEOUT,
+            timeout: EXTENDED_TIMEOUT,
         })
     })
 
@@ -476,7 +474,7 @@ describe('Error handling check for all layer types', () => {
 
             // !TODO: Display error in layer card
 
-            cy.getByDataTest('dhis2-uicore-alertstack', EXTRA_EXTENDED_TIMEOUT)
+            cy.getByDataTest('dhis2-uicore-alertstack', EXTENDED_TIMEOUT)
                 .contains(`Error: ${errorMessage[error]}`)
                 .should('be.visible')
         }
@@ -506,7 +504,7 @@ describe('Error handling check for all layer types', () => {
 
                         cy.getByDataTest(
                             'dhis2-uicore-alertbar',
-                            EXTRA_EXTENDED_TIMEOUT
+                            EXTENDED_TIMEOUT
                         )
                             .contains(errorMessage[error])
                             .should('be.visible')
@@ -524,7 +522,7 @@ describe('Error handling check for all layer types', () => {
                     assertFn: () => {
                         cy.getByDataTest(
                             'dhis2-uicore-alertbar',
-                            EXTRA_EXTENDED_TIMEOUT
+                            EXTENDED_TIMEOUT
                         )
                             .contains(
                                 'This layer requires a Google Earth Engine account. Check the DHIS2 documentation for more information.'
@@ -540,7 +538,7 @@ describe('Error handling check for all layer types', () => {
             ],
             commonTriggerFn,
             commonAssertFn,
-            timeout: EXTRA_EXTENDED_TIMEOUT,
+            timeout: EXTENDED_TIMEOUT,
         })
     })
 })

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -1,9 +1,7 @@
 import { getRequest } from '../support/requests.js'
-import {
-    assertIntercepts,
-    getDhis2Version,
-    EXTENDED_TIMEOUT,
-} from '../support/util.js'
+import { assertIntercepts, getDhis2Version } from '../support/util.js'
+
+const EXTENDED_TIMEOUT = { timeout: 35000 }
 
 const clearAndLogin = () => {
     cy.clearCookies()
@@ -19,10 +17,32 @@ const clearAndLogin = () => {
 }
 
 const commonTriggerFn = () => {
-    cy.reload()
+    cy.reload(true)
     clearAndLogin()
-    cy.reload()
+    cy.reload(true)
 }
+
+Cypress.on('uncaught:exception', (err) => {
+    if (
+        err.message.includes('Failed to fetch user locale: Error: Unauthorized')
+    ) {
+        return false
+    }
+    if (
+        err.message.includes(
+            'Failed to fetch user locale: Error: An unknown network error occurred'
+        )
+    ) {
+        return false
+    }
+    if (
+        err.message.includes(
+            'Failed to fetch user ID: Error: An unknown network error occurred'
+        )
+    ) {
+        return false
+    }
+})
 
 describe('Error handling check for all layer types', () => {
     it.skip('missing map', () => {

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -30,7 +30,7 @@ describe('Error handling check for all layer types', () => {
         })
     })
 
-    it.only('load thematic layer', () => {
+    it('load thematic layer', () => {
         // E2E - Thematic Layer [tFVpGPWj7MJ]
         const id = 'tFVpGPWj7MJ'
 

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -1,26 +1,24 @@
 import { getRequest } from '../support/requests.js'
 import { assertIntercepts, getDhis2Version } from '../support/util.js'
 
-const commonTriggerFn = () => {
-    cy.reload(true)
-}
-
 const EXTRA_EXTENDED_TIMEOUT = { timeout: 60000 }
 
+const commonTriggerFn = () => {
+    cy.reload(true)
+
+    cy.clearCookies()
+    cy.clearLocalStorage()
+
+    const username = Cypress.env('dhis2Username')
+    const password = Cypress.env('dhis2Password')
+    const baseUrl = Cypress.env('dhis2BaseUrl')
+
+    cy.loginByApi({ username, password, baseUrl })
+        .its('status')
+        .should('equal', 200)
+}
+
 describe('Error handling check for all layer types', () => {
-    beforeEach(() => {
-        cy.clearCookies()
-        cy.clearLocalStorage()
-
-        const username = Cypress.env('dhis2Username')
-        const password = Cypress.env('dhis2Password')
-        const baseUrl = Cypress.env('dhis2BaseUrl')
-
-        cy.loginByApi({ username, password, baseUrl })
-            .its('status')
-            .should('equal', 200)
-    })
-
     it.skip('missing map', () => {
         // !TODO: Handle error
         const id = '00000000000'
@@ -62,7 +60,6 @@ describe('Error handling check for all layer types', () => {
                 {
                     ...getRequest('getThematic_Analytics1'),
                     errors: ['network', 409],
-                    skip: true,
                 },
                 {
                     ...getRequest('getThematic_Analytics2'),

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -4,8 +4,6 @@ import { assertIntercepts, getDhis2Version } from '../support/util.js'
 const EXTRA_EXTENDED_TIMEOUT = { timeout: 60000 }
 
 const commonTriggerFn = () => {
-    cy.reload(true)
-
     cy.clearCookies()
     cy.clearLocalStorage()
 
@@ -16,6 +14,8 @@ const commonTriggerFn = () => {
     cy.loginByApi({ username, password, baseUrl })
         .its('status')
         .should('equal', 200)
+
+    cy.reload(true)
 }
 
 describe('Error handling check for all layer types', () => {

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -1,14 +1,47 @@
 const fs = require('fs')
 const path = require('path')
 
-const getAllFiles = (dirPath, arrayOfFiles = []) => {
+const excludedFiles = new Set([
+    'basemaps.cy.js',
+    'dataDownload.cy.js',
+    'dataTable.cy.js',
+    'fetcherrors.cy.js',
+    'filemenu.cy.js',
+    'interpretations.cy.js',
+    'keyboard.cy.js',
+    'manageLayerSources.cy.js',
+    'mapDownload.cy.js',
+    'orgUnitInfo.cy.js',
+    'plugin.cy.js',
+    'pushAnalytics.cy.js',
+    'requests.cy.js',
+    'routes.cy.js',
+    'systemsettings.cy.js',
+    'ui.cy.js',
+    'usersettings.cy.js',
+    'eventlayer.cy.js',
+    'multilayers.cy.js',
+    'externallayer.cy.js',
+    'orgunitlayer.cy.js',
+    'facilitylayer.cy.js',
+    'thematiclayer.cy.js',
+    'geojsonlayer.cy.js',
+    'trackedentitylayer.cy.js',
+])
+
+const filterFn = (file) => !excludedFiles.has(file)
+
+const getAllFiles = (dirPath, arrayOfFiles = [], filterFn = () => true) => {
     const files = fs.readdirSync(dirPath)
 
     files.forEach((file) => {
-        if (fs.statSync(path.join(dirPath, file)).isDirectory()) {
-            arrayOfFiles = getAllFiles(path.join(dirPath, file), arrayOfFiles)
-        } else if (path.extname(file) === '.js') {
-            arrayOfFiles.push(path.join(dirPath, file))
+        const fullPath = path.join(dirPath, file)
+        const stats = fs.statSync(fullPath)
+
+        if (stats.isDirectory()) {
+            arrayOfFiles = getAllFiles(fullPath, arrayOfFiles, filterFn)
+        } else if (path.extname(file) === '.js' && filterFn(file, fullPath)) {
+            arrayOfFiles.push(fullPath)
         }
     })
 
@@ -29,7 +62,7 @@ const createGroups = (files, numberOfGroups = 5) => {
 }
 
 const cypressSpecsPath = './cypress/integration'
-const specs = getAllFiles(cypressSpecsPath)
+const specs = getAllFiles(cypressSpecsPath, [], filterFn)
 const groupedSpecs = createGroups(specs)
 
 console.log(JSON.stringify(groupedSpecs))

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -3,66 +3,66 @@ const path = require('path')
 
 const NUMBER_OF_GROUPS = 5
 const CYPRESS_FILES = {
-    'cypress/integration/basemaps.cy.js': { include: false, duration: 60 },
-    'cypress/integration/dataDownload.cy.js': { include: false, duration: 60 },
-    'cypress/integration/dataTable.cy.js': { include: false, duration: 60 },
-    'cypress/integration/fetcherrors.cy.js': { include: false, duration: 30 },
-    'cypress/integration/filemenu.cy.js': { include: false, duration: 90 },
+    'cypress/integration/basemaps.cy.js': { include: true, duration: 60 },
+    'cypress/integration/dataDownload.cy.js': { include: true, duration: 60 },
+    'cypress/integration/dataTable.cy.js': { include: true, duration: 60 },
+    'cypress/integration/fetcherrors.cy.js': { include: true, duration: 30 },
+    'cypress/integration/filemenu.cy.js': { include: true, duration: 90 },
     'cypress/integration/interpretations.cy.js': {
-        include: false,
-        duration: 45,
-    },
-    'cypress/integration/keyboard.cy.js': { include: false, duration: 30 },
-    'cypress/integration/manageLayerSources.cy.js': {
-        include: false,
-        duration: 45,
-    },
-    'cypress/integration/mapDownload.cy.js': { include: false, duration: 15 },
-    'cypress/integration/orgUnitInfo.cy.js': { include: false, duration: 15 },
-    'cypress/integration/plugin.cy.js': { include: false, duration: 15 },
-    'cypress/integration/pushAnalytics.cy.js': { include: false, duration: 15 },
-    'cypress/integration/requests.cy.js': { include: false, duration: 120 },
-    'cypress/integration/requestsErrors.cy.js': {
         include: true,
+        duration: 45,
+    },
+    'cypress/integration/keyboard.cy.js': { include: true, duration: 30 },
+    'cypress/integration/manageLayerSources.cy.js': {
+        include: true,
+        duration: 45,
+    },
+    'cypress/integration/mapDownload.cy.js': { include: true, duration: 15 },
+    'cypress/integration/orgUnitInfo.cy.js': { include: true, duration: 15 },
+    'cypress/integration/plugin.cy.js': { include: true, duration: 15 },
+    'cypress/integration/pushAnalytics.cy.js': { include: true, duration: 15 },
+    'cypress/integration/requests.cy.js': { include: true, duration: 120 },
+    'cypress/integration/requestsErrors.cy.js': {
+        include: false,
         duration: 480,
     },
-    'cypress/integration/routes.cy.js': { include: false, duration: 120 },
+    'cypress/integration/routes.cy.js': { include: true, duration: 120 },
     'cypress/integration/systemsettings.cy.js': {
-        include: false,
+        include: true,
         duration: 45,
     },
-    'cypress/integration/ui.cy.js': { include: false, duration: 30 },
-    'cypress/integration/usersettings.cy.js': { include: false, duration: 45 },
+    'cypress/integration/ui.cy.js': { include: true, duration: 30 },
+    'cypress/integration/usersettings.cy.js': { include: true, duration: 45 },
     'cypress/integration/layers/eventlayer.cy.js': {
-        include: false,
+        include: true,
         duration: 210,
     },
     'cypress/integration/layers/multilayers.cy.js': {
-        include: false,
+        include: true,
         duration: 15,
     },
     'cypress/integration/layers/externallayer.cy.js': {
-        include: false,
+        include: true,
         duration: 15,
     },
     'cypress/integration/layers/orgunitlayer.cy.js': {
-        include: false,
+        include: true,
         duration: 30,
     },
     'cypress/integration/layers/facilitylayer.cy.js': {
-        include: false,
+        include: true,
         duration: 30,
     },
     'cypress/integration/layers/thematiclayer.cy.js': {
-        include: false,
+        include: true,
         duration: 240,
     },
     'cypress/integration/layers/geojsonlayer.cy.js': {
-        include: false,
+        include: true,
         duration: 30,
     },
     'cypress/integration/layers/trackedentitylayer.cy.js': {
-        include: false,
+        include: true,
         duration: 60,
     },
 }

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -48,7 +48,7 @@ const getAllFiles = (dirPath, arrayOfFiles = [], filterFn = () => true) => {
     return arrayOfFiles
 }
 
-const createGroups = (files, numberOfGroups = 5) => {
+const createGroups = (files, numberOfGroups = 1) => {
     const groups = []
     for (let i = 0; i < numberOfGroups; i++) {
         groups.push([])

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 
-const NUMBER_OF_GROUPS = 5
+const NUMBER_OF_GROUPS = 1
 const CYPRESS_FILES = {
     'cypress/integration/basemaps.cy.js': { include: false, duration: 60 },
     'cypress/integration/dataDownload.cy.js': { include: false, duration: 60 },

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 
-const NUMBER_OF_GROUPS = 1
+const NUMBER_OF_GROUPS = 5
 const CYPRESS_FILES = {
     'cypress/integration/basemaps.cy.js': { include: false, duration: 60 },
     'cypress/integration/dataDownload.cy.js': { include: false, duration: 60 },
@@ -118,7 +118,7 @@ const createGroupsByDuration = (files, numberOfGroups = NUMBER_OF_GROUPS) => {
     // Sort longest duration first (greedy assignment works better this way)
     enriched.sort((a, b) => b.duration - a.duration)
 
-    const groups = Array.from({ length: numberOfGroups }, (_, i) => ({
+    let groups = Array.from({ length: numberOfGroups }, (_, i) => ({
         id: i + 1,
         tests: [],
         totalDuration: 0,
@@ -128,6 +128,7 @@ const createGroupsByDuration = (files, numberOfGroups = NUMBER_OF_GROUPS) => {
         groups[0].tests.push(file)
         groups[0].totalDuration += file.duration
     }
+    groups = groups.map(({ id, tests }) => ({ id, tests }))
     return groups
 }
 
@@ -139,11 +140,12 @@ const createGroups = (files, numberOfGroups = NUMBER_OF_GROUPS) => {
     const durations = Object.values(CYPRESS_FILES)
         .map((f) => f.duration)
         .filter((d) => typeof d === 'number' && !isNaN(d))
+    const adjustedNumberOfGroups = Math.min(files.length, numberOfGroups)
 
     if (durations.length === 0) {
-        return createGroupsStandard(files, numberOfGroups)
+        return createGroupsStandard(files, adjustedNumberOfGroups)
     } else {
-        return createGroupsByDuration(files, numberOfGroups)
+        return createGroupsByDuration(files, adjustedNumberOfGroups)
     }
 }
 

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -128,7 +128,7 @@ const createGroupsByDuration = (files, numberOfGroups = NUMBER_OF_GROUPS) => {
         groups[0].tests.push(f.file)
         groups[0].totalDuration += f.duration
     }
-    return groups
+    return groups.sort((a, b) => a.id - b.id)
 }
 
 const createGroups = (files, numberOfGroups = NUMBER_OF_GROUPS) => {

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -118,17 +118,16 @@ const createGroupsByDuration = (files, numberOfGroups = NUMBER_OF_GROUPS) => {
     // Sort longest duration first (greedy assignment works better this way)
     enriched.sort((a, b) => b.duration - a.duration)
 
-    let groups = Array.from({ length: numberOfGroups }, (_, i) => ({
+    const groups = Array.from({ length: numberOfGroups }, (_, i) => ({
         id: i + 1,
         tests: [],
         totalDuration: 0,
     }))
-    for (const file of enriched) {
+    for (const f of enriched) {
         groups.sort((a, b) => a.totalDuration - b.totalDuration)
-        groups[0].tests.push(file)
-        groups[0].totalDuration += file.duration
+        groups[0].tests.push(f.file)
+        groups[0].totalDuration += f.duration
     }
-    groups = groups.map(({ id, tests }) => ({ id, tests }))
     return groups
 }
 

--- a/src/components/app/useLoadDataStore.js
+++ b/src/components/app/useLoadDataStore.js
@@ -53,7 +53,7 @@ export const useLoadDataStore = () => {
                         }
                     })
                     .catch(() => {
-                        // Try to create key, if it already exists, fall back to update
+                        // Create key if missing in namespace
                         engine
                             .mutate({
                                 resource: resourceLayerSourcesVisibility,
@@ -64,23 +64,6 @@ export const useLoadDataStore = () => {
                                 dispatch(
                                     initLayerSources(layerSourceDefaultIds)
                                 )
-                            })
-                            .catch(() => {
-                                // Try update
-                                engine
-                                    .mutate({
-                                        resource:
-                                            resourceLayerSourcesVisibility,
-                                        type: 'update',
-                                        data: layerSourceDefaultIds,
-                                    })
-                                    .then(() => {
-                                        dispatch(
-                                            initLayerSources(
-                                                layerSourceDefaultIds
-                                            )
-                                        )
-                                    })
                             })
                     })
             }

--- a/src/components/app/useLoadDataStore.js
+++ b/src/components/app/useLoadDataStore.js
@@ -53,7 +53,7 @@ export const useLoadDataStore = () => {
                         }
                     })
                     .catch(() => {
-                        // Create key if missing in namespace
+                        // Try to create key, if it already exists, fall back to update
                         engine
                             .mutate({
                                 resource: resourceLayerSourcesVisibility,
@@ -64,6 +64,23 @@ export const useLoadDataStore = () => {
                                 dispatch(
                                     initLayerSources(layerSourceDefaultIds)
                                 )
+                            })
+                            .catch(() => {
+                                // Try update
+                                engine
+                                    .mutate({
+                                        resource:
+                                            resourceLayerSourcesVisibility,
+                                        type: 'update',
+                                        data: layerSourceDefaultIds,
+                                    })
+                                    .then(() => {
+                                        dispatch(
+                                            initLayerSources(
+                                                layerSourceDefaultIds
+                                            )
+                                        )
+                                    })
                             })
                     })
             }


### PR DESCRIPTION
### Description

The version of `requestsErrors.cy.js` in this PR consistently passes on v40 and v42 but fails on v41.

<img width="1283" height="875" alt="image" src="https://github.com/user-attachments/assets/42b80abe-a033-4e86-8d1a-28f8c1cea034" />

In this test, the most reliable approach seems to be clearing the browser cache between each step in order to assess request failures independently. This also requires re-logging in.

The failures on v41 appear to be related to the login step:

<img width="1498" height="939" alt="image" src="https://github.com/user-attachments/assets/5d95e834-515a-4658-beb3-807d7dca6635" />

To properly address this issue, we would likely need to understand the differences in the login process across backend versions.

**At the moment, the time required to investigate these failures seems to outweigh the benefits of maintaining this test. This is especially true since our current approach to handling such errors is inconsistent—or in some cases, missing entirely. I will just deactivate `requestsErrors.cy.js` for now.**

As part of the investigation, we also developed some improvements: we can now generate the test matrix based on specified test duration rather than splitting files into five arbitrary groups.