### PR TITLE
feat: format numeric values with digit group separator [PR3] [DHIS2-18242]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-04-24T10:52:00.804Z\n"
-"PO-Revision-Date: 2026-04-24T10:52:00.804Z\n"
+"POT-Creation-Date: 2026-04-26T10:03:57.925Z\n"
+"PO-Revision-Date: 2026-04-26T10:03:57.925Z\n"
 
 msgid "2020"
 msgstr "2020"
@@ -1758,11 +1758,11 @@ msgstr "Data item was not found"
 msgid "Thematic layer"
 msgstr "Thematic layer"
 
-msgid "Tracked entity"
-msgstr "Tracked entity"
-
 msgid "related"
 msgstr "related"
+
+msgid "Tracked entity"
+msgstr "Tracked entity"
 
 msgid "not one of"
 msgstr "not one of"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-04-26T10:03:57.925Z\n"
-"PO-Revision-Date: 2026-04-26T10:03:57.925Z\n"
+"POT-Creation-Date: 2026-04-26T11:10:26.962Z\n"
+"PO-Revision-Date: 2026-04-26T11:10:26.963Z\n"
 
 msgid "2020"
 msgstr "2020"
@@ -1824,3 +1824,11 @@ msgstr "End date is invalid"
 
 msgid "End date cannot be earlier than start date"
 msgstr "End date cannot be earlier than start date"
+
+msgctxt "Application title"
+msgid "__MANIFEST_APP_TITLE"
+msgstr "Maps"
+
+msgctxt "Application description"
+msgid "__MANIFEST_APP_DESCRIPTION"
+msgstr "DHIS2 Maps"

--- a/src/components/datatable/DataTable.jsx
+++ b/src/components/datatable/DataTable.jsx
@@ -26,6 +26,8 @@ import { highlightFeature, setFeatureProfile } from '../../actions/feature.js'
 import { setOrgUnitProfile } from '../../actions/orgUnits.js'
 import { EVENT_LAYER, GEOJSON_URL_LAYER } from '../../constants/layers.js'
 import { isDarkColor } from '../../util/colors.js'
+import { formatWithSeparator } from '../../util/numbers.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.jsx'
 import FilterInput from './FilterInput.jsx'
 import styles from './styles/DataTable.module.css'
 import { useTableData } from './useTableData.js'
@@ -88,6 +90,10 @@ const TableComponents = {
 }
 
 const Table = ({ availableHeight, availableWidth }) => {
+    const {
+        systemSettings: { keyAnalysisDigitGroupSeparator },
+    } = useCachedData()
+
     const headerRowRef = useRef(null)
     const [columnWidths, setColumnWidths] = useState([])
     const { mapViews } = useSelector((state) => state.map)
@@ -293,7 +299,12 @@ const Table = ({ availableHeight, availableWidth }) => {
                             backgroundColor={dataKey === 'color' ? value : null}
                             align={align}
                         >
-                            {dataKey === 'color' ? value?.toLowerCase() : value}
+                            {dataKey === 'color'
+                                ? value?.toLowerCase()
+                                : formatWithSeparator(
+                                      value,
+                                      keyAnalysisDigitGroupSeparator
+                                  )}
                         </DataTableCell>
                     ))
                 }

--- a/src/components/datatable/__tests__/useTableData.spec.jsx
+++ b/src/components/datatable/__tests__/useTableData.spec.jsx
@@ -136,7 +136,8 @@ describe('useTableData headers', () => {
                         color: '#FFFFB2',
                         legend: 'Great',
                         range: '90 - 120',
-                        value: 106.3,
+                        value: '106.3',
+                        rawValue: 106.3,
                     },
                 },
             ],
@@ -160,7 +161,7 @@ describe('useTableData headers', () => {
             { name: 'Index', dataKey: 'index', type: 'number' },
             { name: 'Name', dataKey: 'name', type: 'string' },
             { name: 'Id', dataKey: 'id', type: 'string' },
-            { name: 'Value', dataKey: 'value', type: 'number' },
+            { name: 'Value', dataKey: 'rawValue', type: 'number' },
             { name: 'Legend', dataKey: 'legend', type: 'string' },
             { name: 'Range', dataKey: 'range', type: 'string' },
             { name: 'Level', dataKey: 'level', type: 'number' },
@@ -179,7 +180,7 @@ describe('useTableData headers', () => {
             { value: 0, dataKey: 'index' },
             { value: 'Ngelehun CHC', dataKey: 'name' },
             { value: 'thematicId-1', dataKey: 'id' },
-            { value: 106.3, dataKey: 'value' },
+            { value: 106.3, dataKey: 'rawValue' },
             { value: 'Great', dataKey: 'legend' },
             { value: '90 - 120', dataKey: 'range' },
             { value: 4, dataKey: 'level' },
@@ -544,11 +545,11 @@ describe('useTableData sorting', () => {
         layer: 'thematic',
         dataFilters: null,
         data: [
-            { id: '1', properties: { name: 'Item A', value: 10 } },
-            { id: '2', properties: { name: 'Item B', value: 5 } },
-            { id: '3', properties: { name: 'Item C', value: undefined } },
-            { id: '4', properties: { name: 'Item D', value: 15 } },
-            { id: '5', properties: { name: 'Item E', value: undefined } },
+            { id: '1', properties: { name: 'Item A', rawValue: 10 } },
+            { id: '2', properties: { name: 'Item B', rawValue: 5 } },
+            { id: '3', properties: { name: 'Item C', rawValue: undefined } },
+            { id: '4', properties: { name: 'Item D', rawValue: 15 } },
+            { id: '5', properties: { name: 'Item E', rawValue: undefined } },
         ],
     }
 
@@ -560,7 +561,7 @@ describe('useTableData sorting', () => {
             () =>
                 useTableData({
                     layer: mockLayer,
-                    sortField: 'value',
+                    sortField: 'rawValue',
                     sortDirection: 'asc',
                 }),
             {
@@ -582,7 +583,7 @@ describe('useTableData sorting', () => {
             () =>
                 useTableData({
                     layer: mockLayer,
-                    sortField: 'value',
+                    sortField: 'rawValue',
                     sortDirection: 'desc',
                 }),
             {
@@ -670,16 +671,16 @@ describe('useTableData sorting', () => {
             layer: 'thematic',
             dataFilters: null,
             data: [
-                { id: '1', properties: { name: 'Item A', value: 10 } },
+                { id: '1', properties: { name: 'Item A', rawValue: 10 } },
                 {
                     id: '2',
-                    properties: { name: 'Item B', value: undefined },
+                    properties: { name: 'Item B', rawValue: undefined },
                 },
                 {
                     id: '3',
-                    properties: { name: 'Item C', value: undefined },
+                    properties: { name: 'Item C', rawValue: undefined },
                 },
-                { id: '4', properties: { name: 'Item D', value: 5 } },
+                { id: '4', properties: { name: 'Item D', rawValue: 5 } },
             ],
         }
 
@@ -690,7 +691,7 @@ describe('useTableData sorting', () => {
             () =>
                 useTableData({
                     layer: layerWithManyUndefined,
-                    sortField: 'value',
+                    sortField: 'rawValue',
                     sortDirection: 'asc',
                 }),
             {
@@ -712,15 +713,15 @@ describe('useTableData sorting', () => {
             data: [
                 {
                     id: '1',
-                    properties: { name: 'Item A', value: undefined },
+                    properties: { name: 'Item A', rawValue: undefined },
                 },
                 {
                     id: '2',
-                    properties: { name: 'Item B', value: undefined },
+                    properties: { name: 'Item B', rawValue: undefined },
                 },
                 {
                     id: '3',
-                    properties: { name: 'Item C', value: undefined },
+                    properties: { name: 'Item C', rawValue: undefined },
                 },
             ],
         }
@@ -732,7 +733,7 @@ describe('useTableData sorting', () => {
             () =>
                 useTableData({
                     layer: layerWithAllUndefined,
-                    sortField: 'value',
+                    sortField: 'rawValue',
                     sortDirection: 'asc',
                 }),
             {

--- a/src/components/datatable/useTableData.js
+++ b/src/components/datatable/useTableData.js
@@ -25,7 +25,7 @@ const TYPE_DATE = 'date'
 const INDEX = 'index'
 const NAME = 'name'
 const ID = 'id'
-const VALUE = 'value'
+const VALUE = 'rawValue'
 const LEGEND = 'legend'
 const RANGE = 'range'
 const LEVEL = 'level'
@@ -298,30 +298,30 @@ export const useTableData = ({ layer, sortField, sortDirection }) => {
 
         //sort
         filteredData.sort((a, b) => {
-            a = a[sortField]
-            b = b[sortField]
+            const aVal = a[sortField]
+            const bVal = b[sortField]
 
             // All undefined values should be sorted to the end
-            if (a === undefined && b === undefined) {
+            if (aVal === undefined && bVal === undefined) {
                 return 0
             }
 
-            if (a === undefined) {
+            if (aVal === undefined) {
                 return 1 // a goes to end
             }
 
-            if (b === undefined) {
+            if (bVal === undefined) {
                 return -1 // b goes to end
             }
 
-            if (typeof a === TYPE_NUMBER) {
-                return sortDirection === ASCENDING ? a - b : b - a
+            if (typeof aVal === TYPE_NUMBER) {
+                return sortDirection === ASCENDING ? aVal - bVal : bVal - aVal
             }
 
             // TODO: Make sure sorting works across different locales
             return sortDirection === ASCENDING
-                ? a.localeCompare(b)
-                : b.localeCompare(a)
+                ? aVal.localeCompare(bVal)
+                : bVal.localeCompare(aVal)
         })
 
         return filteredData.map((item) =>

--- a/src/components/edit/earthEngine/LegendPreview.jsx
+++ b/src/components/edit/earthEngine/LegendPreview.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { createLegend } from '../../../loaders/earthEngineLoader.js'
 import { sortLegendItems } from '../../../util/legend.js'
+import { useCachedData } from '../../cachedDataProvider/CachedDataProvider.jsx'
 import LegendItem from '../../legend/LegendItem.jsx'
 import styles from '../styles/LayerDialog.module.css'
 
@@ -10,7 +11,12 @@ const styleIsValid = ({ min, max }) =>
     !Number.isNaN(min) && !Number.isNaN(max) && max > min
 
 const LegendPreview = ({ style, showBelowMin }) => {
-    const legend = styleIsValid(style) && createLegend(style, showBelowMin)
+    const {
+        systemSettings: { keyAnalysisDigitGroupSeparator },
+    } = useCachedData()
+    const legend =
+        styleIsValid(style) &&
+        createLegend(style, showBelowMin, keyAnalysisDigitGroupSeparator)
 
     return legend ? (
         <div className={styles.flexColumn}>

--- a/src/components/legend/Bubble.jsx
+++ b/src/components/legend/Bubble.jsx
@@ -1,7 +1,5 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { formatWithSeparator } from '../../util/numbers.js'
-import { useCachedData } from '../cachedDataProvider/CachedDataProvider.jsx'
 import { guideLength, textPadding } from './Bubbles.jsx'
 
 const Bubble = ({
@@ -13,9 +11,6 @@ const Bubble = ({
     stroke,
     pattern,
 }) => {
-    const {
-        systemSettings: { keyAnalysisDigitGroupSeparator },
-    } = useCachedData()
     const leftAlign = textAlign === 'left'
     const x = maxRadius
     const y = maxRadius * 2 - radius
@@ -55,11 +50,7 @@ const Bubble = ({
                         alignmentBaseline="middle"
                         style={{ fontSize: 12 }}
                     >
-                        {formatWithSeparator(
-                            text,
-                            keyAnalysisDigitGroupSeparator,
-                            { force: true }
-                        )}
+                        {text}
                     </text>
                 </g>
             )}

--- a/src/components/legend/Bubble.jsx
+++ b/src/components/legend/Bubble.jsx
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import { formatWithSeparator } from '../../util/numbers.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.jsx'
 import { guideLength, textPadding } from './Bubbles.jsx'
 
 const Bubble = ({
@@ -11,6 +13,9 @@ const Bubble = ({
     stroke,
     pattern,
 }) => {
+    const {
+        systemSettings: { keyAnalysisDigitGroupSeparator },
+    } = useCachedData()
     const leftAlign = textAlign === 'left'
     const x = maxRadius
     const y = maxRadius * 2 - radius
@@ -50,7 +55,11 @@ const Bubble = ({
                         alignmentBaseline="middle"
                         style={{ fontSize: 12 }}
                     >
-                        {text}
+                        {formatWithSeparator(
+                            text,
+                            keyAnalysisDigitGroupSeparator,
+                            { force: true }
+                        )}
                     </text>
                 </g>
             )}

--- a/src/components/legend/Bubbles.jsx
+++ b/src/components/legend/Bubbles.jsx
@@ -7,6 +7,8 @@ import {
     createSingleColorBubbles,
     computeLayout,
 } from '../../util/bubbles.js'
+import { formatWithSeparator } from '../../util/numbers.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.jsx'
 import Bubble from './Bubble.jsx'
 
 const style = {
@@ -25,6 +27,9 @@ const Bubbles = ({
     classes,
     isPlugin,
 }) => {
+    const {
+        systemSettings: { keyAnalysisDigitGroupSeparator },
+    } = useCachedData()
     const legendWidth = isPlugin ? 150 : 245
     const noDataClass = classes.find((c) => c.noData === true)
     const bubbleClasses = classes.filter((c) => !c.noData)
@@ -52,6 +57,18 @@ const Bubbles = ({
               radiusLow,
               radiusHigh,
           })
+
+    bubbles.forEach((bubble) => {
+        if (bubble.text !== undefined) {
+            bubble.text = formatWithSeparator(
+                bubble.text,
+                keyAnalysisDigitGroupSeparator,
+                {
+                    force: true,
+                }
+            )
+        }
+    })
 
     const { alternate, offset, showNumbers } = computeLayout({
         bubbles,

--- a/src/components/legend/LegendItemRange.jsx
+++ b/src/components/legend/LegendItemRange.jsx
@@ -1,13 +1,38 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import { formatWithSeparator } from '../../util/numbers.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.jsx'
 import styles from './styles/LegendItemRange.module.css'
 
-const LegendItemRange = ({ name = '', startValue, endValue, count }) => (
-    <td className={styles.legendItemRange}>
-        {isNaN(startValue) ? name : `${name} ${startValue} - ${endValue}`}
-        {count !== undefined ? ` (${count})` : ''}
-    </td>
-)
+const LegendItemRange = ({ name = '', startValue, endValue, count }) => {
+    const {
+        systemSettings: { keyAnalysisDigitGroupSeparator },
+    } = useCachedData()
+
+    const nameLabel = name ? `${name} ` : ''
+    const rangeLabel =
+        startValue === undefined || Number.isNaN(startValue)
+            ? ''
+            : `${formatWithSeparator(
+                  startValue,
+                  keyAnalysisDigitGroupSeparator
+              )} - ${formatWithSeparator(
+                  endValue,
+                  keyAnalysisDigitGroupSeparator
+              )}`
+    const countLabel =
+        count === undefined
+            ? ''
+            : ` (${formatWithSeparator(count, keyAnalysisDigitGroupSeparator)})`
+
+    return (
+        <td className={styles.legendItemRange}>
+            {nameLabel}
+            {rangeLabel}
+            {countLabel}
+        </td>
+    )
+}
 
 LegendItemRange.propTypes = {
     count: PropTypes.number,

--- a/src/components/map/layers/EventLayer.jsx
+++ b/src/components/map/layers/EventLayer.jsx
@@ -152,7 +152,8 @@ class EventLayer extends Layer {
     }
 
     render() {
-        const { styleDataItem, nameProperty } = this.props
+        const { styleDataItem, nameProperty, keyAnalysisDigitGroupSeparator } =
+            this.props
         const { popup, displayItems, eventCoordinateFieldName } = this.state
 
         return popup && displayItems ? (
@@ -160,6 +161,7 @@ class EventLayer extends Layer {
                 {...popup}
                 styleDataItem={styleDataItem}
                 nameProperty={nameProperty}
+                keyAnalysisDigitGroupSeparator={keyAnalysisDigitGroupSeparator}
                 displayItems={displayItems}
                 eventCoordinateFieldName={eventCoordinateFieldName}
                 onClose={this.onPopupClose}

--- a/src/components/map/layers/EventPopup.jsx
+++ b/src/components/map/layers/EventPopup.jsx
@@ -19,7 +19,12 @@ const EVENTS_QUERY = {
     },
 }
 
-const getDataRows = ({ displayItems, dataValues, orgUnitNames }) => {
+const getDataRows = ({
+    displayItems,
+    dataValues,
+    orgUnitNames,
+    keyAnalysisDigitGroupSeparator,
+}) => {
     const dataRows = []
 
     // Include rows for each data item used for styling and displayInReport
@@ -30,6 +35,7 @@ const getDataRows = ({ displayItems, dataValues, orgUnitNames }) => {
             valueType,
             options,
             orgUnitNames,
+            keyAnalysisDigitGroupSeparator,
         })
 
         dataRows.push(
@@ -53,6 +59,7 @@ const EventPopup = ({
     feature,
     styleDataItem,
     nameProperty,
+    keyAnalysisDigitGroupSeparator,
     displayItems,
     eventCoordinateFieldName,
     onClose,
@@ -151,6 +158,7 @@ const EventPopup = ({
                                 displayItems,
                                 dataValues,
                                 orgUnitNames,
+                                keyAnalysisDigitGroupSeparator,
                             })}
                         {type === 'Point' && (
                             <tr>
@@ -187,6 +195,7 @@ EventPopup.propTypes = {
     nameProperty: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
     eventCoordinateFieldName: PropTypes.string,
+    keyAnalysisDigitGroupSeparator: PropTypes.string,
     styleDataItem: PropTypes.object,
 }
 

--- a/src/components/map/layers/GeoJsonLayer.js
+++ b/src/components/map/layers/GeoJsonLayer.js
@@ -1,6 +1,7 @@
 import { GEOJSON_LAYER } from '../../../constants/layers.js'
 import { filterData } from '../../../util/filter.js'
 import { getGeojsonDisplayData } from '../../../util/geojson.js'
+import { formatWithSeparator } from '../../../util/numbers.js'
 import Layer from './Layer.js'
 
 class GeoJsonLayer extends Layer {
@@ -53,13 +54,18 @@ class GeoJsonLayer extends Layer {
     }
 
     onFeatureClick(evt) {
+        const { keyAnalysisDigitGroupSeparator } = this.props
+
         const feature = this.props.data.find(
             (d) => d.properties.id === evt.feature.properties.id
         )
 
         const data = getGeojsonDisplayData(feature).reduce(
             (acc, { dataKey, value }) => {
-                acc[dataKey] = value
+                acc[dataKey] = formatWithSeparator(
+                    value,
+                    keyAnalysisDigitGroupSeparator
+                )
                 return acc
             },
             {}

--- a/src/components/map/layers/TrackedEntityLayer.jsx
+++ b/src/components/map/layers/TrackedEntityLayer.jsx
@@ -140,7 +140,8 @@ class TrackedEntityLayer extends Layer {
     }
 
     render() {
-        const { program, nameProperty } = this.props
+        const { program, nameProperty, keyAnalysisDigitGroupSeparator } =
+            this.props
         const { popup, displayAttributes } = this.state
 
         return popup ? (
@@ -148,6 +149,7 @@ class TrackedEntityLayer extends Layer {
                 {...popup}
                 program={program}
                 nameProperty={nameProperty}
+                keyAnalysisDigitGroupSeparator={keyAnalysisDigitGroupSeparator}
                 displayAttributes={displayAttributes || []}
                 onClose={this.onPopupClose}
             />

--- a/src/components/map/layers/TrackedEntityPopup.jsx
+++ b/src/components/map/layers/TrackedEntityPopup.jsx
@@ -22,7 +22,12 @@ const TRACKED_ENTITIES_QUERY = {
     },
 }
 
-const getDataRows = ({ displayAttributes, attributes, orgUnitNames }) => {
+const getDataRows = ({
+    displayAttributes,
+    attributes,
+    orgUnitNames,
+    keyAnalysisDigitGroupSeparator,
+}) => {
     const dataRows = []
 
     // Include rows for each displayInList attribute
@@ -33,6 +38,7 @@ const getDataRows = ({ displayAttributes, attributes, orgUnitNames }) => {
             valueType,
             options,
             orgUnitNames,
+            keyAnalysisDigitGroupSeparator,
         })
 
         dataRows.push(
@@ -57,6 +63,7 @@ const TrackedEntityPopup = ({
     activeDataSource,
     program,
     nameProperty,
+    keyAnalysisDigitGroupSeparator,
     displayAttributes,
     onClose,
 }) => {
@@ -154,6 +161,7 @@ const TrackedEntityPopup = ({
                                 displayAttributes,
                                 attributes,
                                 orgUnitNames,
+                                keyAnalysisDigitGroupSeparator,
                             })}
                         {type === 'Point' && (
                             <tr>
@@ -187,6 +195,7 @@ TrackedEntityPopup.propTypes = {
     nameProperty: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
     activeDataSource: PropTypes.string,
+    keyAnalysisDigitGroupSeparator: PropTypes.string,
     program: PropTypes.object,
 }
 

--- a/src/components/map/layers/earthEngine/EarthEngineLayer.jsx
+++ b/src/components/map/layers/earthEngine/EarthEngineLayer.jsx
@@ -216,7 +216,12 @@ export default class EarthEngineLayer extends Layer {
     }
 
     render() {
-        const { legend, aggregationType, loadError } = this.props
+        const {
+            legend,
+            aggregationType,
+            keyAnalysisDigitGroupSeparator,
+            loadError,
+        } = this.props
         const { isLoading, popup, aggregations, error } = this.state
 
         return (
@@ -235,6 +240,9 @@ export default class EarthEngineLayer extends Layer {
                         legend={legend}
                         valueType={aggregationType}
                         onClose={this.onPopupClose}
+                        keyAnalysisDigitGroupSeparator={
+                            keyAnalysisDigitGroupSeparator
+                        }
                         {...popup}
                     />
                 )}

--- a/src/components/map/layers/earthEngine/EarthEnginePopup.jsx
+++ b/src/components/map/layers/earthEngine/EarthEnginePopup.jsx
@@ -7,13 +7,29 @@ import { hasClasses } from '../../../../util/earthEngine.js'
 import {
     getRoundToPrecisionFn,
     getPrecision,
+    formatWithSeparator,
 } from '../../../../util/numbers.js'
 import Popup from '../../Popup.jsx'
 import styles from '../styles/Popup.module.css'
 import earthEngineStyles from './styles/EarthEnginePopup.module.css'
 
+const getValuesForType = (data, type) =>
+    Object.values(data).flatMap((ou) =>
+        Object.entries(ou)
+            .filter(([key]) => key.includes(type))
+            .map(([, val]) => val)
+    )
+
 const EarthEnginePopup = (props) => {
-    const { coordinates, feature, data, legend, valueType, onClose } = props
+    const {
+        coordinates,
+        feature,
+        data,
+        legend,
+        valueType,
+        onClose,
+        keyAnalysisDigitGroupSeparator,
+    } = props
     const { id, name } = feature.properties
     const { title, unit, items = [], groups } = legend
     const values = typeof data === 'object' ? data[id] : null
@@ -24,7 +40,11 @@ const EarthEnginePopup = (props) => {
 
     if (values) {
         if (classes) {
-            const valueFormat = getRoundToPrecisionFn(isPercentage ? 2 : 0)
+            const valueFormat = (value) =>
+                formatWithSeparator(
+                    getRoundToPrecisionFn(isPercentage ? 2 : 0)(value),
+                    keyAnalysisDigitGroupSeparator
+                )
 
             table = (
                 <table className={earthEngineStyles.table}>
@@ -70,17 +90,12 @@ const EarthEnginePopup = (props) => {
                     : `${group}_${type}`
 
             // Returns the value format (precision) for an aggregation type
-            const getValueFormat = (type) =>
-                getRoundToPrecisionFn(
-                    getPrecision(
-                        Object.values(data)
-                            .map((ou) =>
-                                Object.keys(ou)
-                                    .filter((key) => key.includes(type))
-                                    .map((key) => ou[key])
-                            )
-                            .flat()
-                    )
+            const getValueFormat = (type) => (value) =>
+                formatWithSeparator(
+                    getRoundToPrecisionFn(
+                        getPrecision(getValuesForType(data, type))
+                    )(value),
+                    keyAnalysisDigitGroupSeparator
                 )
 
             // Create value format function for each aggregation type
@@ -191,6 +206,7 @@ EarthEnginePopup.propTypes = {
     legend: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired,
     data: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    keyAnalysisDigitGroupSeparator: PropTypes.string,
     valueType: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
 }
 

--- a/src/components/orgunits/OrgUnitData.jsx
+++ b/src/components/orgunits/OrgUnitData.jsx
@@ -3,10 +3,12 @@ import i18n from '@dhis2/d2-i18n'
 import { CircularLoader } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useState, useEffect } from 'react'
+import { formatWithSeparator } from '../../util/numbers.js'
 import {
     getFixedPeriodsByType,
     filterFuturePeriods,
 } from '../../util/periods.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.jsx'
 import PeriodSelect from '../periods/PeriodSelect.jsx'
 import styles from './styles/OrgUnitData.module.css'
 
@@ -31,6 +33,9 @@ const defaultPeriod = filterFuturePeriods(periods)[0] || periods[0]
  * (data elements, indicators, reporting rates, program indicators)
  */
 const OrgUnitData = ({ id }) => {
+    const {
+        systemSettings: { keyAnalysisDigitGroupSeparator },
+    } = useCachedData()
     const [period, setPeriod] = useState(defaultPeriod)
     const { loading, data, refetch } = useDataQuery(ORGUNIT_PROFILE_QUERY, {
         lazy: true,
@@ -69,7 +74,12 @@ const OrgUnitData = ({ id }) => {
                                     ({ id, label, value }) => (
                                         <tr key={id}>
                                             <th>{label}</th>
-                                            <td>{value}</td>
+                                            <td>
+                                                {formatWithSeparator(
+                                                    value,
+                                                    keyAnalysisDigitGroupSeparator
+                                                )}
+                                            </td>
                                         </tr>
                                     )
                                 )}

--- a/src/components/orgunits/OrgUnitInfo.jsx
+++ b/src/components/orgunits/OrgUnitInfo.jsx
@@ -3,8 +3,12 @@ import i18n from '@dhis2/d2-i18n'
 import { IconDimensionOrgUnit16 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { getRoundToPrecisionFn } from '../../util/numbers.js'
+import {
+    getRoundToPrecisionFn,
+    formatWithSeparator,
+} from '../../util/numbers.js'
 import { formatDate } from '../../util/time.js'
+import { useCachedData } from '../cachedDataProvider/CachedDataProvider.jsx'
 import ListItem from '../core/ListItem.jsx'
 import styles from './styles/OrgUnitInfo.module.css'
 
@@ -41,6 +45,9 @@ const OrgUnitInfo = ({
     url,
 }) => {
     const { baseUrl } = useConfig()
+    const {
+        systemSettings: { keyAnalysisDigitGroupSeparator },
+    } = useCachedData()
     return (
         <div className={styles.info} data-test="org-unit-info">
             {imageId && (
@@ -111,7 +118,10 @@ const OrgUnitInfo = ({
                 <ListItem label={i18n.t('Comment')}>{comment}</ListItem>
                 {attributes.map(({ id, label, value }) => (
                     <ListItem key={id} label={label}>
-                        {value}
+                        {formatWithSeparator(
+                            value,
+                            keyAnalysisDigitGroupSeparator
+                        )}
                     </ListItem>
                 ))}
             </div>

--- a/src/components/orgunits/__tests__/OrgUnitInfo.spec.jsx
+++ b/src/components/orgunits/__tests__/OrgUnitInfo.spec.jsx
@@ -6,6 +6,12 @@ jest.mock('@dhis2/app-runtime', () => ({
     useConfig: jest.fn(() => ({ baseUrl: 'dhis2' })),
 }))
 
+jest.mock('../../cachedDataProvider/CachedDataProvider.jsx', () => ({
+    useCachedData: jest.fn(() => ({
+        systemSettings: { keyAnalysisDigitGroupSeparator: 'NONE' },
+    })),
+}))
+
 const groupSets = [
     {
         id: 'Bpx0589u8y0',

--- a/src/components/plugin/LayerLoader.jsx
+++ b/src/components/plugin/LayerLoader.jsx
@@ -28,7 +28,10 @@ const LayerLoader = ({ config, onLoad }) => {
     const { baseUrl, serverVersion } = useConfig()
     const engine = useDataEngine()
     const [analyticsEngine] = useState(() => Analytics.getAnalytics(engine))
-    const { currentUser } = useCachedData()
+    const {
+        systemSettings: { keyAnalysisDigitGroupSeparator },
+        currentUser,
+    } = useCachedData()
     const { keyAnalysisDisplayProperty, id: userId } = currentUser
     const periodTypeData = useDataOutputPeriodTypes()
 
@@ -45,6 +48,7 @@ const LayerLoader = ({ config, onLoad }) => {
             config,
             engine,
             keyAnalysisDisplayProperty, // name/shortName
+            keyAnalysisDigitGroupSeparator, // NONE/SPACE/COMMA
             userId,
             baseUrl,
             analyticsEngine, // Thematic and Event loader
@@ -62,6 +66,7 @@ const LayerLoader = ({ config, onLoad }) => {
         userId,
         baseUrl,
         keyAnalysisDisplayProperty,
+        keyAnalysisDigitGroupSeparator,
         serverVersion,
     ])
 

--- a/src/constants/settings.js
+++ b/src/constants/settings.js
@@ -3,11 +3,17 @@ import { MAP_SERVICE_KEY_TESTS } from './layers.js'
 
 export const apiVersion = 40
 
+export const DIGIT_GROUP_SEPARATOR_SPACE = 'SPACE'
+export const DIGIT_GROUP_SEPARATOR_COMMA = 'COMMA'
+export const DIGIT_GROUP_SEPARATOR_NONE = 'NONE'
+
 export const DEFAULT_SYSTEM_SETTINGS = {
     keyDefaultBaseMap: FALLBACK_BASEMAP_ID,
+    keyAnalysisDigitGroupSeparator: DIGIT_GROUP_SEPARATOR_NONE,
 }
 
 export const SYSTEM_SETTINGS = [
+    'keyAnalysisDigitGroupSeparator',
     'keyAnalysisRelativePeriod',
     'keyHideDailyPeriods',
     'keyHideWeeklyPeriods',

--- a/src/hooks/useLayersLoader.js
+++ b/src/hooks/useLayersLoader.js
@@ -31,7 +31,10 @@ export const useLayersLoader = () => {
     const { baseUrl, serverVersion } = useConfig()
     const engine = useDataEngine()
     const [analyticsEngine] = useState(() => Analytics.getAnalytics(engine))
-    const { currentUser } = useCachedData()
+    const {
+        systemSettings: { keyAnalysisDigitGroupSeparator },
+        currentUser,
+    } = useCachedData()
     const { showAlerts } = useLoaderAlerts()
     const allLayers = useSelector((state) => state.map.mapViews)
     const dataTable = useSelector((state) => state.dataTable)
@@ -50,6 +53,7 @@ export const useLayersLoader = () => {
                 config,
                 engine,
                 keyAnalysisDisplayProperty, // name/shortName
+                keyAnalysisDigitGroupSeparator, // NONE/SPACE/COMMA
                 userId,
                 baseUrl,
                 analyticsEngine, // Thematic and Event loader
@@ -108,6 +112,7 @@ export const useLayersLoader = () => {
         allLayers,
         dispatch,
         keyAnalysisDisplayProperty,
+        keyAnalysisDigitGroupSeparator,
         userId,
         engine,
         analyticsEngine,

--- a/src/loaders/__tests__/earthEngineLoader.spec.js
+++ b/src/loaders/__tests__/earthEngineLoader.spec.js
@@ -1,0 +1,89 @@
+import {
+    DIGIT_GROUP_SEPARATOR_COMMA,
+    DIGIT_GROUP_SEPARATOR_NONE,
+    DIGIT_GROUP_SEPARATOR_SPACE,
+} from '../../constants/settings.js'
+import { createLegend } from '../earthEngineLoader.js'
+
+jest.mock('../../components/map/MapApi.js', () => ({
+    loadEarthEngineWorker: jest.fn(),
+}))
+
+describe('createLegend', () => {
+    describe('when ranges are provided', () => {
+        it('maps palette colors to ranges and ignores separator', () => {
+            const style = {
+                min: 0,
+                max: 100,
+                palette: ['red', 'blue'],
+                ranges: [
+                    { startValue: 0, endValue: 50, name: 'Low' },
+                    { startValue: 50, endValue: 100, name: 'High' },
+                ],
+            }
+            const items = createLegend(
+                style,
+                false,
+                DIGIT_GROUP_SEPARATOR_COMMA
+            )
+            expect(items).toHaveLength(2)
+            const low = items.find((i) => i.name === 'Low')
+            const high = items.find((i) => i.name === 'High')
+            expect(low.color).toBe('red')
+            expect(high.color).toBe('blue')
+        })
+    })
+
+    describe('when ranges are not provided', () => {
+        const style = { min: 1000, max: 3000, palette: ['#a', '#b'] }
+
+        it('formats item names with COMMA separator', () => {
+            const items = createLegend(
+                style,
+                false,
+                DIGIT_GROUP_SEPARATOR_COMMA
+            )
+            const names = items.map((i) => i.name)
+            expect(names).toContain('1,000 - 3,000')
+            expect(names).toContain('> 3,000')
+        })
+
+        it('formats item names with SPACE separator', () => {
+            const items = createLegend(
+                style,
+                false,
+                DIGIT_GROUP_SEPARATOR_SPACE
+            )
+            const names = items.map((i) => i.name)
+            expect(names).toContain('1 000 - 3 000')
+            expect(names).toContain('> 3 000')
+        })
+
+        it('does not group digits with NONE separator', () => {
+            const items = createLegend(style, false, DIGIT_GROUP_SEPARATOR_NONE)
+            const names = items.map((i) => i.name)
+            expect(names).toContain('1000 - 3000')
+            expect(names).toContain('> 3000')
+        })
+
+        it('includes a "less than min" item when showBelowMin is true', () => {
+            const items = createLegend(
+                { min: 1000, max: 3000, palette: ['#a', '#b', '#c'] },
+                true,
+                DIGIT_GROUP_SEPARATOR_COMMA
+            )
+            const belowMin = items.find((i) => i.from === -Infinity)
+            expect(belowMin).toBeDefined()
+            expect(belowMin.name).toBe('< 1,000')
+        })
+
+        it('sets correct from/to boundaries for range items', () => {
+            const items = createLegend(style, false, DIGIT_GROUP_SEPARATOR_NONE)
+            const rangeItem = items.find(
+                (i) => i.from !== undefined && i.to !== undefined
+            )
+            expect(rangeItem.from).toBe(1000)
+            expect(rangeItem.to).toBe(3000)
+        })
+    })
+})

--- a/src/loaders/earthEngineLoader.js
+++ b/src/loaders/earthEngineLoader.js
@@ -14,7 +14,7 @@ import {
 } from '../util/earthEngine.js'
 import { sortLegendItems } from '../util/legend.js'
 import { toGeoJson } from '../util/map.js'
-import { getRoundToPrecisionFn } from '../util/numbers.js'
+import { getRoundToPrecisionFn, formatWithSeparator } from '../util/numbers.js'
 import {
     getCoordinateField,
     addAssociatedGeometries,
@@ -25,6 +25,7 @@ const earthEngineLoader = async ({
     config,
     engine,
     keyAnalysisDisplayProperty,
+    keyAnalysisDigitGroupSeparator,
     userId,
 }) => {
     const { format, rows, aggregationType } = config
@@ -201,7 +202,11 @@ const earthEngineLoader = async ({
         !hasClasses(aggregationType) &&
         style?.palette
     ) {
-        legend.items = createLegend(style, !maskOperator)
+        legend.items = createLegend(
+            style,
+            !maskOperator,
+            keyAnalysisDigitGroupSeparator
+        )
     }
 
     const filter = getStaticFilterFromPeriod(period, filters)
@@ -211,6 +216,7 @@ const earthEngineLoader = async ({
         legend,
         name,
         data,
+        keyAnalysisDigitGroupSeparator,
         filter,
         alerts,
         isLoaded: true,
@@ -221,7 +227,11 @@ const earthEngineLoader = async ({
     }
 }
 
-export const createLegend = ({ min, max, palette, ranges }, showBelowMin) => {
+export const createLegend = (
+    { min, max, palette, ranges },
+    showBelowMin,
+    keyAnalysisDigitGroupSeparator
+) => {
     if (ranges && ranges.length === palette.length) {
         return sortLegendItems(
             ranges.map((range, index) => ({
@@ -246,16 +256,23 @@ export const createLegend = ({ min, max, palette, ranges }, showBelowMin) => {
                 // Less than min
                 item.from = -Infinity
                 item.to = min
-                item.name = '< ' + min
+                item.name =
+                    '< ' +
+                    formatWithSeparator(min, keyAnalysisDigitGroupSeparator)
                 to = min
             } else if (+from < max) {
                 item.from = +from
                 item.to = +to
-                item.name = from + ' - ' + to
+                item.name =
+                    formatWithSeparator(from, keyAnalysisDigitGroupSeparator) +
+                    ' - ' +
+                    formatWithSeparator(to, keyAnalysisDigitGroupSeparator)
             } else {
                 // Higher than max
                 item.from = +from
-                item.name = '> ' + from
+                item.name =
+                    '> ' +
+                    formatWithSeparator(from, keyAnalysisDigitGroupSeparator)
             }
 
             from = to

--- a/src/loaders/eventLoader.js
+++ b/src/loaders/eventLoader.js
@@ -47,11 +47,15 @@ const eventLoader = async ({
     config: layerConfig,
     engine,
     keyAnalysisDisplayProperty,
+    keyAnalysisDigitGroupSeparator,
     analyticsEngine,
     periodTypeData,
     loadExtended,
 }) => {
-    const config = { ...layerConfig }
+    const config = {
+        ...layerConfig,
+        keyAnalysisDigitGroupSeparator,
+    }
     const displayNameProp =
         keyAnalysisDisplayProperty === 'name'
             ? 'displayName'

--- a/src/loaders/geoJsonUrlLoader.js
+++ b/src/loaders/geoJsonUrlLoader.js
@@ -45,7 +45,12 @@ const fetchData = async (url, engine, baseUrl) => {
 }
 
 const EMPTY_FEATURE_STYLE = {}
-const geoJsonUrlLoader = async ({ config: layer, engine, baseUrl }) => {
+const geoJsonUrlLoader = async ({
+    config: layer,
+    engine,
+    baseUrl,
+    keyAnalysisDigitGroupSeparator,
+}) => {
     const { config } = layer
 
     let newConfig
@@ -114,9 +119,10 @@ const geoJsonUrlLoader = async ({ config: layer, engine, baseUrl }) => {
 
     return {
         ...layer,
-        name: newConfig.name, // TODO - will be fixed by DHIS2-16088
+        name: newConfig.name, // Overrides layer.name from spread — redundant on 2.42+ (DHIS2-16088), remove when 2.41 support is dropped
         legend,
         data,
+        keyAnalysisDigitGroupSeparator,
         config: newConfig,
         featureStyle,
         isLoaded: true,

--- a/src/loaders/geoJsonUrlLoader.js
+++ b/src/loaders/geoJsonUrlLoader.js
@@ -119,7 +119,7 @@ const geoJsonUrlLoader = async ({
 
     return {
         ...layer,
-        name: newConfig.name, // Overrides layer.name from spread — redundant on 2.42+ (DHIS2-16088), remove when 2.41 support is dropped
+        name: newConfig.name, // VERSION-TOGGLE: remove when 41 is lowest supported version, overrides layer.name from spread (DHIS2-16088)
         legend,
         data,
         keyAnalysisDigitGroupSeparator,

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -34,6 +34,7 @@ import {
     getAutomaticLegendItems,
 } from '../util/legend.js'
 import { toGeoJson } from '../util/map.js'
+import { formatWithSeparator } from '../util/numbers.js'
 import {
     getCoordinateField,
     addAssociatedGeometries,
@@ -45,6 +46,7 @@ const thematicLoader = async ({
     config,
     engine,
     keyAnalysisDisplayProperty,
+    keyAnalysisDigitGroupSeparator,
     userId,
     analyticsEngine,
     periodTypeData,
@@ -301,7 +303,13 @@ const thematicLoader = async ({
                         ? ORG_UNIT_COLOR
                         : legendItem.color
                 properties.legend = legendItem.name // Shown in data table
-                properties.range = `${legendItem.startValue} - ${legendItem.endValue}` // Shown in data table
+                properties.range = `${formatWithSeparator(
+                    legendItem.startValue,
+                    keyAnalysisDigitGroupSeparator
+                )} - ${formatWithSeparator(
+                    legendItem.endValue,
+                    keyAnalysisDigitGroupSeparator
+                )}` // Shown in data table
             }
 
             // Only count org units once in legend
@@ -312,7 +320,11 @@ const thematicLoader = async ({
                 }
             }
 
-            properties.value = value
+            properties.value = formatWithSeparator(
+                value,
+                keyAnalysisDigitGroupSeparator
+            ) // Shown in tooltip, label, pop-up, data table
+            properties.rawValue = value // Numeric form for data table sorting
             properties.radius = hasAdditionalGeometry
                 ? ORG_UNIT_RADIUS_SMALL
                 : getRadiusForValue(value) || THEMATIC_RADIUS_DEFAULT

--- a/src/loaders/trackedEntityLoader.js
+++ b/src/loaders/trackedEntityLoader.js
@@ -100,7 +100,16 @@ const TRACKED_ENTITY_TYPES_QUERY = {
     },
 }
 
-const trackedEntityLoader = async ({ config, engine, serverVersion }) => {
+const toGeoJson = (instances) =>
+    instances.map(({ id, geometry }) => ({
+        type: GEO_TYPE_FEATURE,
+        geometry,
+        properties: {
+            id,
+        },
+    }))
+
+const parseJsonConfig = (config) => {
     if (config.config && typeof config.config === 'string') {
         try {
             const customConfig = JSON.parse(config.config)
@@ -116,6 +125,113 @@ const trackedEntityLoader = async ({ config, engine, serverVersion }) => {
         }
         delete config.config
     }
+}
+
+const fetchRelationshipData = async ({
+    engine,
+    isVersion40,
+    instances,
+    relationshipTypeID,
+    orgUnits,
+    organisationUnitSelectionMode,
+    relatedPointColor,
+    relatedPointRadius,
+    relationshipLineColor,
+    legend,
+}) => {
+    const { relationshipType } = await engine.query(
+        { relationshipType: RELATIONSHIP_TYPES_QUERY },
+        { variables: { id: relationshipTypeID } }
+    )
+
+    const { relatedEntityType } = await engine.query(
+        { relatedEntityType: TRACKED_ENTITY_TYPES_QUERY },
+        {
+            variables: {
+                id: relationshipType.toConstraint.trackedEntityType.id,
+            },
+        }
+    )
+
+    const isPoint =
+        relatedEntityType.featureType === GEO_TYPE_POINT.toUpperCase()
+
+    legend.items.push(
+        {
+            type: GEO_TYPE_LINE,
+            name: relationshipType.displayName,
+            color: relationshipLineColor || TEI_RELATIONSHIP_LINE_COLOR,
+            weight: 1,
+        },
+        {
+            name: `${relatedEntityType.displayName} (${i18n.t('related')})`,
+            color: relatedPointColor || TEI_RELATED_COLOR,
+            radius: isPoint
+                ? relatedPointRadius || TEI_RELATED_RADIUS
+                : undefined,
+            weight: isPoint ? undefined : 1,
+        }
+    )
+
+    const dataWithRels = await getDataWithRelationships({
+        isVersion40,
+        instances,
+        queryOptions: {
+            relationshipType,
+            orgUnits,
+            organisationUnitSelectionMode,
+        },
+        engine,
+    })
+
+    return {
+        data: toGeoJson(dataWithRels.primary),
+        relationships: dataWithRels.relationships,
+        secondaryData: toGeoJson(dataWithRels.secondary),
+    }
+}
+
+const buildQueryVariables = ({
+    fields,
+    orgUnits,
+    orgUnitMode,
+    program,
+    programStatus,
+    followUp,
+    trackedEntityType,
+    periodType,
+    startDate,
+    endDate,
+}) => {
+    const followUpBool = followUp ? 'TRUE' : 'FALSE'
+    const boolFollowUp =
+        program && followUp !== undefined ? followUpBool : undefined
+
+    return {
+        fields,
+        orgUnits,
+        orgUnitMode,
+        program: program?.id,
+        programStatus,
+        followUp: boolFollowUp,
+        trackedEntityType: program ? undefined : trackedEntityType?.id,
+        enrollmentEnrolledAfter:
+            periodType === 'program' ? trimTime(startDate) : undefined,
+        enrollmentEnrolledBefore:
+            periodType === 'program' ? trimTime(endDate) : undefined,
+        updatedAfter:
+            periodType === 'program' ? undefined : trimTime(startDate),
+        updatedBefore: periodType === 'program' ? undefined : trimTime(endDate),
+    }
+}
+
+const trackedEntityLoader = async ({
+    config,
+    engine,
+    keyAnalysisDigitGroupSeparator,
+    serverVersion,
+}) => {
+    parseJsonConfig(config)
 
     const {
         trackedEntityType,
@@ -164,7 +280,6 @@ const trackedEntityLoader = async ({ config, engine, serverVersion }) => {
 
     const fieldsWithRelationships = [...fields, 'relationships']
     let explanation
-    let boolFollowUp = undefined
 
     if (program && programStatus) {
         explanation = `${i18n.t('Program status')}: ${
@@ -172,30 +287,21 @@ const trackedEntityLoader = async ({ config, engine, serverVersion }) => {
         }`
     }
 
-    if (program && followUp !== undefined) {
-        boolFollowUp = followUp ? 'TRUE' : 'FALSE'
-    }
-
     const { trackedEntities } = await engine.query(
         { trackedEntities: isVersion40 ? TEI_40_QUERY : TEI_41_QUERY },
         {
-            variables: {
+            variables: buildQueryVariables({
                 fields: fieldsWithRelationships,
-                orgUnits: orgUnits,
+                orgUnits,
                 orgUnitMode: organisationUnitSelectionMode,
-                program: program?.id,
+                program,
                 programStatus,
-                followUp: boolFollowUp,
-                trackedEntityType: !program ? trackedEntityType?.id : undefined,
-                enrollmentEnrolledAfter:
-                    periodType === 'program' ? trimTime(startDate) : undefined,
-                enrollmentEnrolledBefore:
-                    periodType === 'program' ? trimTime(endDate) : undefined,
-                updatedAfter:
-                    periodType !== 'program' ? trimTime(startDate) : undefined,
-                updatedBefore:
-                    periodType !== 'program' ? trimTime(endDate) : undefined,
-            },
+                followUp,
+                trackedEntityType,
+                periodType,
+                startDate,
+                endDate,
+            }),
         }
     )
 
@@ -219,58 +325,18 @@ const trackedEntityLoader = async ({ config, engine, serverVersion }) => {
     let data, relationships, secondaryData
 
     if (relationshipTypeID) {
-        const { relationshipType } = await engine.query(
-            { relationshipType: RELATIONSHIP_TYPES_QUERY },
-            {
-                variables: {
-                    id: relationshipTypeID,
-                },
-            }
-        )
-
-        const { relatedEntityType } = await engine.query(
-            { relatedEntityType: TRACKED_ENTITY_TYPES_QUERY },
-            {
-                variables: {
-                    id: relationshipType.toConstraint.trackedEntityType.id,
-                },
-            }
-        )
-
-        const isPoint =
-            relatedEntityType.featureType === GEO_TYPE_POINT.toUpperCase()
-
-        legend.items.push(
-            {
-                type: GEO_TYPE_LINE,
-                name: relationshipType.displayName,
-                color: relationshipLineColor || TEI_RELATIONSHIP_LINE_COLOR,
-                weight: 1,
-            },
-            {
-                name: `${relatedEntityType.displayName} (${i18n.t('related')})`,
-                color: relatedPointColor || TEI_RELATED_COLOR,
-                radius: isPoint
-                    ? relatedPointRadius || TEI_RELATED_RADIUS
-                    : undefined,
-                weight: !isPoint ? 1 : undefined,
-            }
-        )
-
-        const dataWithRels = await getDataWithRelationships({
+        ;({ data, relationships, secondaryData } = await fetchRelationshipData({
+            engine,
             isVersion40,
             instances,
-            queryOptions: {
-                relationshipType,
-                orgUnits,
-                organisationUnitSelectionMode,
-            },
-            engine,
-        })
-
-        data = toGeoJson(dataWithRels.primary)
-        relationships = dataWithRels.relationships
-        secondaryData = toGeoJson(dataWithRels.secondary)
+            relationshipTypeID,
+            orgUnits,
+            organisationUnitSelectionMode,
+            relatedPointColor,
+            relatedPointRadius,
+            relationshipLineColor,
+            legend,
+        }))
     } else {
         data = toGeoJson(instances)
     }
@@ -283,6 +349,7 @@ const trackedEntityLoader = async ({ config, engine, serverVersion }) => {
         ...config,
         name,
         data,
+        keyAnalysisDigitGroupSeparator,
         relationships,
         secondaryData,
         legend,
@@ -293,14 +360,5 @@ const trackedEntityLoader = async ({ config, engine, serverVersion }) => {
         isVisible: true,
     }
 }
-
-const toGeoJson = (instances) =>
-    instances.map(({ id, geometry }) => ({
-        type: GEO_TYPE_FEATURE,
-        geometry,
-        properties: {
-            id,
-        },
-    }))
 
 export default trackedEntityLoader

--- a/src/util/__tests__/bubbles.spec.js
+++ b/src/util/__tests__/bubbles.spec.js
@@ -28,6 +28,7 @@ jest.mock('../helpers.js', () => ({
 }))
 
 jest.mock('../numbers.js', () => ({
+    formatWithSeparator: jest.fn((n) => String(n)),
     getRoundToPrecisionFn: jest.fn(() => (n) => n),
 }))
 

--- a/src/util/__tests__/bubbles.spec.js
+++ b/src/util/__tests__/bubbles.spec.js
@@ -28,7 +28,7 @@ jest.mock('../helpers.js', () => ({
 }))
 
 jest.mock('../numbers.js', () => ({
-    formatWithSeparator: jest.fn((n) => String(n)),
+    formatWithSeparator: jest.fn(String),
     getRoundToPrecisionFn: jest.fn(() => (n) => n),
 }))
 

--- a/src/util/__tests__/helpers.spec.js
+++ b/src/util/__tests__/helpers.spec.js
@@ -1,3 +1,8 @@
+import {
+    DIGIT_GROUP_SEPARATOR_COMMA,
+    DIGIT_GROUP_SEPARATOR_NONE,
+    DIGIT_GROUP_SEPARATOR_SPACE,
+} from '../../constants/settings.js'
 import { formatValueForDisplay, sumObjectValues } from '../helpers.js'
 
 describe('formatValueForDisplay', () => {
@@ -136,6 +141,66 @@ describe('formatValueForDisplay', () => {
         },
     ])('$desc', ({ input, expected }) => {
         expect(formatValueForDisplay(input)).toBe(expected)
+    })
+
+    describe('formats number value types with digit group separator', () => {
+        it.each([
+            'NUMBER',
+            'INTEGER',
+            'INTEGER_POSITIVE',
+            'INTEGER_NEGATIVE',
+            'INTEGER_ZERO_OR_POSITIVE',
+            'PERCENTAGE',
+            'UNIT_INTERVAL',
+        ])('formats %s with COMMA separator', (valueType) => {
+            expect(
+                formatValueForDisplay({
+                    value: '1234567',
+                    valueType,
+                    keyAnalysisDigitGroupSeparator: DIGIT_GROUP_SEPARATOR_COMMA,
+                })
+            ).toBe('1,234,567')
+        })
+
+        it('formats NUMBER with SPACE separator', () => {
+            expect(
+                formatValueForDisplay({
+                    value: '1234567',
+                    valueType: 'NUMBER',
+                    keyAnalysisDigitGroupSeparator: DIGIT_GROUP_SEPARATOR_SPACE,
+                })
+            ).toBe('1 234 567')
+        })
+
+        it('returns plain value with NONE separator', () => {
+            expect(
+                formatValueForDisplay({
+                    value: '1234567',
+                    valueType: 'NUMBER',
+                    keyAnalysisDigitGroupSeparator: DIGIT_GROUP_SEPARATOR_NONE,
+                })
+            ).toBe('1234567')
+        })
+
+        it('preserves decimal part', () => {
+            expect(
+                formatValueForDisplay({
+                    value: '1234.56',
+                    valueType: 'NUMBER',
+                    keyAnalysisDigitGroupSeparator: DIGIT_GROUP_SEPARATOR_COMMA,
+                })
+            ).toBe('1,234.56')
+        })
+
+        it('does not apply separator to non-number types like TEXT', () => {
+            expect(
+                formatValueForDisplay({
+                    value: '1234567',
+                    valueType: 'TEXT',
+                    keyAnalysisDigitGroupSeparator: DIGIT_GROUP_SEPARATOR_COMMA,
+                })
+            ).toBe('1234567')
+        })
     })
 
     it('returns raw value for other DHIS2 types not specially handled', () => {

--- a/src/util/__tests__/numbers.spec.js
+++ b/src/util/__tests__/numbers.spec.js
@@ -1,4 +1,14 @@
-import { formatCount, getPrecision } from '../numbers.js'
+import {
+    DIGIT_GROUP_SEPARATOR_COMMA,
+    DIGIT_GROUP_SEPARATOR_NONE,
+    DIGIT_GROUP_SEPARATOR_SPACE,
+} from '../../constants/settings.js'
+import {
+    formatCount,
+    getPrecision,
+    formatWithSeparator,
+    parseWithSeparator,
+} from '../numbers.js'
 
 describe('numbers', () => {
     describe('formatCount', () => {
@@ -78,6 +88,119 @@ describe('numbers', () => {
 
         it('returns 2 with negative max and absValue >=100 and gapValue <= 1', () => {
             expect(getPrecision([-100.67, -100.1, -100.2, -100.3])).toEqual(2)
+        })
+    })
+
+    describe('formatWithSeparator', () => {
+        it('formats positive integers with comma separator', () => {
+            expect(
+                formatWithSeparator(1234567, DIGIT_GROUP_SEPARATOR_COMMA)
+            ).toBe('1,234,567')
+        })
+
+        it('formats positive integers with space separator', () => {
+            expect(
+                formatWithSeparator(1234567, DIGIT_GROUP_SEPARATOR_SPACE)
+            ).toBe('1 234 567')
+        })
+
+        it('does not group with NONE separator', () => {
+            expect(
+                formatWithSeparator(1234567, DIGIT_GROUP_SEPARATOR_NONE)
+            ).toBe('1234567')
+        })
+
+        it('handles negative numbers', () => {
+            expect(
+                formatWithSeparator(-1234567, DIGIT_GROUP_SEPARATOR_COMMA)
+            ).toBe('-1,234,567')
+        })
+
+        it('preserves decimals', () => {
+            expect(
+                formatWithSeparator(1234.56, DIGIT_GROUP_SEPARATOR_COMMA)
+            ).toBe('1,234.56')
+        })
+
+        it('applies precision when specified', () => {
+            expect(
+                formatWithSeparator(1234.5, DIGIT_GROUP_SEPARATOR_COMMA, {
+                    precision: 3,
+                })
+            ).toBe('1,234.500')
+        })
+
+        it('handles zero', () => {
+            expect(formatWithSeparator(0, DIGIT_GROUP_SEPARATOR_COMMA)).toBe(
+                '0'
+            )
+        })
+
+        it('handles numbers below 1000 without grouping', () => {
+            expect(formatWithSeparator(42, DIGIT_GROUP_SEPARATOR_COMMA)).toBe(
+                '42'
+            )
+        })
+
+        it('returns non-numeric input unchanged', () => {
+            expect(
+                formatWithSeparator('hello', DIGIT_GROUP_SEPARATOR_COMMA)
+            ).toBe('hello')
+            expect(
+                formatWithSeparator(null, DIGIT_GROUP_SEPARATOR_COMMA)
+            ).toBeNull()
+            expect(
+                formatWithSeparator(undefined, DIGIT_GROUP_SEPARATOR_COMMA)
+            ).toBeUndefined()
+        })
+
+        it('forces formatting of numeric strings when force: true', () => {
+            expect(
+                formatWithSeparator('1234.56', DIGIT_GROUP_SEPARATOR_COMMA, {
+                    force: true,
+                })
+            ).toBe('1,234.56')
+        })
+
+        it('treats unknown separator values as NONE', () => {
+            expect(formatWithSeparator(1234, 'WEIRD')).toBe(
+                formatWithSeparator(1234, DIGIT_GROUP_SEPARATOR_NONE)
+            )
+        })
+    })
+
+    describe('parseWithSeparator', () => {
+        it('parses comma-separated integers', () => {
+            expect(parseWithSeparator('1,234,567')).toBe(1234567)
+        })
+
+        it('parses space-separated integers', () => {
+            expect(parseWithSeparator('1 234 567')).toBe(1234567)
+        })
+
+        it('parses values with decimals', () => {
+            expect(parseWithSeparator('1,234.56')).toBe(1234.56)
+        })
+
+        it('parses negative values', () => {
+            expect(parseWithSeparator('-1,234')).toBe(-1234)
+        })
+
+        it('returns undefined for non-numeric input', () => {
+            expect(parseWithSeparator('abc')).toBeUndefined()
+        })
+
+        it('round-trips with formatWithSeparator', () => {
+            expect(
+                parseWithSeparator(
+                    formatWithSeparator(1234567, DIGIT_GROUP_SEPARATOR_COMMA)
+                )
+            ).toBe(1234567)
+            expect(
+                parseWithSeparator(
+                    formatWithSeparator(1234.56, DIGIT_GROUP_SEPARATOR_SPACE)
+                )
+            ).toBe(1234.56)
         })
     })
 })

--- a/src/util/bubbles.js
+++ b/src/util/bubbles.js
@@ -7,7 +7,7 @@ import {
 } from '../components/legend/Bubbles.jsx'
 import { getContrastColor } from './colors.js'
 import { getLongestTextLength } from './helpers.js'
-import { getRoundToPrecisionFn } from './numbers.js'
+import { formatWithSeparator, getRoundToPrecisionFn } from './numbers.js'
 
 const getBubbleValueFormat = ({ minValue, maxValue, divisor }) => {
     if (minValue === maxValue) {
@@ -111,12 +111,18 @@ export const computeLayout = ({
     bubbleClasses,
     radiusHigh,
     legendWidth,
+    keyAnalysisDigitGroupSeparator,
 }) => {
-    // Calculate the pixel length of the longest number
+    // Calculate the pixel length of the longest formatted number
+    const formattedLen = (v) =>
+        typeof v === 'number'
+            ? formatWithSeparator(v, keyAnalysisDigitGroupSeparator).length
+            : 0
     let textLength = Math.ceil(
         Math.max(
-            getLongestTextLength(bubbleClasses, 'startValue'),
-            getLongestTextLength(bubbleClasses, 'endValue')
+            0,
+            ...bubbleClasses.map((c) => formattedLen(c.startValue)),
+            ...bubbleClasses.map((c) => formattedLen(c.endValue))
         ) * digitWidth
     )
 

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -6,8 +6,10 @@ import {
     dateValueTypes,
     datetimeValueTypes,
     coordinateValueTypes,
+    numberValueTypes,
     ouValueTypes,
 } from '../constants/valueTypes.js'
+import { formatWithSeparator } from './numbers.js'
 
 const getBaseFields = (withSubscribers) => {
     const baseFields = [
@@ -144,7 +146,7 @@ export const formatCoordinate = (value) => {
         if (
             Array.isArray(array) &&
             array.length === 2 &&
-            array.every((v) => !isNaN(Number(v)))
+            array.every((v) => !Number.isNaN(Number(v)))
         ) {
             return array.map((v) => Number(v).toFixed(6)).join(', ')
         }
@@ -193,6 +195,7 @@ export const formatValueForDisplay = ({
     valueType,
     options,
     orgUnitNames,
+    keyAnalysisDigitGroupSeparator,
 }) => {
     if (!hasValue(value)) {
         return i18n.t('Not set')
@@ -224,7 +227,11 @@ export const formatValueForDisplay = ({
     if (datetimeValueTypes.includes(valueType)) {
         return formatDatetime(value)
     }
-    // TODO formatNumeric
+    if (numberValueTypes.includes(valueType)) {
+        return formatWithSeparator(value, keyAnalysisDigitGroupSeparator, {
+            force: true,
+        })
+    }
     return value
 }
 
@@ -246,5 +253,5 @@ export const getCssVar = (cssVar) =>
     Number(
         getComputedStyle(document.documentElement)
             .getPropertyValue(cssVar)
-            .replace('px', '')
+            .replaceAll('px', '')
     )

--- a/src/util/numbers.js
+++ b/src/util/numbers.js
@@ -1,3 +1,9 @@
+import {
+    DIGIT_GROUP_SEPARATOR_SPACE,
+    DIGIT_GROUP_SEPARATOR_COMMA,
+    DIGIT_GROUP_SEPARATOR_NONE,
+} from '../constants/settings.js'
+
 export const formatCount = (count) => {
     let num
 
@@ -56,4 +62,39 @@ export const getPrecision = (values = []) => {
     }
 
     return 0
+}
+
+const DIGIT_GROUP_SEPARATORS = {
+    [DIGIT_GROUP_SEPARATOR_SPACE]: ' ',
+    [DIGIT_GROUP_SEPARATOR_COMMA]: ',',
+    [DIGIT_GROUP_SEPARATOR_NONE]: '',
+}
+
+export const formatWithSeparator = (
+    value,
+    separator,
+    { force = false, precision } = {}
+) => {
+    if (!force && typeof value !== 'number') {
+        return value
+    }
+    const sep = DIGIT_GROUP_SEPARATORS[separator] ?? ''
+    const formatted =
+        precision === undefined
+            ? String(value)
+            : Number(value).toFixed(precision)
+    const [integer, decimal] = formatted.split('.')
+    const isNegative = integer.startsWith('-')
+    const digits = isNegative ? integer.slice(1) : integer
+    const groups = []
+    for (let i = digits.length; i > 0; i -= 3) {
+        groups.unshift(digits.slice(Math.max(0, i - 3), i))
+    }
+    const grouped = (isNegative ? '-' : '') + groups.join(sep)
+    return decimal ? `${grouped}.${decimal}` : grouped
+}
+
+export const parseWithSeparator = (value) => {
+    const num = Number(String(value).replaceAll(/[\s,]/g, ''))
+    return Number.isNaN(num) ? undefined : num
 }


### PR DESCRIPTION
### Parent

- [DHIS2-18242](https://dhis2.atlassian.net/browse/DHIS2-18242)

### Implements

- [DHIS2-18963](https://dhis2.atlassian.net/browse/DHIS2-18963): Digit groups separator functionality in maps

### Overview

Third PR in the series extracted from the parent epic. Threads the system-configured digit group separator (`keyAnalysisDigitGroupSeparator`: `NONE` / `SPACE` / `COMMA`) through the maps app so all numeric output is formatted consistently with the rest of DHIS2.

No new behavior except formatting — every place a number renders to the user now respects the system setting.

### Changes

#### Utility and plumbing

`formatWithSeparator` and `parseWithSeparator` helpers in `src/util/numbers.js`, plus `DIGIT_GROUP_SEPARATOR_{SPACE,COMMA,NONE}` constants in `src/constants/settings.js`.

`keyAnalysisDigitGroupSeparator` added to `SYSTEM_SETTINGS` so it's fetched by both the main app (`useLayersLoader`) and the plugin (`LayerLoader`). Both orchestrators thread it as a named parameter to every loader.

The separator is exposed as a Redux-free dependency via the existing `useCachedData()` provider, so the plugin (which doesn't have Redux) can read it the same way as the main app.

`formatWithSeparator` accepts an optional `precision` parameter for forward compatibility with DHIS2-3156, but no consumer wires it through yet.

*Files:* `src/util/numbers.js`, `src/constants/settings.js`, `src/hooks/useLayersLoader.js`, `src/components/plugin/LayerLoader.jsx`

#### Loaders

Each loader accepts `keyAnalysisDigitGroupSeparator` and attaches it to the loaded layer config. Two loaders also bake formatted strings into feature properties at load time:

- **`thematicLoader`**: `properties.value` is set to the formatted display string (consumed by tooltip, label, popup); `properties.rawValue` preserves the numeric value for sort and computation. `properties.range` is formatted with the separator.
- **`earthEngineLoader`**: `createLegend` constructs item names ("< min", "from - to", "> max") with the separator applied.
- **`eventLoader`**, **`trackedEntityLoader`**, **`geoJsonUrlLoader`**: thread the separator on config; raw per-feature values are preserved unchanged. These layer types use dynamic column names for data items, making parallel "raw" fields impractical, so formatting happens at the consumption site.

The `properties.value` flip in `thematicLoader` is a breaking change for anyone reading `feature.properties.value` expecting a `Number`. All internal consumers are updated.

A side refactor extracts `parseJsonConfig`, `fetchRelationshipData`, and `buildQueryVariables` from `trackedEntityLoader` to keep the main loader function under SonarQube's complexity threshold. No behavior change.

*Files:* `src/loaders/thematicLoader.js`, `src/loaders/earthEngineLoader.js`, `src/loaders/eventLoader.js`, `src/loaders/trackedEntityLoader.js`, `src/loaders/geoJsonUrlLoader.js`

#### Display components

Components format at the render site, reading the separator either from layer config (popups, GeoJSON profile) or from cached system settings directly (legend, data table, org unit info, EE preview):

- **`formatValueForDisplay`** in `helpers.js` learns to format numeric value types using `formatWithSeparator` with `force: true`. Popup data values arrive as strings from the API.
- **Data table** reads `rawValue` as the value column's `dataKey` so sort and display both come from a single source. Cell rendering formats non-color cells with the separator.
- **Legend item ranges** format `startValue`/`endValue`/`count`. Refactored into `nameLabel`/`rangeLabel`/`countLabel` for readability and to fix a leading-space artifact when name is empty.
- **Bubble** legend: `Bubbles.jsx` formats bubble text values with the separator before passing them to `computeLayout`, so the layout offset correctly accounts for separator characters in text width. `Bubble.jsx` now renders the pre-formatted `text` prop directly.
- **EventPopup**, **TrackedEntityPopup**, and **Earth Engine popup** data values, **GeoJsonLayer** feature profile, **OrgUnitInfo** attributes (note: the backend returns numeric attribute values as strings), **OrgUnitData** data items, **LegendPreview** (Earth Engine edit dialog) — all format their displayed numbers. The Earth Engine popup reads the separator from the layer config via `EarthEngineLayer` rather than `useCachedData()`, since its parent is a class component.

*Files:* `src/components/legend/LegendItemRange.jsx`, `src/components/legend/Bubbles.jsx`, `src/components/map/layers/EventLayer.jsx`, `src/components/map/layers/EventPopup.jsx`, `src/components/map/layers/TrackedEntityLayer.jsx`, `src/components/map/layers/TrackedEntityPopup.jsx`, `src/components/map/layers/GeoJsonLayer.js`, `src/components/datatable/DataTable.jsx`, `src/components/datatable/useTableData.js`, `src/components/orgunits/OrgUnitInfo.jsx`, `src/components/orgunits/OrgUnitData.jsx`, `src/components/edit/earthEngine/LegendPreview.jsx`, `src/components/map/layers/earthEngine/EarthEnginePopup.jsx`, `src/components/map/layers/earthEngine/EarthEngineLayer.jsx`, `src/util/helpers.js`

### Tests update

- `src/util/__tests__/numbers.spec.js`
- `src/util/__tests__/helpers.spec.js`
- `src/util/__tests__/bubbles.spec.js`
- `src/loaders/__tests__/earthEngineLoader.spec.js`

### Manual testing

Netlify: https://pr-3647.maps.netlify.dhis2.org/ + Instance: https://dev.im.dhis2.org/maps-app-42-3 (keyAnalysisDigitGroupSeparator === SPACE)

- [DHIS2-18963](https://dhis2.atlassian.net/browse/DHIS2-18963): Digit groups separator functionality in maps

  - Test maps

    - Thematic: Labels, Tooltips, Legend (Cloropleth & Bubble), Popup, Data table: [gugP3BzGjK1 - main](https://pr-3647.maps.netlify.dhis2.org/#/gugP3BzGjK1) + [gugP3BzGjK1?interpretationId=u8oNynUvJMm - plugin](https://pr-3647.maps.netlify.dhis2.org/#/gugP3BzGjK1?interpretationId=u8oNynUvJMm)
    
    <img height="250" alt="image" src="https://github.com/user-attachments/assets/e743a141-74a2-4059-8e08-8c85864f7302" />
    <img height="250" alt="image" src="https://github.com/user-attachments/assets/2f2b866d-65f8-446e-98a8-dcffe6d7f287" />
    
    &nbsp;

    - Events: Legend, Popup, Data table: [UPtjWBCx4pJ - main](https://pr-3647.maps.netlify.dhis2.org/#/UPtjWBCx4pJ) + [UPtjWBCx4pJ?interpretationId=TeoPqwMvTjJ - plugin](https://pr-3647.maps.netlify.dhis2.org/#/UPtjWBCx4pJ?interpretationId=TeoPqwMvTjJ)
    
    <img height="250" alt="image" src="https://github.com/user-attachments/assets/d7f1830c-496a-445a-84b1-73da7b1896ab" />
    
    &nbsp;

    - Tracked entities: Popup: [lL0i0WO23Gw - main](https://pr-3647.maps.netlify.dhis2.org/#/lL0i0WO23Gw) + [lL0i0WO23Gw?interpretationId=Z1SspFwvWck - plugin](https://pr-3647.maps.netlify.dhis2.org/#/lL0i0WO23Gw?interpretationId=Z1SspFwvWck)
    
    <img height="250" alt="image" src="https://github.com/user-attachments/assets/23277645-9f69-46fd-a7da-40fbf2982052" />
    
    &nbsp;

    - Facilities & Organisation units: Facility / Org Unit profile: [N3N3m9zyKy5](https://pr-3647.maps.netlify.dhis2.org/#/N3N3m9zyKy5) & [WR6S8roHTao](https://pr-3647.maps.netlify.dhis2.org/#/WR6S8roHTao)
    
    <img height="250" alt="image" src="https://github.com/user-attachments/assets/b93a677c-bdf7-4faf-85be-c7144f1b8ab0" />
    
    &nbsp;

    - Earth engine: Legend preview, Legend, Popup, Data table: [DpskVx1d2Jh - main](https://pr-3647.maps.netlify.dhis2.org/#/DpskVx1d2Jh) + [DpskVx1d2Jh?interpretationId=lDWkXPuW5kt - plugin](https://pr-3647.maps.netlify.dhis2.org/#/DpskVx1d2Jh?interpretationId=lDWkXPuW5kt)
    
    <img height="250" alt="image" src="https://github.com/user-attachments/assets/de8454cb-bc42-4ef8-9903-ea0536dba56c" />

    &nbsp;

    - GeoJSON: Feature profile: [gmSDDyzZHy2](https://pr-3647.maps.netlify.dhis2.org/#/gmSDDyzZHy2)
    
    <img height="250" alt="image" src="https://github.com/user-attachments/assets/0f7f5797-9f2d-4f7e-b0d9-f3c244c1252d" />

    &nbsp;

### Quality checklist

Add _N/A_ to items that are not applicable.

- [x] Jest tests added/updated
- [ ] Docs added _N/A_
- [ ] d2-ci dependencies replaced _N/A_
- [x] Include plugin in testing
- [x] Tester approved (@edoardo)

[DHIS2-18242]: https://dhis2.atlassian.net/browse/DHIS2-18242
[DHIS2-18963]: https://dhis2.atlassian.net/browse/DHIS2-18963