### PR TITLE
feat: new classification methods and edge-case handling [PR2] [DHIS2-18242]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-03-12T18:11:56.380Z\n"
-"PO-Revision-Date: 2026-03-12T18:11:56.380Z\n"
+"POT-Creation-Date: 2026-04-24T10:52:00.804Z\n"
+"PO-Revision-Date: 2026-04-24T10:52:00.804Z\n"
 
 msgid "2020"
 msgstr "2020"
@@ -1637,6 +1637,18 @@ msgstr "Equal intervals"
 
 msgid "Equal counts"
 msgstr "Equal counts"
+
+msgid "Natural breaks (intervals)"
+msgstr "Natural breaks (intervals)"
+
+msgid "Natural breaks (clusters)"
+msgstr "Natural breaks (clusters)"
+
+msgid "Pretty breaks"
+msgstr "Pretty breaks"
+
+msgid "Logarithmic scale"
+msgstr "Logarithmic scale"
 
 msgid "Symbol"
 msgstr "Symbol"

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "redux": "^4.2.1",
         "redux-logger": "^3.0.6",
         "redux-thunk": "^2.4.2",
+        "simple-statistics": "^7.8.9",
         "styled-jsx": "^4.0.1",
         "url-polyfill": "^1.1.14"
     },

--- a/src/components/classification/LegendSetSelect.jsx
+++ b/src/components/classification/LegendSetSelect.jsx
@@ -1,7 +1,7 @@
 import { useDataQuery } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { setLegendSet } from '../../actions/layerEdit.js'
 import { SelectField } from '../core/index.js'
@@ -21,10 +21,21 @@ const style = {
     width: '100%',
 }
 
-const LegendSetSelect = ({ legendSetError }) => {
+const LegendSetSelect = ({ defaultLegendSet, legendSetError }) => {
     const legendSet = useSelector((state) => state.layerEdit.legendSet)
     const dispatch = useDispatch()
     const { loading, error, data } = useDataQuery(LEGEND_SETS_QUERY)
+
+    useEffect(() => {
+        if (!legendSet && data?.sets.legendSets?.length) {
+            const legendSets = data.sets.legendSets
+            const defaultItem = defaultLegendSet
+                ? legendSets.find((ls) => ls.id === defaultLegendSet.id) ??
+                  legendSets[0]
+                : legendSets[0]
+            dispatch(setLegendSet(defaultItem))
+        }
+    }, [legendSet, data, defaultLegendSet, dispatch])
 
     return (
         <SelectField
@@ -40,6 +51,9 @@ const LegendSetSelect = ({ legendSetError }) => {
 }
 
 LegendSetSelect.propTypes = {
+    defaultLegendSet: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+    }),
     legendSetError: PropTypes.string,
 }
 

--- a/src/components/classification/LegendTypeSelect.jsx
+++ b/src/components/classification/LegendTypeSelect.jsx
@@ -4,8 +4,8 @@ import { connect } from 'react-redux'
 import { setClassification } from '../../actions/layerEdit.js'
 import {
     getLegendTypes,
-    CLASSIFICATION_EQUAL_INTERVALS,
-    CLASSIFICATION_EQUAL_COUNTS,
+    getClassificationTypes,
+    CLASSIFICATION_AUTO_DEFAULT,
 } from '../../constants/layers.js'
 import { Radio, RadioGroup } from '../core/index.js'
 
@@ -13,15 +13,17 @@ import { Radio, RadioGroup } from '../core/index.js'
 const LegendTypeSelect = ({ mapType, method, setClassification }) =>
     method ? (
         <RadioGroup
-            value={
-                method === CLASSIFICATION_EQUAL_COUNTS
-                    ? CLASSIFICATION_EQUAL_INTERVALS
+            value={String(
+                getClassificationTypes()
+                    .map(({ id }) => id)
+                    .includes(method)
+                    ? CLASSIFICATION_AUTO_DEFAULT
                     : method
-            }
+            )}
             onChange={(method) => setClassification(Number(method))}
         >
             {getLegendTypes(mapType === 'BUBBLE').map(({ id, name }) => (
-                <Radio key={id} value={id} label={name} />
+                <Radio key={id} value={String(id)} label={name} />
             ))}
         </RadioGroup>
     ) : null

--- a/src/components/classification/NumericLegendStyle.jsx
+++ b/src/components/classification/NumericLegendStyle.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import { connect } from 'react-redux'
-import { setClassification, setLegendSet } from '../../actions/layerEdit.js'
+import { setClassification } from '../../actions/layerEdit.js'
 import {
     CLASSIFICATION_PREDEFINED,
-    CLASSIFICATION_EQUAL_INTERVALS,
+    CLASSIFICATION_AUTO_DEFAULT,
     CLASSIFICATION_SINGLE_COLOR,
 } from '../../constants/layers.js'
 import Classification from './Classification.jsx'
@@ -18,9 +18,7 @@ const NumericLegendStyle = (props) => {
         mapType,
         method,
         dataItem,
-        legendSet,
         setClassification,
-        setLegendSet,
         legendSetError,
         style,
     } = props
@@ -35,17 +33,10 @@ const NumericLegendStyle = (props) => {
             setClassification(
                 dataItem && dataItem.legendSet
                     ? CLASSIFICATION_PREDEFINED
-                    : CLASSIFICATION_EQUAL_INTERVALS
+                    : CLASSIFICATION_AUTO_DEFAULT
             )
         }
     }, [method, dataItem, setClassification])
-
-    useEffect(() => {
-        // Set legend set defined for data item in use by default
-        if (isPredefined && !legendSet && dataItem?.legendSet) {
-            setLegendSet(dataItem.legendSet)
-        }
-    }, [isPredefined, legendSet, dataItem, setLegendSet])
 
     return (
         <div style={style}>
@@ -57,7 +48,10 @@ const NumericLegendStyle = (props) => {
             {isSingleColor ? (
                 <SingleColor />
             ) : isPredefined ? (
-                <LegendSetSelect legendSetError={legendSetError} />
+                <LegendSetSelect
+                    legendSetError={legendSetError}
+                    defaultLegendSet={dataItem?.legendSet}
+                />
             ) : (
                 <Classification />
             )}
@@ -67,9 +61,7 @@ const NumericLegendStyle = (props) => {
 
 NumericLegendStyle.propTypes = {
     setClassification: PropTypes.func.isRequired,
-    setLegendSet: PropTypes.func.isRequired,
     dataItem: PropTypes.object,
-    legendSet: PropTypes.object,
     legendSetError: PropTypes.string,
     mapType: PropTypes.string,
     method: PropTypes.number,
@@ -79,7 +71,6 @@ NumericLegendStyle.propTypes = {
 export default connect(
     ({ layerEdit }) => ({
         method: layerEdit.method,
-        legendSet: layerEdit.legendSet,
     }),
-    { setClassification, setLegendSet }
+    { setClassification }
 )(NumericLegendStyle)

--- a/src/components/legend/Bubbles.jsx
+++ b/src/components/legend/Bubbles.jsx
@@ -16,26 +16,27 @@ export const digitWidth = 6.8
 export const guideLength = 16
 export const textPadding = 4
 
-const Bubbles = ({
-    radiusLow,
-    radiusHigh,
+const filterBubbleText = (bubbles, showNumbers) => {
+    if (!showNumbers) {
+        return
+    }
+    bubbles.forEach((b, i) => {
+        if (!showNumbers.includes(i)) {
+            delete b.text
+        }
+    })
+}
+
+const computeBubbleLayout = ({
+    bubbleClasses,
     color,
     minValue,
     maxValue,
-    classes,
-    isPlugin,
+    scale,
+    radiusLow,
+    radiusHigh,
+    legendWidth,
 }) => {
-    const legendWidth = isPlugin ? 150 : 245
-    const noDataClass = classes.find((c) => c.noData === true)
-    const bubbleClasses = classes.filter((c) => !c.noData)
-
-    const height = radiusHigh * 2 + 4
-    const scale = scaleSqrt().range([radiusLow, radiusHigh])
-
-    if (isNaN(radiusLow) || isNaN(radiusHigh)) {
-        return null
-    }
-
     const bubbles = bubbleClasses.length
         ? createBubbleItems({
               classes: bubbleClasses,
@@ -53,32 +54,76 @@ const Bubbles = ({
               radiusHigh,
           })
 
-    const { alternate, offset, showNumbers } = computeLayout({
+    const layout = computeLayout({
         bubbles,
         bubbleClasses,
         radiusHigh,
         legendWidth,
     })
+    filterBubbleText(bubbles, layout.showNumbers)
 
-    if (showNumbers) {
-        bubbles.forEach((b, i) => {
-            if (!showNumbers.includes(i)) {
-                delete b.text
-            }
-        })
+    return { bubbles, alternate: layout.alternate, offset: layout.offset }
+}
+
+const Bubbles = ({
+    radiusLow,
+    radiusHigh,
+    color,
+    minValue,
+    maxValue,
+    classes,
+    isPlugin,
+}) => {
+    const legendWidth = isPlugin ? 150 : 245
+    const noDataClass = classes.find((c) => c.noData === true)
+    const bubbleClasses = classes.filter((c) => !c.noData)
+    const hasDataRange = minValue != null && maxValue != null
+    const height = hasDataRange
+        ? radiusHigh * 2 + 4
+        : THEMATIC_RADIUS_DEFAULT + 2
+    const scale = scaleSqrt().range([radiusLow, radiusHigh])
+    const noDataTranslateY = hasDataRange ? 20 : 0
+
+    if (isNaN(radiusLow) || isNaN(radiusHigh)) {
+        return null
     }
+
+    if (!hasDataRange && !noDataClass) {
+        return null
+    }
+
+    let bubbles = []
+    let alternate = false
+    let offset = '2'
+
+    if (hasDataRange) {
+        ;({ bubbles, alternate, offset } = computeBubbleLayout({
+            bubbleClasses,
+            color,
+            minValue,
+            maxValue,
+            scale,
+            radiusLow,
+            radiusHigh,
+            legendWidth,
+        }))
+    }
+
+    const xTranslate = alternate ? offset : '2'
 
     return (
         <div style={style}>
             <svg
                 width={legendWidth}
                 height={
-                    height +
-                    20 +
-                    (noDataClass ? THEMATIC_RADIUS_DEFAULT + 1 : 0)
+                    hasDataRange
+                        ? height +
+                          20 +
+                          (noDataClass ? THEMATIC_RADIUS_DEFAULT + 1 : 0)
+                        : 20
                 }
             >
-                <g transform={`translate(${alternate ? offset : '2'} 10)`}>
+                <g transform={`translate(${xTranslate} 10)`}>
                     {bubbles.map((bubble, i) => (
                         <Bubble
                             key={i}
@@ -93,9 +138,7 @@ const Bubbles = ({
                     <>
                         {' '}
                         <circle
-                            transform={`translate(${
-                                alternate ? offset : '2'
-                            } 20)`}
+                            transform={`translate(${xTranslate} ${noDataTranslateY})`}
                             cx={radiusHigh}
                             cy={height}
                             r={THEMATIC_RADIUS_DEFAULT}
@@ -106,9 +149,7 @@ const Bubbles = ({
                             }}
                         />
                         <text
-                            transform={`translate(${
-                                alternate ? offset : '2'
-                            } 20)`}
+                            transform={`translate(${xTranslate} ${noDataTranslateY})`}
                             x={radiusHigh + THEMATIC_RADIUS_DEFAULT + 5}
                             y={height + 4}
                             fontSize={12}

--- a/src/constants/layers.js
+++ b/src/constants/layers.js
@@ -150,10 +150,11 @@ export const CLASSIFICATION_PRETTY_BREAKS = 6
 export const CLASSIFICATION_LOGARITHMIC = 7
 export const CLASSIFICATION_STANDARD_DEVIATION = 8
 export const CLASSIFICATION_SINGLE_COLOR = 10
+export const CLASSIFICATION_AUTO_DEFAULT = CLASSIFICATION_EQUAL_INTERVALS
 
 export const getLegendTypes = (isBubble) => [
     {
-        id: CLASSIFICATION_EQUAL_INTERVALS,
+        id: CLASSIFICATION_AUTO_DEFAULT,
         name: i18n.t('Automatic color legend'),
     },
     {

--- a/src/constants/layers.js
+++ b/src/constants/layers.js
@@ -144,6 +144,11 @@ export const EE_BUFFER = 5000
 export const CLASSIFICATION_PREDEFINED = 1
 export const CLASSIFICATION_EQUAL_INTERVALS = 2
 export const CLASSIFICATION_EQUAL_COUNTS = 3
+export const CLASSIFICATION_NATURAL_BREAKS_RANGES = 4
+export const CLASSIFICATION_NATURAL_BREAKS_CLUSTERS = 5
+export const CLASSIFICATION_PRETTY_BREAKS = 6
+export const CLASSIFICATION_LOGARITHMIC = 7
+export const CLASSIFICATION_STANDARD_DEVIATION = 8
 export const CLASSIFICATION_SINGLE_COLOR = 10
 
 export const getLegendTypes = (isBubble) => [
@@ -173,6 +178,26 @@ export const getClassificationTypes = () => [
     {
         id: CLASSIFICATION_EQUAL_COUNTS,
         name: i18n.t('Equal counts'),
+    },
+    {
+        id: CLASSIFICATION_NATURAL_BREAKS_RANGES,
+        name: i18n.t('Natural breaks (intervals)'),
+    },
+    {
+        id: CLASSIFICATION_NATURAL_BREAKS_CLUSTERS,
+        name: i18n.t('Natural breaks (clusters)'),
+    },
+    {
+        id: CLASSIFICATION_PRETTY_BREAKS,
+        name: i18n.t('Pretty breaks'),
+    },
+    {
+        id: CLASSIFICATION_LOGARITHMIC,
+        name: i18n.t('Logarithmic scale'),
+    },
+    {
+        id: CLASSIFICATION_STANDARD_DEVIATION,
+        name: i18n.t('Standard deviation'),
     },
 ]
 

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -237,6 +237,10 @@ const thematicLoader = async ({
         const regularItems = legend.items.filter((item) => !item.noData)
         minValue = regularItems[0].startValue
         maxValue = regularItems.at(-1).endValue
+        if (legend.bubbles) {
+            legend.bubbles.minValue ??= minValue
+            legend.bubbles.maxValue ??= maxValue
+        }
     }
 
     const getRadiusForValue = scaleSqrt()

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -228,6 +228,7 @@ const thematicLoader = async ({
         getLegendItemForValue({
             value,
             valueFormat,
+            method,
             legendItems: legend.items.filter((item) => !item.noData),
             clamp: method !== CLASSIFICATION_PREDEFINED,
         })

--- a/src/reducers/layerEdit.js
+++ b/src/reducers/layerEdit.js
@@ -2,9 +2,8 @@ import * as types from '../constants/actionTypes.js'
 import { EVENT_STATUS_ALL } from '../constants/eventStatuses.js'
 import {
     CLASSIFICATION_SINGLE_COLOR,
-    CLASSIFICATION_EQUAL_INTERVALS,
-    CLASSIFICATION_EQUAL_COUNTS,
     CLASSIFICATION_PREDEFINED,
+    getClassificationTypes,
     THEMATIC_CHOROPLETH,
     EE_BUFFER,
     NONE,
@@ -279,10 +278,9 @@ const layerEdit = (state = null, action) => {
 
             if (
                 state.method === CLASSIFICATION_SINGLE_COLOR ||
-                ![
-                    CLASSIFICATION_EQUAL_INTERVALS,
-                    CLASSIFICATION_EQUAL_COUNTS,
-                ].includes(action.method)
+                !getClassificationTypes()
+                    .map((t) => t.id)
+                    .includes(action.method)
             ) {
                 delete newState.colorScale
                 delete newState.classes

--- a/src/util/__tests__/bubbles.spec.js
+++ b/src/util/__tests__/bubbles.spec.js
@@ -32,6 +32,34 @@ jest.mock('../numbers.js', () => ({
 }))
 
 describe('createBubbleItems', () => {
+    it('should return a single bubble when minValue === maxValue', () => {
+        const mockScale = { domain: jest.fn(() => () => 5) }
+        const classes = [{ startValue: 7, endValue: 7, color: '#abc' }]
+        const bubbles = createBubbleItems({
+            classes,
+            minValue: 7,
+            maxValue: 7,
+            scale: mockScale,
+            radiusHigh: 20,
+        })
+        expect(bubbles).toHaveLength(1)
+        expect(bubbles[0].text).toBe('7')
+        expect(bubbles[0].color).toBe('#abc')
+    })
+
+    it('should not produce NaN text when minValue === maxValue', () => {
+        const mockScale = { domain: jest.fn(() => () => 5) }
+        const classes = [{ startValue: 42, endValue: 42, color: '#def' }]
+        const bubbles = createBubbleItems({
+            classes,
+            minValue: 42,
+            maxValue: 42,
+            scale: mockScale,
+            radiusHigh: 20,
+        })
+        expect(bubbles[0].text).not.toContain('NaN')
+    })
+
     it('should create bubble items from class breaks', () => {
         const mockScale = {
             domain: jest.fn(() => (value) => value * 2),
@@ -57,6 +85,34 @@ describe('createBubbleItems', () => {
 })
 
 describe('createSingleColorBubbles', () => {
+    it('should return a single bubble when minValue === maxValue', () => {
+        const mockScale = { domain: jest.fn(() => () => 5) }
+        const bubbles = createSingleColorBubbles({
+            color: '#abc',
+            minValue: 50,
+            maxValue: 50,
+            scale: mockScale,
+            radiusLow: 5,
+            radiusHigh: 20,
+        })
+        expect(bubbles).toHaveLength(1)
+        expect(bubbles[0].text).toBe('50')
+        expect(bubbles[0].color).toBe('#abc')
+    })
+
+    it('should not produce NaN text when minValue === maxValue', () => {
+        const mockScale = { domain: jest.fn(() => () => 5) }
+        const bubbles = createSingleColorBubbles({
+            color: '#abc',
+            minValue: 100,
+            maxValue: 100,
+            scale: mockScale,
+            radiusLow: 5,
+            radiusHigh: 20,
+        })
+        expect(bubbles[0].text).not.toContain('NaN')
+    })
+
     it('should return three bubbles with single color and formatted values', () => {
         const mockScale = {
             domain: jest.fn(() => (value) => value * 0.5),

--- a/src/util/__tests__/classify.spec.js
+++ b/src/util/__tests__/classify.spec.js
@@ -80,7 +80,7 @@ describe('getLegendItemForValue', () => {
 
 describe('getLegendItems', () => {
     it('returns equal intervals for CLASSIFICATION_EQUAL_INTERVALS', () => {
-        const values = [0, 100]
+        const values = [0, 25, 50, 75, 100]
         const { items } = getLegendItems(
             values,
             CLASSIFICATION_EQUAL_INTERVALS,

--- a/src/util/__tests__/classify.spec.js
+++ b/src/util/__tests__/classify.spec.js
@@ -1,6 +1,11 @@
 import {
     CLASSIFICATION_EQUAL_INTERVALS,
     CLASSIFICATION_EQUAL_COUNTS,
+    CLASSIFICATION_NATURAL_BREAKS_RANGES,
+    CLASSIFICATION_NATURAL_BREAKS_CLUSTERS,
+    CLASSIFICATION_PRETTY_BREAKS,
+    CLASSIFICATION_LOGARITHMIC,
+    CLASSIFICATION_STANDARD_DEVIATION,
 } from '../../constants/layers.js'
 import { getLegendItemForValue, getLegendItems } from '../classify.js'
 
@@ -76,6 +81,70 @@ describe('getLegendItemForValue', () => {
             })
         ).toEqual(legendItems[1])
     })
+
+    it('matches value equal to a single-value class (startValue === endValue)', () => {
+        const items = [
+            { startValue: 0, endValue: 10 },
+            { startValue: 100, endValue: 100 },
+            { startValue: 100, endValue: 200 },
+        ]
+        expect(
+            getLegendItemForValue({ value: 100, legendItems: items })
+        ).toEqual(items[1])
+    })
+
+    it('does not match single-value class with a different value', () => {
+        const items = [
+            { startValue: 0, endValue: 10 },
+            { startValue: 100, endValue: 100 },
+        ]
+        expect(
+            getLegendItemForValue({ value: 50, legendItems: items })
+        ).toBeUndefined()
+    })
+
+    it('matches value at non-last cluster endValue under CLUSTERS method', () => {
+        const clusterItems = [
+            { startValue: 1, endValue: 3 },
+            { startValue: 10, endValue: 12 },
+            { startValue: 100, endValue: 102 },
+        ]
+        expect(
+            getLegendItemForValue({
+                value: 3,
+                method: CLASSIFICATION_NATURAL_BREAKS_CLUSTERS,
+                legendItems: clusterItems,
+            })
+        ).toEqual(clusterItems[0])
+    })
+
+    it('does not match non-last endValue under non-clusters method', () => {
+        const intervalItems = [
+            { startValue: 0, endValue: 10 },
+            { startValue: 10, endValue: 20 },
+        ]
+        expect(
+            getLegendItemForValue({
+                value: 10,
+                method: CLASSIFICATION_EQUAL_INTERVALS,
+                legendItems: intervalItems,
+            })
+        ).toEqual(intervalItems[1])
+    })
+
+    it('still matches last endValue regardless of method', () => {
+        const items = [
+            { startValue: 0, endValue: 50 },
+            { startValue: 50, endValue: 100 },
+        ]
+        expect(
+            getLegendItemForValue({
+                value: 100,
+                method: CLASSIFICATION_EQUAL_INTERVALS,
+                legendItems: items,
+            })
+        ).toEqual(items[1])
+    })
 })
 
 describe('getLegendItems', () => {
@@ -116,5 +185,163 @@ describe('getLegendItems', () => {
             4
         )
         expect(typeof valueFormat).toBe('function')
+    })
+
+    it('returns natural breaks (intervals) as continuous bins', () => {
+        const values = [1, 2, 3, 10, 11, 12, 100, 101, 102]
+        const { items } = getLegendItems(
+            values,
+            CLASSIFICATION_NATURAL_BREAKS_RANGES,
+            3
+        )
+        expect(items).toHaveLength(3)
+        expect(items[0].endValue).toBe(items[1].startValue)
+        expect(items[1].endValue).toBe(items[2].startValue)
+        expect(items[0].startValue).toBe(1)
+        expect(items[2].endValue).toBe(102)
+    })
+
+    it('returns natural breaks (clusters) with gaps between clusters', () => {
+        const values = [1, 2, 3, 10, 11, 12, 100, 101, 102]
+        const { items } = getLegendItems(
+            values,
+            CLASSIFICATION_NATURAL_BREAKS_CLUSTERS,
+            3
+        )
+        expect(items).toHaveLength(3)
+        expect(items[0].endValue).toBeLessThan(items[1].startValue)
+        expect(items[1].endValue).toBeLessThan(items[2].startValue)
+    })
+
+    it('returns logarithmic bins for strictly positive data', () => {
+        const values = [1, 10, 100, 1000, 10000]
+        const { items } = getLegendItems(values, CLASSIFICATION_LOGARITHMIC, 4)
+        expect(items).toHaveLength(4)
+        expect(items[0].startValue).toBe(1)
+        expect(items[3].endValue).toBe(10000)
+        expect(items[0].endValue).toBe(items[1].startValue)
+    })
+
+    it('falls back to equal intervals for logarithmic when min <= 0', () => {
+        const values = [0, 25, 50, 75, 100]
+        const { items: logItems } = getLegendItems(
+            values,
+            CLASSIFICATION_LOGARITHMIC,
+            4
+        )
+        const { items: equalItems } = getLegendItems(
+            values,
+            CLASSIFICATION_EQUAL_INTERVALS,
+            4
+        )
+        expect(logItems).toEqual(equalItems)
+    })
+
+    it('returns standard deviation bins spanning [min, max]', () => {
+        const values = [0, 10, 20, 50, 80, 90, 100]
+        const { items } = getLegendItems(
+            values,
+            CLASSIFICATION_STANDARD_DEVIATION,
+            5
+        )
+        expect(items[0].startValue).toBe(0)
+        expect(items[items.length - 1].endValue).toBe(100)
+        expect(items.length).toBeGreaterThanOrEqual(1)
+        expect(items.length).toBeLessThanOrEqual(5)
+    })
+
+    it('returns pretty breaks with round boundaries', () => {
+        const { items } = getLegendItems(
+            [0, 100],
+            CLASSIFICATION_PRETTY_BREAKS,
+            5
+        )
+        expect(items[0].endValue).toBe(20)
+    })
+
+    it('removes consecutive duplicate bins', () => {
+        const values = [5, 5, 5, 5, 5, 10, 10, 10]
+        const { items } = getLegendItems(values, CLASSIFICATION_EQUAL_COUNTS, 5)
+        for (let i = 1; i < items.length; i++) {
+            expect(
+                items[i].startValue === items[i - 1].startValue &&
+                    items[i].endValue === items[i - 1].endValue
+            ).toBe(false)
+        }
+    })
+
+    it('caps class count for natural breaks (intervals) when fewer distinct values', () => {
+        const { items } = getLegendItems(
+            [1, 2, 3],
+            CLASSIFICATION_NATURAL_BREAKS_RANGES,
+            5
+        )
+        expect(items).toHaveLength(3)
+    })
+
+    it('caps class count for natural breaks (clusters) when fewer distinct values', () => {
+        const { items } = getLegendItems(
+            [1, 2, 3],
+            CLASSIFICATION_NATURAL_BREAKS_CLUSTERS,
+            5
+        )
+        expect(items).toHaveLength(3)
+    })
+
+    it('caps class count for equal counts when fewer distinct values', () => {
+        const { items } = getLegendItems(
+            [1, 2, 3],
+            CLASSIFICATION_EQUAL_COUNTS,
+            5
+        )
+        expect(items.length).toBeLessThanOrEqual(3)
+    })
+
+    it('does not throw for pretty breaks with few distinct values', () => {
+        expect(() =>
+            getLegendItems([1, 2], CLASSIFICATION_PRETTY_BREAKS, 5)
+        ).not.toThrow()
+    })
+
+    it('does not throw for standard deviation with few distinct values', () => {
+        expect(() =>
+            getLegendItems([1, 2], CLASSIFICATION_STANDARD_DEVIATION, 5)
+        ).not.toThrow()
+    })
+
+    it('returns single bin when all values are equal', () => {
+        const { items } = getLegendItems(
+            [5, 5, 5, 5],
+            CLASSIFICATION_EQUAL_INTERVALS,
+            4
+        )
+        expect(items).toEqual([{ startValue: 5, endValue: 5 }])
+    })
+
+    it('short-circuits to single bin for all-equal values regardless of method', () => {
+        const methods = [
+            CLASSIFICATION_EQUAL_INTERVALS,
+            CLASSIFICATION_EQUAL_COUNTS,
+            CLASSIFICATION_NATURAL_BREAKS_RANGES,
+            CLASSIFICATION_NATURAL_BREAKS_CLUSTERS,
+            CLASSIFICATION_STANDARD_DEVIATION,
+            CLASSIFICATION_LOGARITHMIC,
+            CLASSIFICATION_PRETTY_BREAKS,
+        ]
+        methods.forEach((method) => {
+            const { items } = getLegendItems([7, 7, 7], method, 5)
+            expect(items).toEqual([{ startValue: 7, endValue: 7 }])
+        })
+    })
+
+    it('all-equal single bin is matched by getLegendItemForValue', () => {
+        const { items } = getLegendItems(
+            [7, 7, 7],
+            CLASSIFICATION_EQUAL_INTERVALS,
+            5
+        )
+        expect(getLegendItemForValue({ value: 7, legendItems: items })).toEqual(
+            items[0]
+        )
     })
 })

--- a/src/util/bubbles.js
+++ b/src/util/bubbles.js
@@ -9,6 +9,14 @@ import { getContrastColor } from './colors.js'
 import { getLongestTextLength } from './helpers.js'
 import { getRoundToPrecisionFn } from './numbers.js'
 
+const getBubbleValueFormat = ({ minValue, maxValue, divisor }) => {
+    if (minValue === maxValue) {
+        return (n) => n.toString()
+    }
+    const precision = precisionRound((maxValue - minValue) / divisor, maxValue)
+    return (n) => getRoundToPrecisionFn(precision)(n).toString()
+}
+
 export const createBubbleItems = ({
     classes,
     minValue,
@@ -16,9 +24,11 @@ export const createBubbleItems = ({
     scale,
     radiusHigh,
 }) => {
-    const binSize = (maxValue - minValue) / classes.length
-    const precision = precisionRound(binSize, maxValue)
-    const valueFormat = (n) => getRoundToPrecisionFn(precision)(n).toString()
+    const valueFormat = getBubbleValueFormat({
+        minValue,
+        maxValue,
+        divisor: classes.length,
+    })
 
     const startValue = classes[0].startValue
     const endValue = classes[classes.length - 1].endValue
@@ -30,6 +40,10 @@ export const createBubbleItems = ({
         color: c.color,
         text: valueFormat(c.endValue),
     }))
+
+    if (minValue === maxValue) {
+        return bubbles
+    }
 
     bubbles.push({
         radius: itemScale(startValue),
@@ -48,12 +62,23 @@ export const createSingleColorBubbles = ({
     radiusLow,
     radiusHigh,
 }) => {
-    const binSize = (maxValue - minValue) / 3
-    const precision = precisionRound(binSize, maxValue)
-    const valueFormat = (n) => getRoundToPrecisionFn(precision)(n).toString()
+    const valueFormat = getBubbleValueFormat({ minValue, maxValue, divisor: 3 })
 
     const stroke = color && getContrastColor(color)
     const itemScale = scale.domain([minValue, maxValue])
+
+    if (minValue === maxValue) {
+        return [
+            {
+                radius: itemScale(minValue),
+                maxRadius: radiusHigh,
+                color,
+                stroke,
+                text: valueFormat(minValue),
+            },
+        ]
+    }
+
     const midValue = (maxValue + minValue) / 2
 
     return [

--- a/src/util/classify.js
+++ b/src/util/classify.js
@@ -51,23 +51,31 @@ export const getLegendItemForValue = ({
 export const getLegendItems = (values, method, numClasses) => {
     const minValue = values[0]
     const maxValue = values[values.length - 1]
-    // TODO: guard against minValue === maxValue. Currently handled downstream
-    // (DHIS2-20818 for bubble legend; still produces degenerate output for
-    // other methods like pretty breaks where Math.log10(0) = -Infinity).
+    if (minValue === maxValue) {
+        return {
+            items: [{ startValue: minValue, endValue: maxValue }],
+        }
+    }
+
+    const distinctValues = [...new Set(values)]
+    const k = Math.min(numClasses, distinctValues.length)
+
     let classification
 
     if (method === CLASSIFICATION_EQUAL_INTERVALS) {
-        classification = getEqualIntervals(minValue, maxValue, { numClasses })
+        classification = getEqualIntervals(minValue, maxValue, {
+            numClasses: k,
+        })
     } else if (method === CLASSIFICATION_EQUAL_COUNTS) {
-        classification = getQuantiles(values, { numClasses })
+        classification = getQuantiles(values, { numClasses: k })
     } else if (method === CLASSIFICATION_NATURAL_BREAKS_RANGES) {
         classification = getCkMeans(values, {
-            numClasses,
+            numClasses: k,
             continuous: true,
         })
     } else if (method === CLASSIFICATION_NATURAL_BREAKS_CLUSTERS) {
         classification = getCkMeans(values, {
-            numClasses,
+            numClasses: k,
             continuous: false,
         })
     } else if (method === CLASSIFICATION_STANDARD_DEVIATION) {

--- a/src/util/classify.js
+++ b/src/util/classify.js
@@ -1,8 +1,14 @@
 // Utils for thematic mapping
 import { precisionRound } from 'd3-format'
+import { ckmeans, mean, standardDeviation } from 'simple-statistics'
 import {
     CLASSIFICATION_EQUAL_INTERVALS,
     CLASSIFICATION_EQUAL_COUNTS,
+    CLASSIFICATION_NATURAL_BREAKS_RANGES,
+    CLASSIFICATION_NATURAL_BREAKS_CLUSTERS,
+    CLASSIFICATION_STANDARD_DEVIATION,
+    CLASSIFICATION_LOGARITHMIC,
+    CLASSIFICATION_PRETTY_BREAKS,
 } from '../constants/layers.js'
 import { hasValue } from './helpers.js'
 import { getRoundToPrecisionFn } from './numbers.js'
@@ -11,6 +17,7 @@ import { getRoundToPrecisionFn } from './numbers.js'
 export const getLegendItemForValue = ({
     value,
     valueFormat,
+    method,
     legendItems,
     clamp = false,
 }) => {
@@ -30,25 +37,56 @@ export const getLegendItemForValue = ({
         }
     }
 
+    const isClusters = method === CLASSIFICATION_NATURAL_BREAKS_CLUSTERS
     const isLast = (index) => index === legendItems.length - 1
     return legendItems.find((item, index) =>
         item.startValue === item.endValue
             ? value === item.startValue
             : value >= item.startValue &&
               (value < item.endValue ||
-                  (isLast(index) && value === item.endValue))
+                  (value === item.endValue && (isClusters || isLast(index))))
     )
 }
 
 export const getLegendItems = (values, method, numClasses) => {
     const minValue = values[0]
     const maxValue = values[values.length - 1]
+    // TODO: guard against minValue === maxValue. Currently handled downstream
+    // (DHIS2-20818 for bubble legend; still produces degenerate output for
+    // other methods like pretty breaks where Math.log10(0) = -Infinity).
     let classification
 
     if (method === CLASSIFICATION_EQUAL_INTERVALS) {
-        classification = getEqualIntervals(minValue, maxValue, numClasses)
+        classification = getEqualIntervals(minValue, maxValue, { numClasses })
     } else if (method === CLASSIFICATION_EQUAL_COUNTS) {
-        classification = getQuantiles(values, numClasses)
+        classification = getQuantiles(values, { numClasses })
+    } else if (method === CLASSIFICATION_NATURAL_BREAKS_RANGES) {
+        classification = getCkMeans(values, {
+            numClasses,
+            continuous: true,
+        })
+    } else if (method === CLASSIFICATION_NATURAL_BREAKS_CLUSTERS) {
+        classification = getCkMeans(values, {
+            numClasses,
+            continuous: false,
+        })
+    } else if (method === CLASSIFICATION_STANDARD_DEVIATION) {
+        classification = getStandardDeviation(values, { numClasses })
+    } else if (method === CLASSIFICATION_LOGARITHMIC) {
+        if (minValue <= 0) {
+            // Logarithmic scale requires strictly positive values.
+            // Silently fall back to equal intervals for now.
+            // TODO: when DHIS2-19812 (unclassified bucket) lands, filter
+            // non-positive values out of the classification input and route
+            // them to the unclassified bucket instead of falling back.
+            classification = getEqualIntervals(minValue, maxValue, {
+                numClasses,
+            })
+        } else {
+            classification = getLogarithmic(minValue, maxValue, { numClasses })
+        }
+    } else if (method === CLASSIFICATION_PRETTY_BREAKS) {
+        classification = getPrettyBreaks(minValue, maxValue, { numClasses })
     }
 
     if (!classification) {
@@ -65,23 +103,7 @@ export const getLegendItems = (values, method, numClasses) => {
     }
 }
 
-// This function is not in use, but keeping it
-// just in case it's needed in the future
-// export const getClassBins = (values, method, numClasses) => {
-//     const minValue = values[0]
-//     const maxValue = values[values.length - 1]
-//     let bins
-
-//     if (method === CLASSIFICATION_EQUAL_INTERVALS) {
-//         bins = getEqualIntervals(minValue, maxValue, numClasses)
-//     } else if (method === CLASSIFICATION_EQUAL_COUNTS) {
-//         bins = getQuantiles(values, numClasses)
-//     }
-
-//     return bins
-// }
-
-const getEqualIntervals = (minValue, maxValue, numClasses) => {
+const getEqualIntervals = (minValue, maxValue, { numClasses }) => {
     const items = []
     const classSize = (maxValue - minValue) / numClasses
     const precision = precisionRound(classSize, maxValue)
@@ -100,7 +122,7 @@ const getEqualIntervals = (minValue, maxValue, numClasses) => {
     return { items, valueFormat }
 }
 
-const getQuantiles = (values, numClasses) => {
+const getQuantiles = (values, { numClasses }) => {
     const minValue = values[0]
     const maxValue = values[values.length - 1]
     const items = []
@@ -120,14 +142,156 @@ const getQuantiles = (values, numClasses) => {
         }
     }
 
-    // bin can be undefined if few values
+    // item can be undefined if few values
     return {
         items: items
-            .filter((bin) => bin !== undefined)
+            .filter((item) => item !== undefined)
             .map((value, index) => ({
                 startValue: valueFormat(value),
                 endValue: valueFormat(items[index + 1] || maxValue),
             })),
+        valueFormat,
+    }
+}
+
+const getCkMeans = (values, { numClasses, continuous }) => {
+    const minValue = values[0]
+    const maxValue = values[values.length - 1]
+    const precision = precisionRound(
+        (maxValue - minValue) / numClasses,
+        maxValue
+    )
+    const valueFormat = getRoundToPrecisionFn(precision)
+
+    const k = Math.min(numClasses, values.length)
+    const clusters = ckmeans(values, k)
+
+    if (continuous) {
+        // Continuous: midpoint between adjacent cluster bounds
+        const boundaries = [
+            minValue,
+            ...clusters
+                .slice(0, -1)
+                .map(
+                    (cluster, i) =>
+                        (cluster[cluster.length - 1] + clusters[i + 1][0]) / 2
+                ),
+            maxValue,
+        ]
+        return {
+            items: clusters.map((_, index) => ({
+                startValue: valueFormat(boundaries[index]),
+                endValue: valueFormat(boundaries[index + 1]),
+            })),
+            valueFormat,
+        }
+    }
+
+    // Discrete (clusters): true cluster bounds, gaps allowed
+    return {
+        items: clusters.map((cluster) => ({
+            startValue: valueFormat(cluster[0]),
+            endValue: valueFormat(cluster[cluster.length - 1]),
+        })),
+        valueFormat,
+    }
+}
+
+const getStandardDeviation = (values, { numClasses }) => {
+    // TODO: DHIS2-19812 std - dev classification is best interpreted when
+    // breaks fall at μ±Nσ regardless of data extremes. Currently:
+    //   - breaks outside [minValue, maxValue] are filtered (producing
+    //     fewer bins than requested)
+    //   - the outermost kept bins span to min/max rather than the next
+    //     σ boundary, so bin labels no longer mean "Nσ from mean"
+    // When the unclassified bucket lands, preserve σ-aligned boundaries
+    // and route values beyond the outermost break to unclassified.
+    const minValue = values[0]
+    const maxValue = values[values.length - 1]
+    const mu = mean(values)
+    const sigma = standardDeviation(values)
+    const precision = precisionRound(
+        (maxValue - minValue) / numClasses,
+        maxValue
+    )
+    const valueFormat = getRoundToPrecisionFn(precision)
+
+    // Place breaks at 1-sigma intervals centered on the mean.
+    const internalBreaks = []
+    const isEven = numClasses % 2 === 0
+    const maxOffset = Math.floor((numClasses - 1) / 2)
+    for (let i = 0; i < numClasses - 1; i++) {
+        let offset = i - maxOffset
+        if (!isEven && offset >= 0) {
+            offset += 1
+        }
+        const b = mu + offset * sigma
+        if (b > minValue && b < maxValue) {
+            internalBreaks.push(b)
+        }
+    }
+
+    const allBreaks = [minValue, ...internalBreaks, maxValue]
+    return {
+        items: allBreaks.slice(0, -1).map((start, i) => ({
+            startValue: valueFormat(start),
+            endValue: valueFormat(allBreaks[i + 1]),
+        })),
+        valueFormat,
+    }
+}
+
+const getLogarithmic = (minValue, maxValue, { numClasses }) => {
+    const logMin = Math.log(minValue)
+    const logMax = Math.log(maxValue)
+    const logStep = (logMax - logMin) / numClasses
+    const precision = precisionRound(
+        (maxValue - minValue) / numClasses,
+        maxValue
+    )
+    const valueFormat = getRoundToPrecisionFn(precision)
+
+    const items = []
+    for (let i = 0; i < numClasses; i++) {
+        const startValue = Math.exp(logMin + i * logStep)
+        const endValue =
+            i < numClasses - 1 ? Math.exp(logMin + (i + 1) * logStep) : maxValue
+        items.push({
+            startValue: valueFormat(startValue),
+            endValue: valueFormat(endValue),
+        })
+    }
+
+    return { items, valueFormat }
+}
+
+const getPrettyBreaks = (minValue, maxValue, { numClasses }) => {
+    const range = maxValue - minValue
+    const roughStep = range / numClasses
+    const magnitude = Math.pow(10, Math.floor(Math.log10(roughStep)))
+    const niceSteps = [1, 2, 5].map((n) => n * magnitude)
+    const niceStep =
+        niceSteps.filter((s) => s <= roughStep).pop() ?? niceSteps[0]
+
+    const precision = precisionRound(niceStep, maxValue)
+    const valueFormat = getRoundToPrecisionFn(precision)
+
+    const internalBreaks = []
+    let b = Math.ceil(minValue / niceStep) * niceStep
+    if (b === minValue) {
+        b += niceStep
+    }
+    while (b < maxValue && internalBreaks.length < numClasses - 1) {
+        internalBreaks.push(b)
+        b += niceStep
+    }
+
+    const allBreaks = [minValue, ...internalBreaks, maxValue]
+    return {
+        items: allBreaks.slice(0, -1).map((start, i) => ({
+            startValue: valueFormat(start),
+            endValue: valueFormat(allBreaks[i + 1]),
+        })),
         valueFormat,
     }
 }

--- a/src/util/classify.js
+++ b/src/util/classify.js
@@ -278,8 +278,7 @@ const getPrettyBreaks = (minValue, maxValue, { numClasses }) => {
     const roughStep = range / numClasses
     const magnitude = Math.pow(10, Math.floor(Math.log10(roughStep)))
     const niceSteps = [1, 2, 5].map((n) => n * magnitude)
-    const niceStep =
-        niceSteps.filter((s) => s <= roughStep).pop() ?? niceSteps[0]
+    const niceStep = niceSteps.findLast((s) => s <= roughStep) ?? niceSteps[0]
 
     const precision = precisionRound(niceStep, maxValue)
     const valueFormat = getRoundToPrecisionFn(precision)

--- a/src/util/classify.js
+++ b/src/util/classify.js
@@ -31,10 +31,12 @@ export const getLegendItemForValue = ({
     }
 
     const isLast = (index) => index === legendItems.length - 1
-    return legendItems.find(
-        (item, index) =>
-            value >= item.startValue &&
-            (value < item.endValue || (isLast(index) && value == item.endValue))
+    return legendItems.find((item, index) =>
+        item.startValue === item.endValue
+            ? value === item.startValue
+            : value >= item.startValue &&
+              (value < item.endValue ||
+                  (isLast(index) && value === item.endValue))
     )
 }
 
@@ -49,7 +51,18 @@ export const getLegendItems = (values, method, numClasses) => {
         classification = getQuantiles(values, numClasses)
     }
 
-    return classification ?? {}
+    if (!classification) {
+        return {}
+    }
+    return {
+        items: classification.items.filter(
+            (bin, index, arr) =>
+                index === 0 ||
+                bin.startValue !== arr[index - 1].startValue ||
+                bin.endValue !== arr[index - 1].endValue
+        ),
+        valueFormat: classification.valueFormat,
+    }
 }
 
 // This function is not in use, but keeping it

--- a/src/util/styleByDataItem.js
+++ b/src/util/styleByDataItem.js
@@ -192,6 +192,7 @@ const styleByNumeric = async (config, engine) => {
         getLegendItemForValue({
             value,
             valueFormat,
+            method,
             legendItems: legend.items.filter((item) => !item.noData),
             clamp: method !== CLASSIFICATION_PREDEFINED,
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -14134,6 +14134,11 @@ simple-concat@^1.0.0:
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
 
+simple-statistics@^7.8.9:
+  version "7.8.9"
+  resolved "https://registry.yarnpkg.com/simple-statistics/-/simple-statistics-7.8.9.tgz#daa0f089d88ab47a4d6187ace534c459be05742f"
+  integrity sha512-YT6MLqYsz7y1rQZOLFlOCCgSRpCi6bqY417yhoOLI7aVoBi29dD39EPrOE03W9DY25H0J0jizVsHZnkLzyGJFg==
+
 slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"


### PR DESCRIPTION
### Parent

- [DHIS2-18242](https://dhis2.atlassian.net/browse/DHIS2-18242)

### Implements

- [DHIS2-21142](https://dhis2.atlassian.net/browse/DHIS2-21142): Add new classification methods (natural breaks, pretty breaks, logarithmic, standard deviation)
- [DHIS2-12860](https://dhis2.atlassian.net/browse/DHIS2-12860): Equal counts distribution is not ideal when many values are the same
- [DHIS2-8478](https://dhis2.atlassian.net/browse/DHIS2-8478): Automatic legends with few data points
- [DHIS2-20818](https://dhis2.atlassian.net/browse/DHIS2-20818): Thematic layer, bubble style — legends shows NaN when all mapped values are equal
- [DHIS2-21356](https://dhis2.atlassian.net/browse/DHIS2-21356): Saving event layer without choosing predefined legend set breaks layer

### Overview

Second PR in the series extracted from the parent epic. Expands the classification engine with five new methods and hardens edge-case handling across all methods. Builds on the `valueFormat` plumbing from PR 1.

### Changes

#### Five new classification methods [DHIS2-21142]

Added to the "Classification" dropdown, in addition to the existing Equal intervals and Equal counts:

- **Natural breaks (intervals)** — ckmeans clustering with midpoint boundaries between clusters; bins are continuous and span the full data range
- **Natural breaks (clusters)** — ckmeans clustering with true cluster bounds; bins may have gaps, useful for data with distinct groupings
- **Pretty breaks** — bins aligned to round numbers (multiples of 1, 2, or 5 × 10ⁿ) for more readable legend boundaries
- **Logarithmic scale** — log-spaced bins; falls back to equal intervals when data contains non-positive values (TODO in code to route these to the unclassified bucket once DHIS2-19812 lands)
- **Standard deviation** — breaks at 1σ intervals centered on the mean, symmetric around the mean (even class counts include μ as a break; odd class counts skip it)

Natural breaks (clusters) is the only method where non-last bin `endValue`s are inclusive, since clusters can have gaps. `getLegendItemForValue` now accepts a `method` parameter to handle this correctly.

New dependency: `simple-statistics@^7.8.9` for `ckmeans`, `mean`, `standardDeviation`.

Also fixes the "Automatic" radio button highlight in `LegendTypeSelect`. Master only mapped `EQUAL_COUNTS` back to the `EQUAL_INTERVALS` id, so when a user picked any of the new auto methods (natural breaks, pretty breaks, logarithmic, std-dev) the radio appeared deselected. The fix uses `getClassificationTypes()` membership to detect any auto method and maps all of them to a single `CLASSIFICATION_AUTO_DEFAULT` constant — also serving as the default classification method when no method is set, so changing the default updates both consistently.

Also fixes `LAYER_EDIT_CLASSIFICATION_SET` in the reducer, which previously preserved `colorScale`/`classes` only when switching between `EQUAL_INTERVALS` and `EQUAL_COUNTS`; it now uses `getClassificationTypes()` so all auto methods are treated consistently.

*Files:* `src/util/classify.js`, `src/constants/layers.js`, `src/loaders/thematicLoader.js`, `src/util/styleByDataItem.js`, `src/components/classification/LegendTypeSelect.jsx`, `src/reducers/layerEdit.js`, `package.json`

#### Single-value class matching and duplicate bin removal [DHIS2-12860]

Two changes in `classify.js` to handle duplicate-heavy data:

- `getLegendItemForValue` now matches classes where `startValue === endValue` via equality rather than range comparison, so single-value classes (e.g. `{startValue: 100, endValue: 100}`) are actually reachable.
- `getLegendItems` filters consecutive duplicate bins from the dispatcher output, preventing equal-counts classification from producing unreachable `[n, n]` bins when many values are identical.

*Files:* `src/util/classify.js`

#### Handle classifications with few distinct values [DHIS2-8478]

Two guards added to the `getLegendItems` dispatcher:

- **All values equal**: short-circuit and return a single bin `[v, v]` regardless of method. Protects downstream methods (notably `getPrettyBreaks`, where `Math.log10(0) = -Infinity` would otherwise propagate NaN) and guarantees a sensible legend when a layer filters to a uniform-value dataset.
- **Fewer distinct values than requested classes**: cap the effective class count (`k = min(numClasses, distinctValues.length)`) for methods that partition the data (equal counts, natural breaks variants). Methods that derive bins from the data range (equal intervals, logarithmic, std-dev, pretty breaks) are unaffected.

No silent method switching — user-selected method is preserved, result size simply adapts to the data.

*Files:* `src/util/classify.js`

#### Fix NaN in bubble legend for equal values [DHIS2-20818]

When a thematic bubble layer has all values equal, the bubble radius calculation hit `precisionRound(0, maxValue)` → `NaN`, rendering the legend with "NaN" labels.

Extracted a `getBubbleValueFormat` helper that bypasses `precisionRound` for the equal-values case. Both `createBubbleItems` and `createSingleColorBubbles` now produce a single bubble matching the map's rendered size.

Composes with DHIS2-8478's single-bin short-circuit: classification returns one class, bubble layer renders one bubble, legend shows one bubble. Consistent end-to-end.

Also guards `Bubbles` against `undefined` `minValue`/`maxValue` — a crash path introduced by the `minValue === maxValue` shortcut in `getBubbleValueFormat` (`undefined === undefined` is true, returning `(n) => n.toString()` which throws on `undefined`). When no data range is present but `noDataColor` is set, the component now renders a compact legend with just the no-data circle.

*Files:* `src/util/bubbles.js`, `src/components/legend/Bubbles.jsx`

#### Auto-select legend set when switching to predefined type [DHIS2-21356]

When a user switched the "Legend type" to "Predefined" without explicitly picking a legend set, the layer would save with `legendSet: null` and break on reload. The pre-existing `useEffect` in `NumericLegendStyle` only fired when the data item *had* an associated legend set — leaving the no-association case unhandled.

Moved legend-set auto-selection into `LegendSetSelect`, where the available list is guaranteed to be loaded. Pass `dataItem?.legendSet` down as `defaultLegendSet`; the component prefers that, falls back to the first available legend set when the association is missing or the associated set isn't in the user's list.

*Files:* `src/components/classification/LegendSetSelect.jsx`, `src/components/classification/NumericLegendStyle.jsx`

### Tests update

- `src/util/__tests__/bubbles.spec.js`
- `src/util/__tests__/classify.spec.js` 


### Manual testing

Netlify: https://pr-3646.maps.netlify.dhis2.org/ + Instance: https://dev.im.dhis2.org/maps-app-42-3

- [DHIS2-21142](https://dhis2.atlassian.net/browse/DHIS2-21142): Add new classification methods (natural breaks, pretty breaks, logarithmic, standard deviation)
  - Test maps - Thematic:
    - Natural breaks (intervals): [gknlGRJdMGm](https://pr-3646.maps.netlify.dhis2.org/#/gknlGRJdMGm)
    - Natural breaks (clusters): [U47qkyBswH3](https://pr-3646.maps.netlify.dhis2.org/#/U47qkyBswH3)
    - Pretty breaks: [uk0XWmJKu1F](https://pr-3646.maps.netlify.dhis2.org/#/uk0XWmJKu1F)
    - Logarithmic: [pug8veMeiwZ](https://pr-3646.maps.netlify.dhis2.org/#/pug8veMeiwZ)
    - Standard deviation: [BX6mkHJjxJB](https://pr-3646.maps.netlify.dhis2.org/#/BX6mkHJjxJB)
  - Test maps - Thematic:
    - Natural breaks (intervals): [aofoN7sSfY4](https://pr-3646.maps.netlify.dhis2.org/#/aofoN7sSfY4)
    - Natural breaks (clusters): [RY9YSaRra0G](https://pr-3646.maps.netlify.dhis2.org/#/RY9YSaRra0G)
    - Pretty breaks: [MCYWgkdRG6d](https://pr-3646.maps.netlify.dhis2.org/#/MCYWgkdRG6d)
    - Logarithmic: [FFeRG0g9kvp](https://pr-3646.maps.netlify.dhis2.org/#/FFeRG0g9kvp)
    - Standard deviation: [d10Qxol74Je](https://pr-3646.maps.netlify.dhis2.org/#/d10Qxol74Je)

<img height="250" alt="image" src="https://github.com/user-attachments/assets/002126b1-1e4f-4795-a0cb-d36b3b2e0e61" />

&nbsp;

- [DHIS2-12860](https://dhis2.atlassian.net/browse/DHIS2-12860): Equal counts distribution is not ideal when many values are the same
  - Test map: [APqEkeE0Nr5](https://pr-3646.maps.netlify.dhis2.org/#/APqEkeE0Nr5)
 
<img height="250" alt="image" src="https://github.com/user-attachments/assets/562817f3-d236-480f-82e6-ca519d85be6d" />

&nbsp;

- [DHIS2-8478](https://dhis2.atlassian.net/browse/DHIS2-8478): Automatic legends with few data points
  - Test map: [r56Jrw3ZOQs](https://pr-3646.maps.netlify.dhis2.org/#/r56Jrw3ZOQs)
 
<img height="250" alt="image" src="https://github.com/user-attachments/assets/f2b9a1e0-b815-46f0-a1b6-ad7297d17532" />

&nbsp;

- [DHIS2-20818](https://dhis2.atlassian.net/browse/DHIS2-20818): Thematic layer, bubble style — legends shows NaN when all mapped values are equal
  - Test map: [nxq2hIlZdAK](https://pr-3646.maps.netlify.dhis2.org/#/nxq2hIlZdAK)
 
<img height="250" alt="image" src="https://github.com/user-attachments/assets/6f7b501a-fd7f-4327-b78c-0fa5cc09dcde" />

&nbsp;

- [DHIS2-21356](https://dhis2.atlassian.net/browse/DHIS2-21356): Saving event layer without choosing predefined legend set breaks layer

### Quality checklist

Add _N/A_ to items that are not applicable.

- [x] Jest tests added/updated
- [ ] Docs added _N/A_
- [ ] d2-ci dependencies replaced _N/A_
- [x] Include plugin in testing
- [x] Tester approved (@edoardo)

[DHIS2-18242]: https://dhis2.atlassian.net/browse/DHIS2-18242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-21142]: https://dhis2.atlassian.net/browse/DHIS2-21142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-12860]: https://dhis2.atlassian.net/browse/DHIS2-12860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-8478]: https://dhis2.atlassian.net/browse/DHIS2-8478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-20818]: https://dhis2.atlassian.net/browse/DHIS2-20818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-21356]: https://dhis2.atlassian.net/browse/DHIS2-21356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ