### PR TITLE
fix: prevent timeline crash on load failure and fix period after drilling up/down [DHIS2-19063] [DHIS2-21113]

### DIFF
--- a/src/components/map/Map.jsx
+++ b/src/components/map/Map.jsx
@@ -222,9 +222,9 @@ class Map extends Component {
                                     setFeatureProfile={setFeatureProfile}
                                     engine={engine}
                                     nameProperty={nameProperty}
-                                    externalPeriod={period}
                                     resizeCount={resizeCount}
                                     {...config}
+                                    externalPeriod={period}
                                 />
                             )
                         })}

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -97,6 +97,7 @@ const thematicLoader = async ({
                 : {}),
             name: dataItem ? dataItem.name : i18n.t('Thematic layer'),
             data: [],
+            periods: [],
             legend: null,
             isLoaded: true,
             isLoading: false,


### PR DESCRIPTION
Implements:

- [DHIS2-19063](https://dhis2.atlassian.net/browse/DHIS2-19063)
- [DHIS2-21113](https://dhis2.atlassian.net/browse/DHIS2-21113)

### Description

- DHIS2-19063: A failed timeline thematic layer no longer crashes the app.
- DHIS2-21113:  Timeline period changes now update the map correctly after drilling up/down on an org unit.

---

### Quality checklist

Add N/A to items that are not applicable.

- [ ] Dashboard tested
- [ ] Cypress and/or Jest tests added/updated
- [ ] Docs added N/A
- [ ] d2-ci dependencies replaced N/A
- [ ] Tester approved (name)

[DHIS2-19063]: https://dhis2.atlassian.net/browse/DHIS2-19063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-21113]: https://dhis2.atlassian.net/browse/DHIS2-21113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ