### PR TITLE
fix: preserve saved dates and default period when editing/adding thematic and event layers [DHIS2-21516] [DHIS2-21517]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [101.11.1](https://github.com/dhis2/maps-app/compare/v101.11.0...v101.11.1) (2026-06-01)
+
+
+### Bug Fixes
+
+* prevent globe drag image on macOS Chrome when resizing data table ([#3644](https://github.com/dhis2/maps-app/issues/3644)) ([dd19690](https://github.com/dhis2/maps-app/commit/dd1969035718d59cb0fbfd8967fe33cb74f9a308))
+
 # [101.11.0](https://github.com/dhis2/maps-app/compare/v101.10.2...v101.11.0) (2026-05-14)
 
 

--- a/cypress/integration/layers/eventlayer.cy.js
+++ b/cypress/integration/layers/eventlayer.cy.js
@@ -214,6 +214,32 @@ context('Event Layers', () => {
         Layer.validateCardItems(['Event'])
     })
 
+    it('preserves start/end dates when editing a saved event layer', () => {
+        Layer.openDialog('Events')
+            .selectProgram(programIP.name)
+            .validateStage(programIP.stage)
+            .selectTab('Period')
+            .selectPeriodType({ periodType: 'Start/end dates' })
+            .typeStartDate(programIP.startDate)
+            .typeEndDate(programIP.endDate)
+            .selectTab('Org Units')
+            .selectOu(programIP.ous[0])
+            .selectTab('Style')
+            .selectViewAllEvents()
+            .addToMap()
+
+        Layer.validateDialogClosed(true)
+        Layer.validateCardPeriod(programIP.periodText)
+
+        // Open edit dialog and immediately save without changing anything
+        cy.getByDataTest('layer-edit-button').click()
+        Layer.updateMap()
+        Layer.validateDialogClosed(true)
+
+        // Dates must still be the original ones (the fix)
+        Layer.validateCardPeriod(programIP.periodText)
+    })
+
     it('opens an event popup', () => {
         Layer.openDialog('Events')
             .selectProgram(programIP.name)

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -534,6 +534,46 @@ context('Thematic Layers', () => {
         ])
     })
 
+    it('does not inherit period when adding a new thematic layer after single thematic layer', () => {
+        const SPECIFIC_YEAR = CURRENT_YEAR - 3
+
+        // Add first thematic layer with a specific non-default fixed period
+        Layer.openDialog('Thematic')
+            .selectItemType('Indicators')
+            .selectIndicatorGroup(HIV_INDICATOR_GROUP)
+            .selectIndicator(HIV_INDICATOR_NAME)
+            .selectTab('Period')
+            .selectPeriodType({
+                periodType: 'YEARLY',
+                periodDimension: 'fixed',
+                n: 0,
+                y: SPECIFIC_YEAR + 9,
+            })
+            .selectTab('Org Units')
+            .selectOu('Sierra Leone')
+            .addToMap()
+
+        Layer.validateDialogClosed(true)
+        Layer.validateCardTitle(HIV_INDICATOR_NAME)
+        Layer.validateCardPeriod(`${SPECIFIC_YEAR}`)
+
+        // Open dialog for second thematic layer and go to Period tab
+        Layer.openDialog('Thematic')
+            .selectItemType('Indicators')
+            .selectIndicatorGroup(ANC_INDICATOR_GROUP)
+            .selectIndicator(ANC_INDICATOR_NAME)
+            .selectTab('Period')
+
+        // Rendering should be SINGLE (not inherited from layer 1)
+        cy.get('input[value="SINGLE"]').should('be.checked')
+
+        // The specific year from layer 1 should NOT be pre-selected in the
+        // picked area (before the fix it would be inherited)
+        cy.getByDataTest('period-dimension-transfer-pickedoptions')
+            .contains(`${SPECIFIC_YEAR}`)
+            .should('not.exist')
+    })
+
     it('adds two thematic layer with split view period', () => {
         // add a first layer
         Layer.openDialog('Thematic')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maps-app",
-    "version": "101.11.0",
+    "version": "101.11.1",
     "description": "DHIS2 Maps",
     "license": "BSD-3-Clause",
     "author": "Bjørn Sandvik",

--- a/src/components/datatable/ResizeHandle.jsx
+++ b/src/components/datatable/ResizeHandle.jsx
@@ -3,6 +3,13 @@ import React from 'react'
 import { IconDrag } from '../core/icons.jsx'
 import styles from './styles/ResizeHandle.module.css'
 
+// Pre-decoded so setDragImage doesn't fall back to the macOS Chrome globe icon
+// when the image isn't yet `complete` on the dragstart tick.
+// https://www.sam.today/blog/html5-dnd-globe-icon
+const EMPTY_DRAG_IMAGE = new Image(1, 1)
+EMPTY_DRAG_IMAGE.src =
+    'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
+
 const ResizeHandle = ({
     onResize,
     onResizeEnd,
@@ -12,12 +19,10 @@ const ResizeHandle = ({
     let dragHeight = 0
 
     const onDragStart = (evt) => {
-        // Set the drag ghost image to a transparent 1x1px
         // https://stackoverflow.com/questions/7680285/how-do-you-turn-off-setdragimage
-        const img = document.createElement('img')
-        img.src =
-            'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
-        evt.dataTransfer.setDragImage(img, 0, 0)
+        if (EMPTY_DRAG_IMAGE.complete) {
+            evt.dataTransfer.setDragImage(EMPTY_DRAG_IMAGE, 0, 0)
+        }
 
         evt.dataTransfer.setData('text/plain', 'node') // Required to initialize dragging in Firefox
 

--- a/src/components/edit/event/EventDialog.jsx
+++ b/src/components/edit/event/EventDialog.jsx
@@ -146,7 +146,7 @@ class EventDialog extends Component {
         }
 
         // Set default dates
-        if (!backupPeriodsDates) {
+        if (!hasDate && !backupPeriodsDates) {
             const defaultDates = getDefaultDatesInCalendar()
             setStartDate(defaultDates.startDate)
             setEndDate(defaultDates.endDate)

--- a/src/components/edit/thematic/ThematicDialog.jsx
+++ b/src/components/edit/thematic/ThematicDialog.jsx
@@ -119,6 +119,7 @@ const ThematicDialog = ({
                 orgUnits,
                 systemSettings,
                 syncFromOtherLayers,
+                shouldSyncFromOtherLayers,
             })
         )
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/edit/thematic/initializeThematicLayer.js
+++ b/src/components/edit/thematic/initializeThematicLayer.js
@@ -67,6 +67,7 @@ const initializePeriods = (
         defaultRenderingStrategy,
         systemSettings,
         syncFromOtherLayers,
+        shouldSyncFromOtherLayers,
     }
 ) => {
     if (filters || (startDate !== undefined && endDate !== undefined)) {
@@ -76,6 +77,7 @@ const initializePeriods = (
     const defaultPeriods = getDefaultPeriods(systemSettings)
 
     if (
+        shouldSyncFromOtherLayers &&
         syncFromOtherLayers({
             renderingStrategy: renderingStrategy || defaultRenderingStrategy,
         })


### PR DESCRIPTION
Implements:
- [DHIS2-21516](https://dhis2.atlassian.net/browse/DHIS2-21516)
- [DHIS2-21517](https://dhis2.atlassian.net/browse/DHIS2-21517)

### Description

- DHIS2-21516: Start/end dates on a saved event layer are now preserved when opening the layer for editing.
- DHIS2-21517: Adding a new thematic layer to a map with an existing single thematic layer no longer inherits that layer's period - the system default is used instead.

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested _N/A_
- [ ] Cypress and/or Jest tests added/updated
- [ ] Docs added _N/A_
- [ ] d2-ci dependencies replaced _N/A_
- [ ] Tester approved (name)

[DHIS2-21516]: https://dhis2.atlassian.net/browse/DHIS2-21516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-21517]: https://dhis2.atlassian.net/browse/DHIS2-21517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ