### PR TITLE
feat: add filter operators `<=` and `>=` and correct `<` and `>` in data table [DHIS2-19988]

### DIFF
--- a/docs/maps.md
+++ b/docs/maps.md
@@ -374,8 +374,11 @@ The data table displays the data forming the thematic layer.
 
     -   VALUE
 
-        filter values by given numbers and/or ranges, for example:
-        2,\>3&\<8
+        filter values by given numbers and/or ranges using `>` (greater
+        than), `<` (less than), `>=` (greater than or equal), or `<=`
+        (less than or equal). Use `,` for OR and `&` for AND logic, for
+        example: `2,>3&<8` matches the value 2, or any value greater
+        than 3 and less than 8
 
     -   LEGEND
 
@@ -387,7 +390,8 @@ The data table displays the data forming the thematic layer.
 
     -   LEVEL
 
-        filter level by numbers and/or ranges, for example: 2,\>3&\<8
+        filter level by numbers and/or ranges, using the same operators
+        as VALUE, for example: `2,>3&<8`
 
     -   PARENT
 

--- a/docs/maps.md
+++ b/docs/maps.md
@@ -378,7 +378,7 @@ The data table displays the data forming the thematic layer.
         than), `<` (less than), `>=` (greater than or equal), or `<=`
         (less than or equal). Use `,` for OR and `&` for AND logic, for
         example: `2,>3&<8` matches the value 2, or any value greater
-        than 3 and less than 8
+        than 3 and less than 8.
 
     -   LEGEND
 

--- a/src/util/__tests__/filter.spec.js
+++ b/src/util/__tests__/filter.spec.js
@@ -21,16 +21,37 @@ describe('filterData', () => {
         expect(filterData(data, filters)).toEqual([{ a: '2' }])
     })
 
-    // TODO the following tests fail because the code has a bug
-    it.skip('should filter data based on a numeric filter', () => {
+    it('should filter data based on a numeric filter', () => {
         const data = [{ a: 1 }, { a: 2 }, { a: 3 }]
         const filters = { a: '>1' }
         expect(filterData(data, filters)).toEqual([{ a: 2 }, { a: 3 }])
     })
 
-    it.skip('should handle complex numeric filters', () => {
+    it('should handle complex numeric filters', () => {
         const data = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 5 }]
         const filters = { a: '>1&<5' }
+        expect(filterData(data, filters)).toEqual([
+            { a: 2 },
+            { a: 3 },
+            { a: 4 },
+        ])
+    })
+
+    it('should filter data using >= operator', () => {
+        const data = [{ a: 1 }, { a: 2 }, { a: 3 }]
+        const filters = { a: '>=2' }
+        expect(filterData(data, filters)).toEqual([{ a: 2 }, { a: 3 }])
+    })
+
+    it('should filter data using <= operator', () => {
+        const data = [{ a: 1 }, { a: 2 }, { a: 3 }]
+        const filters = { a: '<=2' }
+        expect(filterData(data, filters)).toEqual([{ a: 1 }, { a: 2 }])
+    })
+
+    it('should handle complex numeric filters with >= and <=', () => {
+        const data = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 5 }]
+        const filters = { a: '>=2&<=4' }
         expect(filterData(data, filters)).toEqual([
             { a: 2 },
             { a: 3 },

--- a/src/util/filter.js
+++ b/src/util/filter.js
@@ -42,14 +42,20 @@ export const numericFilter = (value, filter) => {
 
 // Returns true if the filter is true
 const isTrueFilter = (value, filter) => {
+    if (filter.includes('>=')) {
+        return value >= Number(filter.split('>=')[1])
+    }
+
+    if (filter.includes('<=')) {
+        return value <= Number(filter.split('<=')[1])
+    }
+
     if (filter.includes('>')) {
-        // GREATER THAN
-        return value >= Number(filter.split('>')[1])
+        return value > Number(filter.split('>')[1])
     }
 
     if (filter.includes('<')) {
-        // LESS THAN
-        return value <= Number(filter.split('<')[1])
+        return value < Number(filter.split('<')[1])
     }
 
     return value === Number(filter) // Equal number


### PR DESCRIPTION
### Description

Filtering the data table with `<82.19` would include the row with value `82.19` — the `<` and `>` operators were behaving as `<=` and `>=`.

Also added support f for `<=` and `>=` operators.


Implements [DHIS2-19988X](https://dhis2.atlassian.net/browse/DHIS2-19988)

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested _N/A_
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added
- [ ] d2-ci dependencies replaced (analytics or maps-gl link https://github.com/dhis2/[lib]/pull/XXX) _N/A_
- [x] Tester approved (BR) 

### How to test?

  1. Open a map with a thematic layer (e.g. "ANC: 1st visit coverage (%) by district last year")
  2. Open the data table
  3. Filter with `<81.58` → row with value 81.58 should **not** appear
  4. Filter with `>81.58` → row with value 81.58 should **not** appear
  5. Filter with `<=81.58` → row with value 81.58**should** appear
  6. Filter with `>=81.58` → row with value 81.58 **should** appear

---

### Notes

  Two existing tests were previously skipped with the comment "TODO the following tests fail because the   
  code has a bug" — these are now unskipped and passing.

---

### Screenshots

Before:
<img width="320" height="146" alt="image" src="https://github.com/user-attachments/assets/b30a900e-757c-43aa-93e8-7ae22e286046" />
<img width="499" height="185" alt="image" src="https://github.com/user-attachments/assets/e77cc47c-5ba2-497f-9ca2-11eacd412460" />

After:
<img width="238" height="125" alt="image" src="https://github.com/user-attachments/assets/b10715f4-0fb4-4d82-acc8-ff8f50344ddc" />
<img width="255" height="134" alt="image" src="https://github.com/user-attachments/assets/6e1ce351-308c-4aca-b92a-d5f4657c0895" />
<img width="307" height="146" alt="image" src="https://github.com/user-attachments/assets/64483fd2-6ad4-465a-a4da-26dcc4190691" />
<img width="238" height="182" alt="image" src="https://github.com/user-attachments/assets/9f59c519-04a9-4db8-88e9-760aaa23734b" />


