### PR TITLE
fix: preserve saved dates and default period when editing/adding thematic and event layers [DHIS2-21516] [DHIS2-21517]

### DIFF
--- a/cypress/integration/layers/eventlayer.cy.js
+++ b/cypress/integration/layers/eventlayer.cy.js
@@ -214,6 +214,32 @@ context('Event Layers', () => {
         Layer.validateCardItems(['Event'])
     })
 
+    it('preserves start/end dates when editing a saved event layer', () => {
+        Layer.openDialog('Events')
+            .selectProgram(programIP.name)
+            .validateStage(programIP.stage)
+            .selectTab('Period')
+            .selectPeriodType({ periodType: 'Start/end dates' })
+            .typeStartDate(programIP.startDate)
+            .typeEndDate(programIP.endDate)
+            .selectTab('Org Units')
+            .selectOu(programIP.ous[0])
+            .selectTab('Style')
+            .selectViewAllEvents()
+            .addToMap()
+
+        Layer.validateDialogClosed(true)
+        Layer.validateCardPeriod(programIP.periodText)
+
+        // Open edit dialog and immediately save without changing anything
+        cy.getByDataTest('layer-edit-button').click()
+        Layer.updateMap()
+        Layer.validateDialogClosed(true)
+
+        // Dates must still be the original ones (the fix)
+        Layer.validateCardPeriod(programIP.periodText)
+    })
+
     it('opens an event popup', () => {
         Layer.openDialog('Events')
             .selectProgram(programIP.name)

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -534,6 +534,46 @@ context('Thematic Layers', () => {
         ])
     })
 
+    it('does not inherit period when adding a new thematic layer after single thematic layer', () => {
+        const SPECIFIC_YEAR = CURRENT_YEAR - 3
+
+        // Add first thematic layer with a specific non-default fixed period
+        Layer.openDialog('Thematic')
+            .selectItemType('Indicators')
+            .selectIndicatorGroup(HIV_INDICATOR_GROUP)
+            .selectIndicator(HIV_INDICATOR_NAME)
+            .selectTab('Period')
+            .selectPeriodType({
+                periodType: 'YEARLY',
+                periodDimension: 'fixed',
+                n: 0,
+                y: SPECIFIC_YEAR + 9,
+            })
+            .selectTab('Org Units')
+            .selectOu('Sierra Leone')
+            .addToMap()
+
+        Layer.validateDialogClosed(true)
+        Layer.validateCardTitle(HIV_INDICATOR_NAME)
+        Layer.validateCardPeriod(`${SPECIFIC_YEAR}`)
+
+        // Open dialog for second thematic layer and go to Period tab
+        Layer.openDialog('Thematic')
+            .selectItemType('Indicators')
+            .selectIndicatorGroup(ANC_INDICATOR_GROUP)
+            .selectIndicator(ANC_INDICATOR_NAME)
+            .selectTab('Period')
+
+        // Rendering should be SINGLE (not inherited from layer 1)
+        cy.get('input[value="SINGLE"]').should('be.checked')
+
+        // The specific year from layer 1 should NOT be pre-selected in the
+        // picked area (before the fix it would be inherited)
+        cy.getByDataTest('period-dimension-transfer-pickedoptions')
+            .contains(`${SPECIFIC_YEAR}`)
+            .should('not.exist')
+    })
+
     it('adds two thematic layer with split view period', () => {
         // add a first layer
         Layer.openDialog('Thematic')

--- a/src/components/edit/event/EventDialog.jsx
+++ b/src/components/edit/event/EventDialog.jsx
@@ -146,7 +146,7 @@ class EventDialog extends Component {
         }
 
         // Set default dates
-        if (!backupPeriodsDates) {
+        if (!hasDate && !backupPeriodsDates) {
             const defaultDates = getDefaultDatesInCalendar()
             setStartDate(defaultDates.startDate)
             setEndDate(defaultDates.endDate)

--- a/src/components/edit/thematic/ThematicDialog.jsx
+++ b/src/components/edit/thematic/ThematicDialog.jsx
@@ -119,6 +119,7 @@ const ThematicDialog = ({
                 orgUnits,
                 systemSettings,
                 syncFromOtherLayers,
+                shouldSyncFromOtherLayers,
             })
         )
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/edit/thematic/initializeThematicLayer.js
+++ b/src/components/edit/thematic/initializeThematicLayer.js
@@ -67,6 +67,7 @@ const initializePeriods = (
         defaultRenderingStrategy,
         systemSettings,
         syncFromOtherLayers,
+        shouldSyncFromOtherLayers,
     }
 ) => {
     if (filters || (startDate !== undefined && endDate !== undefined)) {
@@ -76,6 +77,7 @@ const initializePeriods = (
     const defaultPeriods = getDefaultPeriods(systemSettings)
 
     if (
+        shouldSyncFromOtherLayers &&
         syncFromOtherLayers({
             renderingStrategy: renderingStrategy || defaultRenderingStrategy,
         })


### PR DESCRIPTION
Implements:
- [DHIS2-21516](https://dhis2.atlassian.net/browse/DHIS2-21516)
- [DHIS2-21517](https://dhis2.atlassian.net/browse/DHIS2-21517)

### Description

- DHIS2-21516: Start/end dates on a saved event layer are now preserved when opening the layer for editing.
- DHIS2-21517: Adding a new thematic layer to a map with an existing single thematic layer no longer inherits that layer's period - the system default is used instead.

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested _N/A_
- [x] Cypress and/or Jest tests added/updated
- [ ] Docs added _N/A_
- [ ] d2-ci dependencies replaced _N/A_
- [ ] Tester approved (name)

[DHIS2-21516]: https://dhis2.atlassian.net/browse/DHIS2-21516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-21517]: https://dhis2.atlassian.net/browse/DHIS2-21517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ