### PR TITLE
fix: render calculated integer values without decimals in timeline [DHIS2-21037]

### DIFF
--- a/src/loaders/__tests__/thematicLoader.spec.js
+++ b/src/loaders/__tests__/thematicLoader.spec.js
@@ -1,0 +1,58 @@
+import { getValuesByPeriod, getValueById } from '../thematicLoader.js'
+
+const headers = [{ name: 'pe' }, { name: 'ou' }, { name: 'value' }]
+
+describe('thematicLoader value extraction', () => {
+    // Analytics returns row values as strings, and computed items (indicators,
+    // calculations) serialize whole numbers with a trailing ".0" (e.g. "16082.0").
+    // Both extractors must yield numbers so integers render without decimals.
+    // See DHIS2-21037.
+
+    test('getValueById coerces string values to numbers', () => {
+        const data = {
+            headers,
+            rows: [
+                ['202501', 'ou1', '16082.0'],
+                ['202501', 'ou2', '118.13'],
+            ],
+        }
+
+        expect(getValueById(data)).toEqual({
+            ou1: 16082,
+            ou2: 118.13,
+        })
+    })
+
+    test('getValuesByPeriod coerces string values to numbers per period', () => {
+        const data = {
+            headers,
+            rows: [
+                ['202501', 'ou1', '16082.0'],
+                ['202501', 'ou2', '118.13'],
+                ['202502', 'ou1', '238.0'],
+            ],
+        }
+
+        expect(getValuesByPeriod(data)).toEqual({
+            202501: {
+                ou1: { value: 16082 },
+                ou2: { value: 118.13 },
+            },
+            202502: {
+                ou1: { value: 238 },
+            },
+        })
+    })
+
+    test('getValuesByPeriod and getValueById agree on the same value', () => {
+        const data = {
+            headers,
+            rows: [['202501', 'ou1', '238.0']],
+        }
+
+        const byId = getValueById(data)
+        const byPeriod = getValuesByPeriod(data)
+
+        expect(byPeriod['202501'].ou1.value).toBe(byId.ou1)
+    })
+})

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -355,7 +355,7 @@ export const getValuesByPeriod = (data) => {
         const period = row[periodIndex]
         const periodObj = (obj[period] = obj[period] || {})
         periodObj[row[ouIndex]] = {
-            value: parseFloat(row[valueIndex]),
+            value: Number.parseFloat(row[valueIndex]),
         }
         return obj
     }, {})
@@ -368,7 +368,7 @@ export const getValueById = (data) => {
     const valueIndex = findIndex(['name', 'value'], headers)
 
     return rows.reduce((obj, row) => {
-        obj[row[ouIndex]] = parseFloat(row[valueIndex])
+        obj[row[ouIndex]] = Number.parseFloat(row[valueIndex])
         return obj
     }, {})
 }
@@ -378,7 +378,7 @@ const getOrderedValues = (data) => {
     const { headers, rows } = data
     const valueIndex = findIndex(['name', 'value'], headers)
 
-    return rows.map((row) => parseFloat(row[valueIndex])).sort((a, b) => a - b)
+    return rows.map((row) => Number.parseFloat(row[valueIndex])).sort((a, b) => a - b)
 }
 
 // Load features and data values from api

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -378,7 +378,9 @@ const getOrderedValues = (data) => {
     const { headers, rows } = data
     const valueIndex = findIndex(['name', 'value'], headers)
 
-    return rows.map((row) => Number.parseFloat(row[valueIndex])).sort((a, b) => a - b)
+    return rows
+        .map((row) => Number.parseFloat(row[valueIndex]))
+        .sort((a, b) => a - b)
 }
 
 // Load features and data values from api

--- a/src/loaders/thematicLoader.js
+++ b/src/loaders/thematicLoader.js
@@ -345,7 +345,7 @@ const getPeriodsFromMetaData = ({ dimensions, items }) =>
         }
     })
 
-const getValuesByPeriod = (data) => {
+export const getValuesByPeriod = (data) => {
     const { headers, rows } = data
     const periodIndex = findIndex(['name', 'pe'], headers)
     const ouIndex = findIndex(['name', 'ou'], headers)
@@ -355,14 +355,14 @@ const getValuesByPeriod = (data) => {
         const period = row[periodIndex]
         const periodObj = (obj[period] = obj[period] || {})
         periodObj[row[ouIndex]] = {
-            value: row[valueIndex],
+            value: parseFloat(row[valueIndex]),
         }
         return obj
     }, {})
 }
 
 // Returns an object mapping org. units and values
-const getValueById = (data) => {
+export const getValueById = (data) => {
     const { headers, rows } = data
     const ouIndex = findIndex(['name', 'ou'], headers)
     const valueIndex = findIndex(['name', 'value'], headers)


### PR DESCRIPTION
Analytics returns row values as strings, and computed data items (indicators, calculations) serialize whole numbers with a trailing ".0" (e.g. "16082.0"). The single-map path already parseFloats the value, but the timeline / split-by-period path (getValuesByPeriod) kept the raw string, so popups and hover labels rendered the trailing decimal for values that should display as integers.

Coerce the period value with parseFloat to mirror getValueById. This is lossless (single-map display and the GeoJSON export already use numbers) and additionally routes timeline value filtering through the numeric filter instead of substring matching.

AI Assisted

Implements [DHIS2-21037](https://dhis2.atlassian.net/browse/DHIS2-21037)

  ## Test plan

  - [x] New `thematicLoader.spec.js` asserts both extractors yield numbers and strip the trailing `.0`
  - [x] Existing `useTableData.spec.jsx` still passes
  - [x] Manual: Calculation (difference of two integers) as a thematic layer → Timeline / Split by period → confirm integers in popups, hover labels, legend

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested
- [x] Cypress and/or Jest tests added/updated
- [ ] Docs added _N/A_
- [ ] d2-ci dependencies replaced _N/A_
- [ ] Tester approved (name)

---
Before:
<img width="1043" height="563" alt="image" src="https://github.com/user-attachments/assets/39c4ce65-e15a-4e6a-b195-52e089ca714d" />

After: 
<img width="1261" height="584" alt="image" src="https://github.com/user-attachments/assets/4a6a4f01-5e58-4774-a2ca-26381d4e8b9e" />


[DHIS2-21037]: https://dhis2.atlassian.net/browse/DHIS2-21037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ