### PR TITLE
fix: hide 'No data found' message while OU profile data is loading [DHIS2-19268]

### DIFF
--- a/src/components/orgunits/OrgUnitData.jsx
+++ b/src/components/orgunits/OrgUnitData.jsx
@@ -60,25 +60,26 @@ const OrgUnitData = ({ id }) => {
                         <CircularLoader />
                     </div>
                 )}
-                {Array.isArray(data?.profile.dataItems) &&
-                data.profile.dataItems.length ? (
-                    <table data-test="org-unit-data-table">
-                        <tbody>
-                            {data.profile.dataItems.map(
-                                ({ id, label, value }) => (
-                                    <tr key={id}>
-                                        <th>{label}</th>
-                                        <td>{value}</td>
-                                    </tr>
-                                )
-                            )}
-                        </tbody>
-                    </table>
-                ) : (
-                    <div className={styles.noData}>
-                        {i18n.t('No data found for this period.')}
-                    </div>
-                )}
+                {!loading &&
+                    (Array.isArray(data?.profile.dataItems) &&
+                    data.profile.dataItems.length ? (
+                        <table data-test="org-unit-data-table">
+                            <tbody>
+                                {data.profile.dataItems.map(
+                                    ({ id, label, value }) => (
+                                        <tr key={id}>
+                                            <th>{label}</th>
+                                            <td>{value}</td>
+                                        </tr>
+                                    )
+                                )}
+                            </tbody>
+                        </table>
+                    ) : (
+                        <div className={styles.noData}>
+                            {i18n.t('No data found for this period.')}
+                        </div>
+                    ))}
             </div>
         </div>
     )

--- a/src/components/orgunits/styles/OrgUnitData.module.css
+++ b/src/components/orgunits/styles/OrgUnitData.module.css
@@ -8,6 +8,7 @@
 
 .dataTable {
     position: relative;
+    min-height: 72px;
 }
 
 .dataTable table {


### PR DESCRIPTION
### Description

Fixes DHIS2-19268 - the 'No data found for this period.' message was shown simultaneously with the loading spinner when changing years in the OU profile, because the empty-state check fired regardless of loading state. Also adds a min-height to the data table so the spinner is positioned below the period selector rather than overlapping it.

Implements [DHIS2-19268](https://dhis2.atlassian.net/browse/DHIS2-19268)

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested _N/A_
- [ ] Cypress and/or Jest tests added/updated _N/A_
- [ ] Docs added _N/A_
- [ ] d2-ci dependencies replaced (analytics or maps-gl link https://github.com/dhis2/[lib]/pull/XXX) _N/A_
- [x] Tester approved (BR)


---

### Screenshots
Before:
https://www.loom.com/share/8b3e4a01cd8f43e2a0e8dc66948a8270
After:
https://www.loom.com/share/7df1ce0466cd45b2980dc16645dba8f4


[DHIS2-19268]: https://dhis2.atlassian.net/browse/DHIS2-19268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ