### PR TITLE
fix: globe cursor data table resize [DHIS2-19805]

### DIFF
--- a/src/components/datatable/ResizeHandle.jsx
+++ b/src/components/datatable/ResizeHandle.jsx
@@ -26,6 +26,7 @@ const ResizeHandle = ({
     }
 
     const onDrag = (evt) => {
+        evt.preventDefault() // Prevents globe/unavailable cursor in Chrome
         const height = getHeight(evt || window.event)
 
         if (height && onResize) {

--- a/src/components/datatable/ResizeHandle.jsx
+++ b/src/components/datatable/ResizeHandle.jsx
@@ -3,6 +3,13 @@ import React from 'react'
 import { IconDrag } from '../core/icons.jsx'
 import styles from './styles/ResizeHandle.module.css'
 
+// Pre-decoded so setDragImage doesn't fall back to the macOS Chrome globe icon
+// when the image isn't yet `complete` on the dragstart tick.
+// https://www.sam.today/blog/html5-dnd-globe-icon
+const EMPTY_DRAG_IMAGE = new Image(1, 1)
+EMPTY_DRAG_IMAGE.src =
+    'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+
 const ResizeHandle = ({
     onResize,
     onResizeEnd,
@@ -12,12 +19,10 @@ const ResizeHandle = ({
     let dragHeight = 0
 
     const onDragStart = (evt) => {
-        // Set the drag ghost image to a transparent 1x1px
         // https://stackoverflow.com/questions/7680285/how-do-you-turn-off-setdragimage
-        const img = document.createElement('img')
-        img.src =
-            'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
-        evt.dataTransfer.setDragImage(img, 0, 0)
+        if (EMPTY_DRAG_IMAGE.complete) {
+            evt.dataTransfer.setDragImage(EMPTY_DRAG_IMAGE, 0, 0)
+        }
 
         evt.dataTransfer.setData('text/plain', 'node') // Required to initialize dragging in Firefox
 


### PR DESCRIPTION
### Description

  The "globe" isn't actually a cursor — it's the drag image that macOS Chrome falls back to when the image passed to `setDragImage()` isn't yet
  decoded. The handler created a fresh `<img>` and assigned `.src` on the dragstart tick, so the image was always still loading when
  `setDragImage(img, 0, 0)` ran.

  This PR:
  - Pre-decodes the 1×1 transparent GIF at module scope so it's loaded before any drag starts
  - Guards `setDragImage` on `EMPTY_DRAG_IMAGE.complete`
  - Removes the earlier `evt.preventDefault()` in the dragover handler — that controls drop-acceptance (no-drop vs move cursor), not the drag image,
   and was orthogonal to this bug

  Reference: https://www.sam.today/blog/html5-dnd-globe-icon

  Fixes [DHIS2-19805](https://dhis2.atlassian.net/browse/DHIS2-19805)

  ### Test plan

  - Open a map with a thematic layer
  - Open the data table (Show/hide data table)
  - Drag the resize handle to resize the table
  - Verify no globe icon appears next to the cursor (test on Chrome / macOS)
  - Verify the data table still resizes correctly across Chrome, Firefox, Safari (Mac + Windows)

  ---

  ### Quality checklist

  Add _N/A_ to items that are not applicable.

  - [ ] Dashboard tested _N/A_
  - [ ] Cypress and/or Jest tests added/updated _N/A_
  - [ ] Docs added _N/A_
  - [ ] d2-ci dependencies replaced _N/A_
  - [x] Tester approved (JJ)

  _AI Assisted_

[DHIS2-19805]: https://dhis2.atlassian.net/browse/DHIS2-19805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ