### PR TITLE
mockup: add AI map assistant

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -47,6 +47,15 @@ const config = {
     },
 
     viteConfigExtensions: {
+        server: {
+            proxy: {
+                '/anthropic-proxy': {
+                    target: 'https://api.anthropic.com',
+                    changeOrigin: true,
+                    rewrite: (path) => path.replace(/^\/anthropic-proxy/, ''),
+                },
+            },
+        },
         optimizeDeps: {
             esbuildOptions: {
                 target: 'es2022',

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,11 +5,59 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-06-11T16:48:10.810Z\n"
-"PO-Revision-Date: 2026-06-11T16:48:10.810Z\n"
+"POT-Creation-Date: 2026-06-15T12:59:12.638Z\n"
+"PO-Revision-Date: 2026-06-15T12:59:12.638Z\n"
 
 msgid "2020"
 msgstr "2020"
+
+msgid "Thinking…"
+msgstr "Thinking…"
+
+msgid "Running {{name}}…"
+msgstr "Running {{name}}…"
+
+msgid "Map assistant"
+msgstr "Map assistant"
+
+msgid "Demo mode — no AI model connected"
+msgstr "Demo mode — no AI model connected"
+
+msgid "New conversation"
+msgstr "New conversation"
+
+msgid "Close assistant"
+msgstr "Close assistant"
+
+msgid "Add, edit, or remove map layers using plain language."
+msgstr "Add, edit, or remove map layers using plain language."
+
+msgid "Try an example"
+msgstr "Try an example"
+
+msgid "You"
+msgstr "You"
+
+msgid "Assistant"
+msgstr "Assistant"
+
+msgid "Remove a layer"
+msgstr "Remove a layer"
+
+msgid "Try another example"
+msgstr "Try another example"
+
+msgid "Try one of the examples above…"
+msgstr "Try one of the examples above…"
+
+msgid "Ask me to add, edit, or remove a layer…"
+msgstr "Ask me to add, edit, or remove a layer…"
+
+msgid "Send"
+msgstr "Send"
+
+msgid "AI assistant"
+msgstr "AI assistant"
 
 msgid "Untitled map, {{date}}"
 msgstr "Untitled map, {{date}}"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-06-15T12:59:12.638Z\n"
-"PO-Revision-Date: 2026-06-15T12:59:12.638Z\n"
+"POT-Creation-Date: 2026-06-15T13:48:16.543Z\n"
+"PO-Revision-Date: 2026-06-15T13:48:16.543Z\n"
 
 msgid "2020"
 msgstr "2020"
@@ -25,9 +25,6 @@ msgstr "Demo mode — no AI model connected"
 
 msgid "New conversation"
 msgstr "New conversation"
-
-msgid "Close assistant"
-msgstr "Close assistant"
 
 msgid "Add, edit, or remove map layers using plain language."
 msgstr "Add, edit, or remove map layers using plain language."

--- a/src/ai/agent/loop.js
+++ b/src/ai/agent/loop.js
@@ -1,0 +1,139 @@
+import { guardMessages } from '../egress/guard.js'
+import { executeToolCall } from '../tools/executor.js'
+import { TOOL_SCHEMAS } from '../tools/schemas.js'
+import {
+    classifyIntent,
+    getDeclineMessage,
+    getToolsForIntent,
+} from './router.js'
+import { INTENT, SYSTEM_PROMPT } from './systemPrompt.js'
+
+const MAX_ITERATIONS = 8
+
+/**
+ * Run the agent loop for a single user turn.
+ *
+ * @param {Object} opts
+ * @param {import('../connectors/types.js').LLMConnector} opts.connector
+ * @param {import('../tools/executor.js').buildToolRegistry} opts.toolRegistry
+ * @param {Object[]} opts.history - Previous messages in this conversation
+ * @param {string} opts.userText - The user's new message
+ * @param {Function} opts.onUpdate - Called with partial updates: { type, ... }
+ * @param {AbortSignal} [opts.signal]
+ * @returns {Promise<{ history: Object[], reply: string }>}
+ */
+export const runAgentLoop = async ({
+    connector,
+    toolRegistry,
+    history,
+    userText,
+    onUpdate,
+    signal,
+}) => {
+    // Intent classification for tool subsetting
+    const intent = classifyIntent(userText)
+    console.log('[AI] intent:', intent, '| connector:', connector.id)
+
+    // Fast decline — no LLM call needed
+    if (intent === INTENT.DECLINE) {
+        const msg =
+            getDeclineMessage(userText) ??
+            "That's not something I can help with here."
+        onUpdate?.({ type: 'reply', text: msg })
+        return {
+            history: [
+                ...history,
+                { role: 'user', content: userText },
+                { role: 'assistant', content: msg },
+            ],
+            reply: msg,
+        }
+    }
+
+    // Build the active tool subset
+    const activeToolNames = getToolsForIntent(intent)
+    const activeTools = TOOL_SCHEMAS.filter((t) =>
+        activeToolNames.includes(t.name)
+    )
+
+    // Build message list
+    const messages = [...history, { role: 'user', content: userText }]
+
+    const newMessages = [{ role: 'user', content: userText }]
+    let reply = ''
+
+    for (let i = 0; i < MAX_ITERATIONS; i++) {
+        if (signal?.aborted) {
+            break
+        }
+
+        // Egress guard: assert no analytics values in outbound messages
+        guardMessages(messages)
+
+        console.log(
+            `[AI] iteration ${i + 1}/${MAX_ITERATIONS}, messages:`,
+            messages.length
+        )
+        onUpdate?.({ type: 'thinking' })
+
+        const result = await connector.chat({
+            messages: [{ role: 'system', content: SYSTEM_PROMPT }, ...messages],
+            tools: activeTools,
+            signal,
+        })
+
+        console.log(
+            '[AI] connector response — text:',
+            result.text || '(none)',
+            '| toolCalls:',
+            result.toolCalls?.map((t) => t.name)
+        )
+
+        if (result.text) {
+            reply = result.text
+            onUpdate?.({ type: 'text', text: result.text })
+        }
+
+        if (!result.toolCalls?.length) {
+            // No more tool calls — we're done
+            console.log('[AI] done (no more tool calls)')
+            newMessages.push({
+                role: 'assistant',
+                content: result.text,
+                toolCalls: [],
+            })
+            break
+        }
+
+        // Record assistant message with tool calls — keep toolCalls so demo connector can track progress
+        const assistantMsg = {
+            role: 'assistant',
+            content: result.text,
+            toolCalls: result.toolCalls,
+        }
+        newMessages.push(assistantMsg)
+        messages.push(assistantMsg)
+
+        // Execute each tool call
+        const toolResults = []
+        for (const tc of result.toolCalls) {
+            console.log('[AI] → tool call:', tc.name, tc.args)
+            onUpdate?.({ type: 'tool_call', name: tc.name, args: tc.args })
+            const toolResult = await executeToolCall(toolRegistry, tc)
+            const parsed = JSON.parse(toolResult.content)
+            console.log('[AI] ← tool result:', tc.name, parsed)
+            onUpdate?.({ type: 'tool_result', name: tc.name, result: parsed })
+            toolResults.push(toolResult)
+        }
+
+        // Feed results back into the conversation
+        const toolResultMessage = { role: 'user', content: toolResults }
+        newMessages.push(toolResultMessage)
+        messages.push(toolResultMessage)
+    }
+
+    return {
+        history: [...history, ...newMessages],
+        reply,
+    }
+}

--- a/src/ai/agent/loop.js
+++ b/src/ai/agent/loop.js
@@ -31,7 +31,7 @@ export const runAgentLoop = async ({
     signal,
 }) => {
     // Intent classification for tool subsetting
-    const intent = classifyIntent(userText)
+    const intent = classifyIntent(userText, history)
     console.log('[AI] intent:', intent, '| connector:', connector.id)
 
     // Fast decline — no LLM call needed
@@ -50,17 +50,331 @@ export const runAgentLoop = async ({
         }
     }
 
+    // Fast remove — bypass the LLM to avoid spurious confirmation prompts
+    if (intent === INTENT.REMOVE) {
+        const namePattern = userText
+            .replace(
+                /\b(remove|delete|hide|clear|drop|get rid of|the|a|an|my|this|that|it|one|current|latest|all|everything|layers?|map|thematic|choropleth|bubble)\b/gi,
+                ' '
+            )
+            .replace(/\s+/g, ' ')
+            .trim()
+
+        const removeFn = toolRegistry['remove_layer']
+        const wordCount = namePattern.split(/\s+/).length
+
+        // No specific name left after stripping — handle programmatically
+        if (removeFn && !namePattern) {
+            onUpdate?.({ type: 'thinking' })
+            const listFn = toolRegistry['list_layers']
+            const layerList = listFn ? await listFn({}) : { layers: [] }
+            const layers = layerList.layers ?? []
+
+            // "remove all/every/everything"
+            if (/\b(all|every|everything)\b/i.test(userText)) {
+                const msg = layers.length
+                    ? `Done — I've removed all layers.`
+                    : 'There are no layers to remove.'
+                for (const layer of layers) {
+                    await removeFn({ layerId: layer.id })
+                }
+                onUpdate?.({ type: 'reply', text: msg })
+                return {
+                    history: [
+                        ...history,
+                        { role: 'user', content: userText },
+                        { role: 'assistant', content: msg },
+                    ],
+                    reply: msg,
+                }
+            }
+
+            // Deictic / ambiguous reference with exactly one layer → remove it
+            if (layers.length === 1) {
+                const result = await removeFn({ layerId: layers[0].id })
+                const msg = result.success
+                    ? `Done — I've removed the layer.`
+                    : result.message ?? 'Failed to remove the layer.'
+                onUpdate?.({ type: 'reply', text: msg })
+                return {
+                    history: [
+                        ...history,
+                        { role: 'user', content: userText },
+                        { role: 'assistant', content: msg },
+                    ],
+                    reply: msg,
+                }
+            }
+
+            // Zero layers
+            if (layers.length === 0) {
+                const msg = 'There are no layers to remove.'
+                onUpdate?.({ type: 'reply', text: msg })
+                return {
+                    history: [
+                        ...history,
+                        { role: 'user', content: userText },
+                        { role: 'assistant', content: msg },
+                    ],
+                    reply: msg,
+                }
+            }
+
+            // Multiple layers — fall through to LLM with list pre-fetched (it knows the ids)
+        }
+
+        // Skip fast-remove for compound messages (e.g. "remove X then add Y") —
+        // a long pattern won't match any layer name.
+        if (removeFn && namePattern && wordCount <= 5) {
+            onUpdate?.({ type: 'thinking' })
+            const result = await removeFn({ namePattern })
+            console.log('[AI] fast remove result:', result)
+            const msg = result.success
+                ? `Done — I've removed the layer.`
+                : result.message ?? 'No matching layer found.'
+            onUpdate?.({ type: 'reply', text: msg })
+            return {
+                history: [
+                    ...history,
+                    { role: 'user', content: userText },
+                    { role: 'assistant', content: msg },
+                ],
+                reply: msg,
+            }
+        }
+    }
+
+    // COMPOUND: split into sequential remove + add phases so the 7B model
+    // never sees more than ~4 tools at once.
+    if (intent === INTENT.COMPOUND) {
+        // Split on the first "and/then/," separating the remove half from the add half
+        const compoundSplit = userText.match(/^(.+?)\s+(?:and|then|,)\s+(.+)$/i)
+        if (compoundSplit) {
+            const [, removePart, addPart] = compoundSplit
+
+            // Phase 1: fast-remove (same stripping logic as the REMOVE path)
+            const removePattern = removePart
+                .replace(
+                    /\b(remove|delete|hide|clear|drop|get rid of|the|a|an|my|this|that|it|one|current|latest|all|everything|layers?|map|thematic|choropleth|bubble)\b/gi,
+                    ' '
+                )
+                .replace(/\s+/g, ' ')
+                .trim()
+            const removeFn = toolRegistry['remove_layer']
+            let removeMsg = ''
+            const removeWordCount = removePattern.split(/\s+/).length
+            if (removeFn && removePattern && removeWordCount <= 5) {
+                onUpdate?.({ type: 'thinking' })
+                const removeResult = await removeFn({
+                    namePattern: removePattern,
+                })
+                console.log('[AI] compound remove result:', removeResult)
+                removeMsg = removeResult.success
+                    ? 'Done — removed the layer.'
+                    : removeResult.message ?? 'No matching layer found.'
+            }
+
+            // Phase 2: run the add loop recursively with just the add sub-request
+            const addResult = await runAgentLoop({
+                connector,
+                toolRegistry,
+                history: [
+                    ...history,
+                    { role: 'user', content: userText },
+                    { role: 'assistant', content: removeMsg },
+                ],
+                userText: addPart,
+                onUpdate,
+                signal,
+            })
+
+            // Build a clean combined reply
+            const addSuccess = addResult.reply?.startsWith('Done')
+            const removeSuccess = removeMsg === 'Done — removed the layer.'
+            let combinedReply
+            if (removeSuccess && addSuccess) {
+                combinedReply = `Done — I've removed the layer and added the new one.`
+            } else if (removeMsg) {
+                combinedReply = `${removeMsg} ${addResult.reply}`
+            } else {
+                combinedReply = addResult.reply
+            }
+            onUpdate?.({ type: 'reply', text: combinedReply })
+            return {
+                history: [
+                    ...history,
+                    { role: 'user', content: userText },
+                    { role: 'assistant', content: combinedReply },
+                ],
+                reply: combinedReply,
+            }
+        }
+        // Fall through to the main loop if the pattern didn't match
+    }
+
     // Build the active tool subset
     const activeToolNames = getToolsForIntent(intent)
     const activeTools = TOOL_SCHEMAS.filter((t) =>
         activeToolNames.includes(t.name)
     )
 
+    // For EDIT intent, pre-fetch the layer list and append it to the system prompt.
+    // This lets the model reference layer ids directly without needing a list_layers tool call.
+    let systemContent = SYSTEM_PROMPT
+    let hadLayersForEdit = false
+    let prefetchedLayers = [] // cached from EDIT pre-fetch to reuse in fast paths
+    if (intent === INTENT.EDIT) {
+        const listLayersFn = toolRegistry['list_layers']
+        if (listLayersFn) {
+            try {
+                const layerResult = await listLayersFn({})
+                if (layerResult?.layers?.length) {
+                    hadLayersForEdit = true
+                    prefetchedLayers = layerResult.layers
+                    const layerSummary = layerResult.layers
+                        .map((l) => `  - layerId="${l.id}" (${l.summary})`)
+                        .join('\n')
+                    systemContent = `${SYSTEM_PROMPT}\n\nCurrent map layers (for update_layer calls):\n${layerSummary}\nCall update_layer with one of these layerIds. For map type changes (choropleth↔bubble) use changes: { thematicMapType: 'BUBBLE' } or { thematicMapType: 'CHOROPLETH' } — no resolve step needed. For period or org unit changes, resolve first then call update_layer.`
+                } else {
+                    // No layers — skip LLM entirely
+                    const msg =
+                        'There are no layers on the map to edit. Add a layer first.'
+                    onUpdate?.({ type: 'reply', text: msg })
+                    return {
+                        history: [
+                            ...history,
+                            { role: 'user', content: userText },
+                            { role: 'assistant', content: msg },
+                        ],
+                        reply: msg,
+                    }
+                }
+            } catch (_) {
+                // ignore — model will call list_layers itself if needed
+            }
+        }
+    }
+
+    // EDIT fast path: map type change (choropleth ↔ bubble).
+    // Detects "bubble" / "choropleth" in user text and applies directly — no LLM call.
+    if (intent === INTENT.EDIT && hadLayersForEdit) {
+        const wantsBubble = /\bbubble\b/i.test(userText)
+        const wantsChoropleth = /\bchoropleth\b/i.test(userText)
+        if (wantsBubble || wantsChoropleth) {
+            const targetType = wantsBubble ? 'BUBBLE' : 'CHOROPLETH'
+            const updateFn = toolRegistry['update_layer']
+            if (updateFn) {
+                // Use prefetched layer list; fall back to thematic-only filtering
+                const thematicLayers = prefetchedLayers.filter((l) => {
+                    const s = (l.summary ?? '').toLowerCase()
+                    return (
+                        l.type === 'thematic' ||
+                        s.includes('choropleth') ||
+                        s.includes('bubble') ||
+                        s.includes('thematic')
+                    )
+                })
+                const allLayers = thematicLayers.length
+                    ? thematicLayers
+                    : prefetchedLayers
+                // Pick the best match: only one → use it; multiple → match name words
+                let targetLayer = allLayers.length === 1 ? allLayers[0] : null
+                if (!targetLayer && allLayers.length > 1) {
+                    const words = userText
+                        .toLowerCase()
+                        .split(/\s+/)
+                        .filter(
+                            (w) =>
+                                w.length > 3 &&
+                                !/bubble|choropleth|show|make|switch|convert|change|layer|map/i.test(
+                                    w
+                                )
+                        )
+                    targetLayer =
+                        allLayers.find((l) => {
+                            const name = (l.summary ?? '').toLowerCase()
+                            return words.some((w) => name.includes(w))
+                        }) ?? allLayers[0]
+                }
+                if (targetLayer) {
+                    onUpdate?.({ type: 'thinking' })
+                    onUpdate?.({
+                        type: 'tool_call',
+                        name: 'update_layer',
+                        args: {
+                            layerId: targetLayer.id,
+                            changes: { thematicMapType: targetType },
+                        },
+                    })
+                    const result = await updateFn({
+                        layerId: targetLayer.id,
+                        changes: { thematicMapType: targetType },
+                    })
+                    onUpdate?.({
+                        type: 'tool_result',
+                        name: 'update_layer',
+                        result,
+                    })
+                    const msg = result.success
+                        ? `Done — I've switched the layer to ${
+                              targetType === 'BUBBLE'
+                                  ? 'bubble map'
+                                  : 'choropleth'
+                          }.`
+                        : result.message ?? 'Failed to update the layer.'
+                    onUpdate?.({ type: 'reply', text: msg })
+                    return {
+                        history: [
+                            ...history,
+                            { role: 'user', content: userText },
+                            { role: 'assistant', content: msg },
+                        ],
+                        reply: msg,
+                    }
+                }
+            }
+        }
+    }
+
+    // Compress + trim history to prevent 7B model context overload.
+    // Each turn produces 4 messages (user, assistant+toolcalls, tool results, assistant reply).
+    // Strip tool-call scaffolding (array-content tool results and empty assistant tool-call entries)
+    // so the model only sees user questions + final assistant replies from prior turns.
+    const MAX_HISTORY_TURNS = 4
+    const trimHistory = (hist) => {
+        const compressed = hist.filter(
+            (m) => typeof m.content === 'string' && m.content.trim()
+        )
+        const userMsgIndices = compressed
+            .map((m, i) => (m.role === 'user' ? i : -1))
+            .filter((i) => i >= 0)
+        if (userMsgIndices.length <= MAX_HISTORY_TURNS) {
+            return compressed
+        }
+        return compressed.slice(
+            userMsgIndices[userMsgIndices.length - MAX_HISTORY_TURNS]
+        )
+    }
+
     // Build message list
-    const messages = [...history, { role: 'user', content: userText }]
+    const messages = [
+        ...trimHistory(history),
+        { role: 'user', content: userText },
+    ]
 
     const newMessages = [{ role: 'user', content: userText }]
     let reply = ''
+
+    // Track whether resolve tools / layer operations were called during the loop
+    let resolveToolsCalled = false
+    let updateLayerCalled = false
+    let updateLayerSucceeded = false
+    let anyLayerAdded = false
+    let searchDirectiveInjected = false
+    // Cache the last successfully resolved values for programmatic recovery
+    let lastResolvedDataItem = null
+    let lastResolvedOrgUnits = null
+    let lastResolvedPeriods = null
 
     for (let i = 0; i < MAX_ITERATIONS; i++) {
         if (signal?.aborted) {
@@ -77,7 +391,7 @@ export const runAgentLoop = async ({
         onUpdate?.({ type: 'thinking' })
 
         const result = await connector.chat({
-            messages: [{ role: 'system', content: SYSTEM_PROMPT }, ...messages],
+            messages: [{ role: 'system', content: systemContent }, ...messages],
             tools: activeTools,
             signal,
         })
@@ -116,6 +430,7 @@ export const runAgentLoop = async ({
 
         // Execute each tool call
         const toolResults = []
+        let layerAdded = false
         for (const tc of result.toolCalls) {
             console.log('[AI] → tool call:', tc.name, tc.args)
             onUpdate?.({ type: 'tool_call', name: tc.name, args: tc.args })
@@ -124,12 +439,551 @@ export const runAgentLoop = async ({
             console.log('[AI] ← tool result:', tc.name, parsed)
             onUpdate?.({ type: 'tool_result', name: tc.name, result: parsed })
             toolResults.push(toolResult)
+            if (
+                [
+                    'resolve_org_units',
+                    'resolve_periods',
+                    'search_data_items',
+                ].includes(tc.name)
+            ) {
+                resolveToolsCalled = true
+            }
+            if (tc.name === 'update_layer') {
+                updateLayerCalled = true
+                if (parsed.success) {
+                    updateLayerSucceeded = true
+                }
+            }
+            if (
+                tc.name === 'search_data_items' &&
+                parsed.found &&
+                parsed.candidates?.[0]?.id
+            ) {
+                lastResolvedDataItem = parsed.candidates[0]
+            }
+            if (
+                tc.name === 'resolve_org_units' &&
+                parsed.resolved &&
+                parsed.items?.length
+            ) {
+                lastResolvedOrgUnits = parsed.items
+            }
+            if (
+                tc.name === 'resolve_periods' &&
+                parsed.resolved &&
+                parsed.periods?.length
+            ) {
+                lastResolvedPeriods = parsed.periods
+            }
+            if (
+                [
+                    'add_thematic_layer',
+                    'add_facility_layer',
+                    'add_org_unit_layer',
+                ].includes(tc.name) &&
+                parsed.success
+            ) {
+                layerAdded = true
+                anyLayerAdded = true
+            }
         }
 
         // Feed results back into the conversation
         const toolResultMessage = { role: 'user', content: toolResults }
         newMessages.push(toolResultMessage)
         messages.push(toolResultMessage)
+
+        // After search_data_items on an ADD intent: if all values are already resolved
+        // in this same iteration (model made parallel calls), complete programmatically.
+        // This eliminates the wasted iterations where the model retries with wrong args.
+        if (
+            !searchDirectiveInjected &&
+            intent === INTENT.ADD_THEMATIC &&
+            lastResolvedDataItem &&
+            lastResolvedOrgUnits &&
+            lastResolvedPeriods &&
+            !layerAdded
+        ) {
+            searchDirectiveInjected = true
+            const addFn = toolRegistry['add_thematic_layer']
+            if (addFn) {
+                const earlyAddArgs = {
+                    dataItem: {
+                        id: lastResolvedDataItem.id,
+                        name:
+                            lastResolvedDataItem.displayName ??
+                            lastResolvedDataItem.name ??
+                            lastResolvedDataItem.id,
+                        dimensionItemType:
+                            lastResolvedDataItem.dimensionItemType,
+                    },
+                    orgUnits: lastResolvedOrgUnits,
+                    periods: lastResolvedPeriods,
+                }
+                console.log(
+                    '[AI] early add (all resolved in same iter):',
+                    earlyAddArgs
+                )
+                onUpdate?.({
+                    type: 'tool_call',
+                    name: 'add_thematic_layer',
+                    args: earlyAddArgs,
+                })
+                const earlyResult = await addFn(earlyAddArgs)
+                onUpdate?.({
+                    type: 'tool_result',
+                    name: 'add_thematic_layer',
+                    result: earlyResult,
+                })
+                if (earlyResult.success) {
+                    layerAdded = true
+                    anyLayerAdded = true
+                }
+            }
+        } else if (
+            !searchDirectiveInjected &&
+            [
+                INTENT.ADD_THEMATIC,
+                INTENT.ADD_FACILITY,
+                INTENT.ADD_ORG_UNIT,
+            ].includes(intent) &&
+            lastResolvedDataItem &&
+            !layerAdded
+        ) {
+            // Partial resolution — inject directive to tell the model what's still needed
+            searchDirectiveInjected = true
+            const PERIOD_RE =
+                /\b(this year|last year|this quarter|last quarter|last \d+ years?|last \d+ months?|last \d+ weeks?|this month|last month|\d{4}Q[1-4]|\d{4})\b/i
+            const OU_RE =
+                /\b(district|chiefdom|region|province|national|facility|level)\b/i
+            const recentUserTexts = [
+                userText,
+                ...[...history]
+                    .filter(
+                        (m) =>
+                            m.role === 'user' && typeof m.content === 'string'
+                    )
+                    .slice(-4)
+                    .map((m) => m.content),
+            ]
+            const periodHint =
+                recentUserTexts
+                    .map((t) => t.match(PERIOD_RE)?.[0])
+                    .find(Boolean) ?? 'this year'
+            const orgUnitHint =
+                recentUserTexts.map((t) => t.match(OU_RE)?.[1]).find(Boolean) ??
+                'all districts'
+            const needsOU = !lastResolvedOrgUnits
+            const needsPeriod = !lastResolvedPeriods
+            const steps = [
+                needsOU && `resolve_org_units with "${orgUnitHint}"`,
+                needsPeriod && `resolve_periods with "${periodHint}"`,
+            ]
+                .filter(Boolean)
+                .join(' and ')
+            messages.push({
+                role: 'user',
+                content: `Data item found (id="${lastResolvedDataItem.id}"). Do NOT output text. Call ${steps}, then immediately call add_thematic_layer.`,
+            })
+        }
+
+        // Stop after a successful update_layer — prevents the model from echoing garbage on the next iteration
+        if (updateLayerSucceeded) {
+            if (!reply || /^\s*update_layer\s*\{/.test(reply)) {
+                reply = `Done — I've updated the layer.`
+            }
+            const last = newMessages.at(-1)
+            if (last?.role === 'assistant' && !last.content?.trim()) {
+                last.content = reply
+            } else {
+                newMessages.push({ role: 'assistant', content: reply })
+            }
+            onUpdate?.({ type: 'reply', text: reply })
+            break
+        }
+
+        // Stop after a successful layer add — prevents duplicate layers from retry loops
+        if (layerAdded) {
+            if (!reply) {
+                reply = `Done — I've added the layer.`
+            }
+            // Guarantee the reply text appears in the returned history (UI reads history, not reply)
+            const last = newMessages.at(-1)
+            if (last?.role === 'assistant' && !last.content?.trim()) {
+                last.content = reply
+            } else {
+                newMessages.push({ role: 'assistant', content: reply })
+            }
+            break
+        }
+    }
+
+    // If update_layer was called but the model produced no reply text, use a default.
+    if (updateLayerCalled && !reply) {
+        reply = `Done — I've updated the layer.`
+        const last = newMessages.at(-1)
+        if (last?.role === 'assistant' && !last.content?.trim()) {
+            last.content = reply
+        } else {
+            newMessages.push({ role: 'assistant', content: reply })
+        }
+    }
+
+    // EDIT recovery: model did not call update_layer despite having layers available.
+    // Covers two cases: (a) resolve tools called but update_layer skipped, (b) no
+    // tools called at all (e.g. thematicMapType change needs no resolve step).
+    // Guard: only fire when layers were pre-injected; skip if model asked a genuine clarification.
+    // A genuine clarification asks for a specific DHIS2 value (district, period, layer name).
+    // "I wasn't sure what to do" / "Could you rephrase?" are confusion responses, not clarifications.
+    const modelIsConfused =
+        /I wasn't sure|I'm not sure|I couldn't|couldn't determine|try rephrasing|please rephrase|I don't understand|I'm unable|unable to/i.test(
+            reply
+        )
+    const modelAskedClarification =
+        !modelIsConfused &&
+        reply.includes('?') &&
+        /\b(which|what)\b.{0,40}\b(district|region|level|period|year|quarter|layer|indicator|data element|org unit)\b/i.test(
+            reply
+        )
+    if (
+        intent === INTENT.EDIT &&
+        hadLayersForEdit &&
+        !updateLayerCalled &&
+        !modelAskedClarification
+    ) {
+        console.log(
+            '[AI] edit recovery — resolveToolsCalled:',
+            resolveToolsCalled,
+            '| lastResolvedPeriods:',
+            lastResolvedPeriods,
+            '| lastResolvedOrgUnits:',
+            lastResolvedOrgUnits
+        )
+
+        // --- Programmatic recovery (preferred): use cached resolved values directly.
+        // Avoids asking the LLM again, which often calls resolve tools it can't execute
+        // in recovery context, or passes wrong IDs.
+        const updateFn = toolRegistry['update_layer']
+        if (updateFn && prefetchedLayers.length) {
+            // If resolve tools ran but model stalled without update, try to resolve
+            // any missing values programmatically before calling update.
+            if (!lastResolvedPeriods) {
+                // Only scan the current user message — scanning history picks up stale periods
+                // (e.g. the original "last year" from when the layer was added, rather than the
+                // "last 5 years" set in a subsequent edit). If the user didn't mention a period
+                // in this turn, leave it null so update_layer preserves the existing period.
+                const PERIOD_RE =
+                    /\b(this year|last year|this quarter|last quarter|last \d+ years?|last \d+ months?|last \d+ weeks?|this month|last month|\d{4}Q[1-4]|\d{4})\b/i
+                const periodDesc = userText.match(PERIOD_RE)?.[0]
+                if (periodDesc) {
+                    try {
+                        const resolveFn = toolRegistry['resolve_periods']
+                        const pr = resolveFn
+                            ? await resolveFn({ description: periodDesc })
+                            : null
+                        if (pr?.resolved && pr.periods?.length) {
+                            lastResolvedPeriods = pr.periods
+                        }
+                    } catch (_) {}
+                }
+            }
+            // Always re-resolve from current userText — overrides model hallucinations like
+            // passing "by district, by chiefdom" when user only asked for one level.
+            // Fall back to history only if userText has no OU keyword and model didn't resolve.
+            {
+                const OU_RE =
+                    /\b(all\s+)?(districts?|chiefdoms?|regions?|provinces?|national|facilities?)\b/i
+                const ouDescCurrent = userText.match(OU_RE)?.[0]
+                if (ouDescCurrent) {
+                    try {
+                        const resolveFn = toolRegistry['resolve_org_units']
+                        const or = resolveFn
+                            ? await resolveFn({ description: ouDescCurrent })
+                            : null
+                        if (or?.resolved && or.items?.length) {
+                            lastResolvedOrgUnits = or.items
+                        }
+                    } catch (_) {}
+                } else if (!lastResolvedOrgUnits) {
+                    const historyTexts = [...history]
+                        .filter(
+                            (m) =>
+                                m.role === 'user' &&
+                                typeof m.content === 'string'
+                        )
+                        .slice(-4)
+                        .map((m) => m.content)
+                    const ouDescHistory = historyTexts
+                        .map((t) => t.match(OU_RE)?.[0])
+                        .find(Boolean)
+                    if (ouDescHistory) {
+                        try {
+                            const resolveFn = toolRegistry['resolve_org_units']
+                            const or = resolveFn
+                                ? await resolveFn({
+                                      description: ouDescHistory,
+                                  })
+                                : null
+                            if (or?.resolved && or.items?.length) {
+                                lastResolvedOrgUnits = or.items
+                            }
+                        } catch (_) {}
+                    }
+                }
+            }
+
+            const changes = {}
+            if (lastResolvedPeriods?.length) {
+                changes.periods = lastResolvedPeriods
+            }
+            if (lastResolvedOrgUnits?.length) {
+                changes.orgUnits = lastResolvedOrgUnits
+            }
+
+            if (Object.keys(changes).length) {
+                const targetLayer = prefetchedLayers[0]
+                console.log(
+                    '[AI] edit recovery (programmatic): calling update_layer',
+                    targetLayer.id,
+                    changes
+                )
+                onUpdate?.({ type: 'thinking' })
+                onUpdate?.({
+                    type: 'tool_call',
+                    name: 'update_layer',
+                    args: { layerId: targetLayer.id, changes },
+                })
+                const result = await updateFn({
+                    layerId: targetLayer.id,
+                    changes,
+                })
+                onUpdate?.({
+                    type: 'tool_result',
+                    name: 'update_layer',
+                    result,
+                })
+                if (result.success) {
+                    reply = `Done — I've updated the layer.`
+                    const last = newMessages.at(-1)
+                    if (last?.role === 'assistant') {
+                        last.content = reply
+                    } else {
+                        newMessages.push({ role: 'assistant', content: reply })
+                    }
+                    onUpdate?.({ type: 'reply', text: reply })
+                }
+                // Either way, don't fall through to LLM recovery — we tried.
+            } else {
+                // No cached values and couldn't extract from text — fall back to LLM recovery.
+                console.log(
+                    '[AI] edit recovery (LLM fallback): no cached resolved values'
+                )
+                const layerIdHint =
+                    prefetchedLayers[0]?.id ?? '(see system context)'
+                const correctionMsg = `CORRECTION: You did not call update_layer. The user wants: "${userText}". LayerId="${layerIdHint}". Call resolve_periods or resolve_org_units as needed, then call update_layer. Do not output text before calling the tools.`
+                messages.push({ role: 'user', content: correctionMsg })
+                onUpdate?.({ type: 'thinking' })
+                const recoveryResult = await connector.chat({
+                    messages: [
+                        { role: 'system', content: systemContent },
+                        ...messages,
+                    ],
+                    tools: activeTools,
+                    signal,
+                })
+                console.log(
+                    '[AI] edit recovery LLM — toolCalls:',
+                    recoveryResult.toolCalls?.map((t) => t.name)
+                )
+                if (recoveryResult.toolCalls?.length) {
+                    for (const tc of recoveryResult.toolCalls) {
+                        if (tc.name === 'update_layer') {
+                            onUpdate?.({
+                                type: 'tool_call',
+                                name: tc.name,
+                                args: tc.args,
+                            })
+                            const toolResult = await executeToolCall(
+                                toolRegistry,
+                                tc
+                            )
+                            const parsed = JSON.parse(toolResult.content)
+                            onUpdate?.({
+                                type: 'tool_result',
+                                name: tc.name,
+                                result: parsed,
+                            })
+                            if (parsed.success) {
+                                reply =
+                                    recoveryResult.text?.trim() ||
+                                    `Done — I've updated the layer.`
+                                const last = newMessages.at(-1)
+                                if (last?.role === 'assistant') {
+                                    last.content = reply
+                                } else {
+                                    newMessages.push({
+                                        role: 'assistant',
+                                        content: reply,
+                                    })
+                                }
+                                onUpdate?.({ type: 'reply', text: reply })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ADD recovery: model resolved some values but did not add the layer.
+    // Bypass the LLM entirely — complete the operation programmatically using the
+    // values cached during the main loop. This avoids confusing the 7B model with
+    // another LLM iteration after it has already stalled.
+    if (
+        [
+            INTENT.ADD_THEMATIC,
+            INTENT.ADD_FACILITY,
+            INTENT.ADD_ORG_UNIT,
+        ].includes(intent) &&
+        resolveToolsCalled &&
+        !anyLayerAdded
+    ) {
+        console.log(
+            '[AI] add recovery: completing programmatically with cached resolved values'
+        )
+        try {
+            // If data item wasn't resolved (model skipped search_data_items), search now from user text
+            if (!lastResolvedDataItem && intent === INTENT.ADD_THEMATIC) {
+                const searchFn = toolRegistry['search_data_items']
+                if (searchFn) {
+                    const searchQuery = userText
+                        .replace(
+                            /\b(show|display|add|map|layer|by|for|in|at|on|the|a|an|all|this|last|next|year|month|quarter|week|district|region|province|national|chiefdom|facility|boundaries)\b/gi,
+                            ' '
+                        )
+                        .replace(/\s+/g, ' ')
+                        .trim()
+                    if (searchQuery) {
+                        console.log(
+                            '[AI] add recovery: searching for data item with query:',
+                            searchQuery
+                        )
+                        const searchResult = await searchFn({
+                            query: searchQuery,
+                        })
+                        if (
+                            searchResult.found &&
+                            searchResult.candidates?.[0]?.id
+                        ) {
+                            lastResolvedDataItem = searchResult.candidates[0]
+                            console.log(
+                                '[AI] add recovery: found data item:',
+                                lastResolvedDataItem
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Resolve periods if not already done (extract from user text)
+            if (!lastResolvedPeriods && intent === INTENT.ADD_THEMATIC) {
+                const resolvePeriodsFn = toolRegistry['resolve_periods']
+                if (resolvePeriodsFn) {
+                    const periodsResult = await resolvePeriodsFn({
+                        description: userText,
+                    })
+                    if (
+                        periodsResult.resolved &&
+                        periodsResult.periods?.length
+                    ) {
+                        lastResolvedPeriods = periodsResult.periods
+                        console.log(
+                            '[AI] add recovery: resolved periods from user text:',
+                            lastResolvedPeriods
+                        )
+                    }
+                }
+            }
+
+            const addFnName =
+                intent === INTENT.ADD_THEMATIC
+                    ? 'add_thematic_layer'
+                    : intent === INTENT.ADD_FACILITY
+                    ? 'add_facility_layer'
+                    : 'add_org_unit_layer'
+            const addFn = toolRegistry[addFnName]
+
+            if (addFn && lastResolvedOrgUnits) {
+                let addArgs
+                if (
+                    intent === INTENT.ADD_THEMATIC &&
+                    lastResolvedDataItem &&
+                    lastResolvedPeriods
+                ) {
+                    addArgs = {
+                        dataItem: {
+                            id: lastResolvedDataItem.id,
+                            name:
+                                lastResolvedDataItem.displayName ??
+                                lastResolvedDataItem.name ??
+                                lastResolvedDataItem.id,
+                            dimensionItemType:
+                                lastResolvedDataItem.dimensionItemType,
+                        },
+                        orgUnits: lastResolvedOrgUnits,
+                        periods: lastResolvedPeriods,
+                    }
+                } else if (intent !== INTENT.ADD_THEMATIC) {
+                    addArgs = { orgUnits: lastResolvedOrgUnits }
+                }
+
+                if (addArgs) {
+                    console.log(
+                        '[AI] add recovery → calling',
+                        addFnName,
+                        addArgs
+                    )
+                    onUpdate?.({
+                        type: 'tool_call',
+                        name: addFnName,
+                        args: addArgs,
+                    })
+                    const addResult = await addFn(addArgs)
+                    console.log('[AI] add recovery ← result:', addResult)
+                    onUpdate?.({
+                        type: 'tool_result',
+                        name: addFnName,
+                        result: addResult,
+                    })
+                    if (addResult.success) {
+                        reply = `Done — I've added the layer.`
+                        for (let j = newMessages.length - 1; j >= 0; j--) {
+                            if (newMessages[j].role === 'assistant') {
+                                newMessages[j] = {
+                                    role: 'assistant',
+                                    content: reply,
+                                }
+                                break
+                            }
+                        }
+                        onUpdate?.({ type: 'reply', text: reply })
+                    }
+                }
+            }
+        } catch (e) {
+            console.warn('[AI] add recovery failed:', e)
+        }
+    }
+
+    // Guard against empty reply (model returned no text and no tool calls)
+    if (!reply) {
+        reply = "I wasn't sure what to do with that. Could you try rephrasing?"
+        const last = newMessages.at(-1)
+        if (last?.role === 'assistant' && !last.content) {
+            last.content = reply
+        } else {
+            newMessages.push({ role: 'assistant', content: reply })
+        }
     }
 
     return {

--- a/src/ai/agent/router.js
+++ b/src/ai/agent/router.js
@@ -6,10 +6,24 @@ import { INTENT } from './systemPrompt.js'
  * by reducing the number of choices the model must make per call.
  */
 
+// Pure acknowledgments / comments that should not trigger any map action
+const COMMENT_PATTERNS = [
+    /^(ok|okay|great|thanks|thank you|i see|understood|alright|cool|perfect|nice|noted|got it|sounds good)\s*[.!]?$/i,
+    // Combinations like "great, thanks!" or "thanks, that's perfect"
+    /^(great|perfect|nice|cool|awesome)[,!]?\s*(thanks|thank you)[.!]?$/i,
+    /^(thanks|thank you)[,!]?\s*(that[''s]?\s*(great|perfect|good|helpful|awesome)|so much)[.!]?$/i,
+    /^(you[''re\s]+welcome|no problem|sure)[.!]?$/i,
+    /^(that|this)\s+(is|'?s)\b/i,
+    /^yes[,.]?\s*(?:that['']s|it(?:'?s)?|those are)\b/i,
+]
+
 const DECLINE_PATTERNS = [
     /analys[ei]|interpret|what does|explain|why is|trend|pattern|insight/i,
-    /patient|individual|person named|tracked entit|line list/i,
+    /\bpatient\b|\bindividual\b|\bperson named\b|\btracked entit|\bline list\b/i,
     /event.*report|report.*event/i,
+    // Comparative / ranking analytical questions (question-word + superlative, or counting)
+    /\b(which|what)\b.{1,60}\b(highest|lowest|most|fewest|least|greatest|smallest|worst|best|most affected)\b/i,
+    /\bhow\s+many\b/i,
 ]
 
 const THEMATIC_PATTERNS = [
@@ -21,30 +35,59 @@ const FACILITY_PATTERNS = [
     /facilit|health\s+(post|centre|center|facility|clinic)|hospital/i,
 ]
 
-const ORG_UNIT_PATTERNS = [
-    /boundar|org\s+unit\s+layer|administrative|chiefdom|district\s+boundary|region\s+boundary/i,
-]
+const ORG_UNIT_PATTERNS = [/boundar|org\s+unit\s+layer|administrative/i]
 
 const EDIT_PATTERNS = [
     /change|update|modify|switch|make it|convert|turn it|set.*period|set.*org/i,
+    // Map type changes: "switch/convert to bubble", "show it as a choropleth", "as a bubble map"
+    /\b(switch|convert|turn)\b.{0,40}\b(bubble|choropleth)\b/i,
+    /\bas\s+a?\s*(bubble|choropleth)\b/i,
+    // Level navigation: "go down to chiefdoms", "drill into districts", "zoom out to regions"
+    /\b(go|drill|zoom|move|jump)\s+(up|down|in|out|into|deeper|higher|lower|to)\b/i,
+    // "down to X level" / "up to X level" without leading verb
+    /\b(down|up)\s+to\b.{0,30}\b(level|district|chiefdom|region|province|national|ward)\b/i,
+]
+
+const EXPLORE_PATTERNS = [
+    // Plural data-type words = browsing ("list ANC indicators", "show me BCG datasets")
+    // Singular is excluded on purpose — "add an ANC indicator" should route to ADD
+    /\b(list|show me|find|search for|can you list|please list|check|browse|look at|see)\b.{0,60}\b(indicators|data elements|datasets|programs)\b/i,
+    // "what/which X indicators are available/related/there"
+    /\b(what|which)\b.{0,60}\b(indicators?|data elements?|datasets?|programs?)\b.{0,40}\b(available|exist|related|there|do you have)\b/i,
+    // Generic availability
+    /\bwhat.{0,40}(available|exist)\b/i,
 ]
 
 const REMOVE_PATTERNS = [/remove|delete|hide|clear|drop|get rid/i]
+
+// Compound: remove one layer AND add another in the same turn
+const COMPOUND_PATTERNS = [
+    /\b(remove|delete|hide|clear|drop)\b.*\b(then|and|,)\b.*(add|show|create|display)/i,
+]
 
 /**
  * Classify user intent from the latest user message.
  * @param {string} text
  * @returns {string} one of INTENT.*
  */
-export const classifyIntent = (text) => {
+export const classifyIntent = (text, history = []) => {
+    if (COMMENT_PATTERNS.some((p) => p.test(text.trim()))) {
+        return INTENT.DECLINE
+    }
     if (DECLINE_PATTERNS.some((p) => p.test(text))) {
         return INTENT.DECLINE
+    }
+    if (COMPOUND_PATTERNS.some((p) => p.test(text))) {
+        return INTENT.COMPOUND
     }
     if (REMOVE_PATTERNS.some((p) => p.test(text))) {
         return INTENT.REMOVE
     }
     if (EDIT_PATTERNS.some((p) => p.test(text))) {
         return INTENT.EDIT
+    }
+    if (EXPLORE_PATTERNS.some((p) => p.test(text))) {
+        return INTENT.EXPLORE
     }
     if (FACILITY_PATTERNS.some((p) => p.test(text))) {
         return INTENT.ADD_FACILITY
@@ -55,6 +98,37 @@ export const classifyIntent = (text) => {
     if (THEMATIC_PATTERNS.some((p) => p.test(text))) {
         return INTENT.ADD_THEMATIC
     }
+
+    // DHIS2 UID — user is selecting an item from a previous explore list
+    if (/^[A-Za-z0-9]{11}$/.test(text.trim())) {
+        return INTENT.ADD_THEMATIC
+    }
+
+    // Short reply after an assistant question: inherit the intent of the prior user turn.
+    // Covers "Yes", "OK", "All chiefdoms", "Northern region" etc. following a clarification.
+    const wordCount = text.trim().split(/\s+/).length
+    if (wordCount <= 4 && history.length >= 2) {
+        const lastAssistantMsg = [...history]
+            .reverse()
+            .find((m) => m.role === 'assistant')
+        const lastAssistantText =
+            typeof lastAssistantMsg?.content === 'string'
+                ? lastAssistantMsg.content
+                : ''
+        if (lastAssistantText.includes('?')) {
+            const lastUserMsg = [...history]
+                .reverse()
+                .find((m) => m.role === 'user' && typeof m.content === 'string')
+            if (lastUserMsg) {
+                const inherited = classifyIntent(lastUserMsg.content)
+                // EXPLORE → ADD_THEMATIC: user is selecting an item from the explore results
+                return inherited === INTENT.EXPLORE
+                    ? INTENT.ADD_THEMATIC
+                    : inherited
+            }
+        }
+    }
+
     // Default: let the model figure it out with all tools
     return INTENT.ADD_THEMATIC
 }
@@ -91,12 +165,30 @@ export const getToolsForIntent = (intent) => {
                 'list_layers',
                 'resolve_org_units',
                 'resolve_periods',
+                'validate_periods',
                 'search_data_items',
                 'search_org_unit_group_sets',
                 'update_layer',
             ]
         case INTENT.REMOVE:
+            // list_layers is needed when the user says "that layer" or "this one" (deictic refs)
             return ['list_layers', 'remove_layer']
+        case INTENT.EXPLORE:
+            return ['search_data_items']
+        case INTENT.COMPOUND:
+            return [
+                'list_layers',
+                'remove_layer',
+                'search_data_items',
+                'resolve_org_units',
+                'resolve_periods',
+                'validate_periods',
+                'search_org_unit_group_sets',
+                'add_thematic_layer',
+                'add_facility_layer',
+                'add_org_unit_layer',
+                'update_layer',
+            ]
         default:
             return []
     }
@@ -108,11 +200,26 @@ export const getToolsForIntent = (intent) => {
  * @returns {string|null} decline message or null if not declined
  */
 export const getDeclineMessage = (text) => {
+    if (COMMENT_PATTERNS.some((p) => p.test(text.trim()))) {
+        return "Noted! Let me know what you'd like to add, edit, or remove on the map."
+    }
     if (/analys[ei]|interpret|explain|insight|trend|pattern/i.test(text)) {
         return "I can add, edit, and remove map layers, but I can't analyse or interpret map data here. Try the interpretations panel for commentary."
     }
-    if (/patient|individual|person named|tracked entit|line list/i.test(text)) {
+    if (
+        /\bpatient\b|\bindividual\b|\bperson named\b|\btracked entit|\bline list\b/i.test(
+            text
+        )
+    ) {
         return 'Individual-level and tracked entity data is not available through this assistant.'
+    }
+    if (
+        /\b(which|what)\b.{1,60}\b(highest|lowest|most|fewest|least|greatest|smallest|worst|best|most affected)\b/i.test(
+            text
+        ) ||
+        /\bhow\s+many\b/i.test(text)
+    ) {
+        return "I can add, edit, and remove map layers, but I can't answer data questions or rank areas. Add a layer to visualise the data and explore it on the map."
     }
     return null
 }

--- a/src/ai/agent/router.js
+++ b/src/ai/agent/router.js
@@ -1,0 +1,118 @@
+import { INTENT } from './systemPrompt.js'
+
+/**
+ * Two-step router: classify the user's intent, then expose only the relevant
+ * tool subset. This dramatically improves reliability with 7–8B local models
+ * by reducing the number of choices the model must make per call.
+ */
+
+const DECLINE_PATTERNS = [
+    /analys[ei]|interpret|what does|explain|why is|trend|pattern|insight/i,
+    /patient|individual|person named|tracked entit|line list/i,
+    /event.*report|report.*event/i,
+]
+
+const THEMATIC_PATTERNS = [
+    /choropleth|bubble\s+map|incidence|coverage|rate|ratio|proportion|attendance|cases|indicator|data element/i,
+    /malaria|anc|bcg|opd|hiv|tuberculosis|stock.out|mortality|morbidity/i,
+]
+
+const FACILITY_PATTERNS = [
+    /facilit|health\s+(post|centre|center|facility|clinic)|hospital/i,
+]
+
+const ORG_UNIT_PATTERNS = [
+    /boundar|org\s+unit\s+layer|administrative|chiefdom|district\s+boundary|region\s+boundary/i,
+]
+
+const EDIT_PATTERNS = [
+    /change|update|modify|switch|make it|convert|turn it|set.*period|set.*org/i,
+]
+
+const REMOVE_PATTERNS = [/remove|delete|hide|clear|drop|get rid/i]
+
+/**
+ * Classify user intent from the latest user message.
+ * @param {string} text
+ * @returns {string} one of INTENT.*
+ */
+export const classifyIntent = (text) => {
+    if (DECLINE_PATTERNS.some((p) => p.test(text))) {
+        return INTENT.DECLINE
+    }
+    if (REMOVE_PATTERNS.some((p) => p.test(text))) {
+        return INTENT.REMOVE
+    }
+    if (EDIT_PATTERNS.some((p) => p.test(text))) {
+        return INTENT.EDIT
+    }
+    if (FACILITY_PATTERNS.some((p) => p.test(text))) {
+        return INTENT.ADD_FACILITY
+    }
+    if (ORG_UNIT_PATTERNS.some((p) => p.test(text))) {
+        return INTENT.ADD_ORG_UNIT
+    }
+    if (THEMATIC_PATTERNS.some((p) => p.test(text))) {
+        return INTENT.ADD_THEMATIC
+    }
+    // Default: let the model figure it out with all tools
+    return INTENT.ADD_THEMATIC
+}
+
+/**
+ * Return the tool name subset for a given intent.
+ * Edit/remove always start with list_layers.
+ * @param {string} intent
+ * @returns {string[]}
+ */
+export const getToolsForIntent = (intent) => {
+    switch (intent) {
+        case INTENT.ADD_THEMATIC:
+            return [
+                'search_data_items',
+                'resolve_org_units',
+                'resolve_periods',
+                'add_thematic_layer',
+            ]
+        case INTENT.ADD_FACILITY:
+            return [
+                'resolve_org_units',
+                'search_org_unit_group_sets',
+                'add_facility_layer',
+            ]
+        case INTENT.ADD_ORG_UNIT:
+            return [
+                'resolve_org_units',
+                'search_org_unit_group_sets',
+                'add_org_unit_layer',
+            ]
+        case INTENT.EDIT:
+            return [
+                'list_layers',
+                'resolve_org_units',
+                'resolve_periods',
+                'search_data_items',
+                'search_org_unit_group_sets',
+                'update_layer',
+            ]
+        case INTENT.REMOVE:
+            return ['list_layers', 'remove_layer']
+        default:
+            return []
+    }
+}
+
+/**
+ * Decline message for out-of-scope requests.
+ * @param {string} text
+ * @returns {string|null} decline message or null if not declined
+ */
+export const getDeclineMessage = (text) => {
+    if (/analys[ei]|interpret|explain|insight|trend|pattern/i.test(text)) {
+        return "I can add, edit, and remove map layers, but I can't analyse or interpret map data here. Try the interpretations panel for commentary."
+    }
+    if (/patient|individual|person named|tracked entit|line list/i.test(text)) {
+        return 'Individual-level and tracked entity data is not available through this assistant.'
+    }
+    return null
+}

--- a/src/ai/agent/systemPrompt.js
+++ b/src/ai/agent/systemPrompt.js
@@ -5,16 +5,25 @@ Layer types you can work with:
 - facility: health facility points on the map
 - org unit: administrative boundaries (also use for "show the boundaries" requests)
 
+CRITICAL RULE: Never ask confirmation questions. Never say "Shall I proceed?", "Is this configured as intended?", "Do you want me to go ahead?", "Would you like me to add this?", "Can I confirm?", or anything similar. Act immediately once you have the needed values. The user's request IS the confirmation.
+
 Rules:
-- Resolve every name to an id with the search/resolve tools before acting. Never invent ids.
+- Resolve every name to an id with the search/resolve tools before acting. Never invent ids. Never ask the user for an id or code — always call search_data_items or resolve_org_units to find it yourself.
 - For org units like "by district", "all chiefdoms", "regional level": call resolve_org_units, which maps the description to the instance's level. Never hard-code level numbers.
 - For "my facilities" or "my org units": use resolve_org_units with the description — it will return USER_ORGUNIT tokens.
-- To edit or remove a layer: first call list_layers and match the user's reference to a layer id. If it's unclear which layer, ask ONE short clarifying question.
-- Always confirm with the user before calling remove_layer. Set confirmed=true only after they agree.
-- If the request is ambiguous (unclear indicator, org unit, or period): ask ONE short clarifying question. Do not guess.
+- To edit a layer: (1) call list_layers to get the layer id, (2) if the user is changing an org unit or period, resolve the new value with the resolve tools, (3) call update_layer with the layer id and the resolved changes. For map type changes (choropleth ↔ bubble), skip step 2 — just call update_layer directly with changes: { thematicMapType: 'CHOROPLETH' } or changes: { thematicMapType: 'BUBBLE' }. Resolving a value does NOT apply it; you must still call update_layer.
+- To remove a layer: call list_layers to find the layer id, then call remove_layer with that id.
+- When the user asks to remove a layer, call remove_layer immediately with namePattern set to the layer name from the user's message. Do NOT ask for confirmation — the user's request IS the confirmation.
+- For period expressions like "this quarter", "last month", "this year", "last 3 months", "Q2 2023", "2023Q1": always call resolve_periods immediately — it handles all common phrases and quarter formats. Never ask for confirmation or clarification about period formats before calling resolve_periods.
+- If you are unsure whether a period id is valid (e.g. you constructed one yourself rather than getting it from resolve_periods), call validate_periods first. If any period is invalid, call resolve_periods with a natural language description to get a correct id.
+- If the request is ambiguous (unclear indicator or org unit): ask ONE short clarifying question. Do not guess.
+- When you have the data item id, org units, and period resolved, call add_*_layer immediately. Never ask "Is everything in order?", "Shall I proceed?", "Can you confirm?", or any other confirmation question before acting. The user's request is the confirmation.
 - You can add, edit, and remove layers only. If asked to analyse or interpret the map data, briefly say that is not available here. If asked about individual people, patients, or tracked entities, say that is not available here.
 - Only tool calls change the map. Your text is shown to the user but changes nothing.
-- When search results return multiple candidates, pick the most relevant one or ask a short clarifying question — do not list all candidates in detail.`
+- Respond in plain English only. Never output JSON, code blocks, raw IDs, or technical layer metadata (like "CHOROPLETH · THIS_YEAR") in your replies — just a short natural-language sentence confirming what was done.
+- When search results return multiple candidates, pick the most relevant one. Only ask a short clarifying question if you truly cannot determine the best match — and in that case name at most 3 options, not all of them.
+- When the user asks what data is available (e.g. "what malaria indicators exist?", "list ANC data elements"): call search_data_items with a SHORT broad term (1-2 words, e.g. "malaria" not "malaria incidence rate"). Then reply with a plain-language list of what was found — do NOT add a layer. Do NOT output raw IDs in your reply — use display names only.
+- When the user selects an item from a previous list (by name or by ID), do NOT call search_data_items again. The item is already in the conversation history. Proceed directly: call resolve_org_units and resolve_periods, then call add_thematic_layer.`
 
 /**
  * Intent categories used by the router to select the right tool subset.
@@ -26,6 +35,8 @@ export const INTENT = {
     ADD_ORG_UNIT: 'add-org-unit',
     EDIT: 'edit',
     REMOVE: 'remove',
+    COMPOUND: 'compound',
+    EXPLORE: 'explore',
     CLARIFY: 'clarify',
     DECLINE: 'decline',
 }

--- a/src/ai/agent/systemPrompt.js
+++ b/src/ai/agent/systemPrompt.js
@@ -1,0 +1,31 @@
+export const SYSTEM_PROMPT = `You are an assistant inside the DHIS2 Maps app. You help users add, edit, and remove map layers by calling tools.
+
+Layer types you can work with:
+- thematic: choropleth or bubble map of an indicator/data element over org units and periods
+- facility: health facility points on the map
+- org unit: administrative boundaries (also use for "show the boundaries" requests)
+
+Rules:
+- Resolve every name to an id with the search/resolve tools before acting. Never invent ids.
+- For org units like "by district", "all chiefdoms", "regional level": call resolve_org_units, which maps the description to the instance's level. Never hard-code level numbers.
+- For "my facilities" or "my org units": use resolve_org_units with the description — it will return USER_ORGUNIT tokens.
+- To edit or remove a layer: first call list_layers and match the user's reference to a layer id. If it's unclear which layer, ask ONE short clarifying question.
+- Always confirm with the user before calling remove_layer. Set confirmed=true only after they agree.
+- If the request is ambiguous (unclear indicator, org unit, or period): ask ONE short clarifying question. Do not guess.
+- You can add, edit, and remove layers only. If asked to analyse or interpret the map data, briefly say that is not available here. If asked about individual people, patients, or tracked entities, say that is not available here.
+- Only tool calls change the map. Your text is shown to the user but changes nothing.
+- When search results return multiple candidates, pick the most relevant one or ask a short clarifying question — do not list all candidates in detail.`
+
+/**
+ * Intent categories used by the router to select the right tool subset.
+ * @enum {string}
+ */
+export const INTENT = {
+    ADD_THEMATIC: 'add-thematic',
+    ADD_FACILITY: 'add-facility',
+    ADD_ORG_UNIT: 'add-org-unit',
+    EDIT: 'edit',
+    REMOVE: 'remove',
+    CLARIFY: 'clarify',
+    DECLINE: 'decline',
+}

--- a/src/ai/connectors/anthropic.js
+++ b/src/ai/connectors/anthropic.js
@@ -38,6 +38,7 @@ export const makeAnthropic = ({ id, label, baseURL, apiKey, model }) => ({
             headers: {
                 'content-type': 'application/json',
                 'anthropic-version': ANTHROPIC_VERSION,
+                'anthropic-dangerous-direct-browser-access': 'true',
                 ...(apiKey && { 'x-api-key': apiKey }),
             },
             body: JSON.stringify(body),

--- a/src/ai/connectors/anthropic.js
+++ b/src/ai/connectors/anthropic.js
@@ -1,0 +1,83 @@
+const ANTHROPIC_VERSION = '2023-06-01'
+const DEFAULT_MAX_TOKENS = 1024
+
+/**
+ * @param {Object} opts
+ * @param {string} opts.baseURL - Route URL, e.g. '/api/routes/ai-proxy/run'
+ * @param {string} [opts.apiKey] - Only used in dev; in prod the key lives in the Route
+ * @param {string} opts.model
+ * @returns {import('./types.js').LLMConnector}
+ */
+export const makeAnthropic = ({ id, label, baseURL, apiKey, model }) => ({
+    id,
+    label,
+    capabilities: {
+        supportsTools: true,
+        supportsStreaming: false, // SSE through DHIS2 Routes is unverified
+        isLocal: false,
+        maxContextTokens: 200000,
+    },
+
+    async chat({ messages, tools, signal }) {
+        const body = {
+            model,
+            max_tokens: DEFAULT_MAX_TOKENS,
+            messages: toAnthropicMessages(messages),
+            ...(tools?.length && {
+                tools: tools.map((t) => ({
+                    name: t.name,
+                    description: t.description,
+                    input_schema: t.input_schema,
+                })),
+            }),
+        }
+
+        const resp = await fetch(`${baseURL}/v1/messages`, {
+            method: 'POST',
+            signal,
+            headers: {
+                'content-type': 'application/json',
+                'anthropic-version': ANTHROPIC_VERSION,
+                ...(apiKey && { 'x-api-key': apiKey }),
+            },
+            body: JSON.stringify(body),
+        })
+
+        if (!resp.ok) {
+            const err = await resp.text().catch(() => resp.statusText)
+            throw new Error(`Anthropic API error ${resp.status}: ${err}`)
+        }
+
+        const data = await resp.json()
+        const content = data.content ?? []
+
+        return {
+            text: content
+                .filter((b) => b.type === 'text')
+                .map((b) => b.text)
+                .join(''),
+            toolCalls: content
+                .filter((b) => b.type === 'tool_use')
+                .map((b) => ({ id: b.id, name: b.name, args: b.input })),
+        }
+    },
+})
+
+/** Normalise our message format to Anthropic's */
+const toAnthropicMessages = (messages) =>
+    messages.map((msg) => {
+        if (typeof msg.content === 'string') {
+            return { role: msg.role, content: msg.content }
+        }
+        if (Array.isArray(msg.content)) {
+            return {
+                role: 'user',
+                content: msg.content.map((item) => ({
+                    type: 'tool_result',
+                    tool_use_id: item.tool_use_id,
+                    content: item.content,
+                })),
+            }
+        }
+        return msg
+    })

--- a/src/ai/connectors/demo.js
+++ b/src/ai/connectors/demo.js
@@ -1,0 +1,198 @@
+import { DEMO_SCRIPTS, DEMO_FALLBACK_MESSAGE } from './demoScripts.js'
+
+let stepCounter = 0
+const nextId = () => `demo-tc-${++stepCounter}`
+
+/**
+ * Deterministic demo connector — implements LLMConnector without calling any model.
+ * Matches user input against DEMO_SCRIPTS and returns scripted tool calls one at a time.
+ * The real resolver tools and executor run against the live DHIS2 instance; only the
+ * "LLM reasoning" step is replaced by this fixed plan.
+ */
+export const makeDemoConnector = () => ({
+    id: 'demo',
+    label: 'Demo (no model)',
+    capabilities: {
+        supportsTools: true,
+        supportsStreaming: false,
+        isLocal: true,
+        maxContextTokens: Infinity,
+    },
+
+    async chat({ messages }) {
+        // Find the LAST string-content user message — that is the current turn's query.
+        // Messages from previous turns (prior conversation history) appear before it.
+        const lastUserIdx = messages.reduce(
+            (idx, m, i) =>
+                m.role === 'user' && typeof m.content === 'string' ? i : idx,
+            -1
+        )
+        const text = lastUserIdx >= 0 ? messages[lastUserIdx].content : ''
+
+        let script = null
+        let isRemoval = false
+        for (const s of DEMO_SCRIPTS) {
+            if (s.removeMatch?.test(text)) {
+                script = s
+                isRemoval = true
+                break
+            }
+            if (s.match.test(text)) {
+                script = s
+                break
+            }
+        }
+        console.log(
+            '[AI][demo] user text:',
+            text,
+            '| matched script:',
+            script?.label ?? 'none',
+            '| isRemoval:',
+            isRemoval
+        )
+
+        if (!script) {
+            return { text: DEMO_FALLBACK_MESSAGE, toolCalls: [] }
+        }
+
+        // Only look at messages AFTER the current user message — earlier messages
+        // belong to prior turns and must not count as "already done".
+        const currentTurnMessages = messages.slice(lastUserIdx + 1)
+
+        // Which tools have already been called (read from assistant messages)
+        const completedToolNames =
+            extractCompletedToolNames(currentTurnMessages)
+        console.log('[AI][demo] completed tools:', completedToolNames)
+
+        // Collect results from tool calls already executed
+        const toolResults = extractToolResults(currentTurnMessages)
+        console.log('[AI][demo] accumulated tool results:', toolResults)
+
+        const steps = isRemoval ? script.removeSteps ?? [] : script.steps
+        const nextStep = steps.find(
+            (step) => !completedToolNames.includes(step.name)
+        )
+
+        if (!nextStep) {
+            return {
+                text: isRemoval
+                    ? `Done! The layer has been removed from the map.`
+                    : `Done! The ${script.label.toLowerCase()} has been added to the map.`,
+                toolCalls: [],
+            }
+        }
+
+        console.log('[AI][demo] next step:', nextStep.name)
+
+        // Build resolved args for layer-adding steps using prior tool results
+        const resolvedArgs = resolveArgs(nextStep, toolResults)
+        console.log(
+            '[AI][demo] resolved args for',
+            nextStep.name,
+            ':',
+            resolvedArgs
+        )
+
+        if (resolvedArgs === null) {
+            return {
+                text: `I couldn't find a matching data item in this DHIS2 instance. Try a different search term or check available indicators.`,
+                toolCalls: [],
+            }
+        }
+
+        return {
+            text: '',
+            toolCalls: [
+                { id: nextId(), name: nextStep.name, args: resolvedArgs },
+            ],
+        }
+    },
+})
+
+/** Extract tool names already called from assistant messages in history */
+const extractCompletedToolNames = (messages) => {
+    const names = []
+    for (const msg of messages) {
+        if (msg.role === 'assistant' && Array.isArray(msg.toolCalls)) {
+            for (const tc of msg.toolCalls) {
+                names.push(tc.name)
+            }
+        }
+    }
+    return names
+}
+
+/**
+ * Collect the parsed results of all completed tool calls.
+ * Tool result messages have role:'user' with Array content of { tool_use_id, content } objects.
+ * Assistant messages record which tool name each id belongs to.
+ */
+const extractToolResults = (messages) => {
+    // Build a map from tool_use_id → tool name
+    const idToName = {}
+    for (const msg of messages) {
+        if (msg.role === 'assistant' && Array.isArray(msg.toolCalls)) {
+            for (const tc of msg.toolCalls) {
+                idToName[tc.id] = tc.name
+            }
+        }
+    }
+
+    const results = {}
+    for (const msg of messages) {
+        if (msg.role === 'user' && Array.isArray(msg.content)) {
+            for (const item of msg.content) {
+                if (item.tool_use_id && item.content) {
+                    const name = idToName[item.tool_use_id]
+                    if (name) {
+                        try {
+                            results[name] = JSON.parse(item.content)
+                        } catch {
+                            results[name] = item.content
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return results
+}
+
+/**
+ * Build resolved args for a step, substituting actual tool results for
+ * the placeholder strings used in demoScripts.js.
+ */
+const resolveArgs = (step, toolResults) => {
+    switch (step.name) {
+        case 'add_thematic_layer': {
+            const dataItemResult = toolResults['search_data_items']
+            const orgUnitResult = toolResults['resolve_org_units']
+            const periodResult = toolResults['resolve_periods']
+
+            const firstCandidate = dataItemResult?.candidates?.[0]
+            if (!firstCandidate) {
+                // search_data_items found nothing — return a text message and stop
+                return null // signals to chat() to return a fallback message
+            }
+
+            const dataItem = {
+                id: firstCandidate.id,
+                name: firstCandidate.displayName,
+                dimensionItemType: firstCandidate.dimensionItemType,
+            }
+            const orgUnits = orgUnitResult?.items ?? step.args.orgUnits
+            const periods = periodResult?.periods ?? step.args.periods
+
+            return { ...step.args, dataItem, orgUnits, periods }
+        }
+        case 'add_facility_layer':
+        case 'add_org_unit_layer': {
+            const orgUnitResult = toolResults['resolve_org_units']
+            // Fall back to empty array rather than the placeholder string
+            const orgUnits = orgUnitResult?.items ?? []
+            return { ...step.args, orgUnits }
+        }
+        default:
+            return step.args
+    }
+}

--- a/src/ai/connectors/demoScripts.js
+++ b/src/ai/connectors/demoScripts.js
@@ -11,7 +11,7 @@
  */
 export const DEMO_SCRIPTS = [
     {
-        label: 'Malaria incidence by district, last 12 months',
+        label: 'Inpatient malaria cases by district, last year',
         match: /malaria.*district|district.*malaria/i,
         removeLabel: 'Remove malaria layer',
         removeMatch: /remove.*malaria/i,
@@ -19,7 +19,7 @@ export const DEMO_SCRIPTS = [
             {
                 id: 'demo-1',
                 name: 'search_data_items',
-                args: { query: 'malaria' },
+                args: { query: 'Inpatient malaria cases' },
             },
             {
                 id: 'demo-2',
@@ -46,7 +46,7 @@ export const DEMO_SCRIPTS = [
             {
                 id: 'remove-1',
                 name: 'remove_layer',
-                args: { namePattern: 'Malaria', confirmed: true },
+                args: { namePattern: 'malaria', confirmed: true },
             },
         ],
     },

--- a/src/ai/connectors/demoScripts.js
+++ b/src/ai/connectors/demoScripts.js
@@ -1,0 +1,146 @@
+/**
+ * Scripted tool-call plans for demo mode.
+ * Each entry has a label (shown as an example chip), a regex to match user text,
+ * and a sequence of tool calls with natural-language arguments (real resolvers run them).
+ *
+ * removeLabel / removeMatch / removeSteps: shown as a "remove" chip after the layer
+ * is added, so the user can demonstrate removing layers too.
+ *
+ * The real metadata tools + executor run against the live DHIS2 instance —
+ * only the LLM "reasoning" step is replaced by this fixed plan.
+ */
+export const DEMO_SCRIPTS = [
+    {
+        label: 'Malaria incidence by district, last 12 months',
+        match: /malaria.*district|district.*malaria/i,
+        removeLabel: 'Remove malaria layer',
+        removeMatch: /remove.*malaria/i,
+        steps: [
+            {
+                id: 'demo-1',
+                name: 'search_data_items',
+                args: { query: 'malaria' },
+            },
+            {
+                id: 'demo-2',
+                name: 'resolve_org_units',
+                args: { description: 'by district' },
+            },
+            {
+                id: 'demo-3',
+                name: 'resolve_periods',
+                args: { description: 'last 12 months' },
+            },
+            {
+                id: 'demo-4',
+                name: 'add_thematic_layer',
+                args: {
+                    dataItem: '__RESOLVED_DATA_ITEM__',
+                    orgUnits: '__RESOLVED_ORG_UNITS__',
+                    periods: '__RESOLVED_PERIODS__',
+                    thematicMapType: 'CHOROPLETH',
+                },
+            },
+        ],
+        removeSteps: [
+            {
+                id: 'remove-1',
+                name: 'remove_layer',
+                args: { namePattern: 'Malaria', confirmed: true },
+            },
+        ],
+    },
+    {
+        label: 'Health facilities in my organisation units',
+        match: /facilit|health\s+post/i,
+        removeLabel: 'Remove facilities layer',
+        removeMatch: /remove.*facilit/i,
+        steps: [
+            {
+                id: 'demo-1',
+                name: 'resolve_org_units',
+                args: { description: 'facility level' },
+            },
+            {
+                id: 'demo-2',
+                name: 'add_facility_layer',
+                args: { orgUnits: '__RESOLVED_ORG_UNITS__' },
+            },
+        ],
+        removeSteps: [
+            {
+                id: 'remove-1',
+                name: 'remove_layer',
+                args: { namePattern: 'Facilities', confirmed: true },
+            },
+        ],
+    },
+    {
+        label: 'Show district boundaries',
+        match: /boundar|district.*bound|admin.*bound/i,
+        removeLabel: 'Remove district boundaries layer',
+        removeMatch: /remove.*boundar|remove.*district/i,
+        steps: [
+            {
+                id: 'demo-1',
+                name: 'resolve_org_units',
+                args: { description: 'district level' },
+            },
+            {
+                id: 'demo-2',
+                name: 'add_org_unit_layer',
+                args: { orgUnits: '__RESOLVED_ORG_UNITS__' },
+            },
+        ],
+        removeSteps: [
+            {
+                id: 'remove-1',
+                name: 'remove_layer',
+                args: { namePattern: 'Organisation units', confirmed: true },
+            },
+        ],
+    },
+    {
+        label: 'ANC 1 coverage as bubble map by district last year',
+        match: /anc.*bubble|anc.*district.*bubble|bubble.*anc/i,
+        removeLabel: 'Remove ANC bubble layer',
+        removeMatch: /remove.*anc/i,
+        steps: [
+            {
+                id: 'demo-1',
+                name: 'search_data_items',
+                args: { query: 'ANC 1 coverage' },
+            },
+            {
+                id: 'demo-2',
+                name: 'resolve_org_units',
+                args: { description: 'district level' },
+            },
+            {
+                id: 'demo-3',
+                name: 'resolve_periods',
+                args: { description: 'last year' },
+            },
+            {
+                id: 'demo-4',
+                name: 'add_thematic_layer',
+                args: {
+                    dataItem: '__RESOLVED_DATA_ITEM__',
+                    orgUnits: '__RESOLVED_ORG_UNITS__',
+                    periods: '__RESOLVED_PERIODS__',
+                    thematicMapType: 'BUBBLE',
+                },
+            },
+        ],
+        removeSteps: [
+            {
+                id: 'remove-1',
+                name: 'remove_layer',
+                args: { namePattern: 'ANC', confirmed: true },
+            },
+        ],
+    },
+]
+
+export const DEMO_FALLBACK_MESSAGE =
+    'In demo mode, try one of the example prompts below. Connect an AI provider to use free-form input.'

--- a/src/ai/connectors/openaiCompatible.js
+++ b/src/ai/connectors/openaiCompatible.js
@@ -1,0 +1,94 @@
+/** @param {import('./types.js').Tool} tool */
+const toOpenAITool = (tool) => ({
+    type: 'function',
+    function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.input_schema,
+    },
+})
+
+/**
+ * @param {Object} opts
+ * @param {string} opts.baseURL - e.g. 'http://localhost:11434/v1' for Ollama
+ * @param {string} [opts.apiKey]
+ * @param {string} opts.model
+ * @param {boolean} [opts.isLocal]
+ * @returns {import('./types.js').LLMConnector}
+ */
+export const makeOpenAICompatible = ({
+    id,
+    label,
+    baseURL,
+    apiKey,
+    model,
+    isLocal = false,
+}) => ({
+    id,
+    label,
+    capabilities: {
+        supportsTools: true,
+        supportsStreaming: true,
+        isLocal,
+        maxContextTokens: 8192,
+    },
+
+    async chat({ messages, tools, responseSchema, signal }) {
+        const body = {
+            model,
+            messages: messages.map(toOpenAIMessage),
+            ...(tools?.length && { tools: tools.map(toOpenAITool) }),
+            ...(responseSchema && {
+                response_format: {
+                    type: 'json_schema',
+                    json_schema: { name: 'response', schema: responseSchema },
+                },
+            }),
+        }
+
+        const resp = await fetch(`${baseURL}/chat/completions`, {
+            method: 'POST',
+            signal,
+            headers: {
+                'Content-Type': 'application/json',
+                ...(apiKey && { Authorization: `Bearer ${apiKey}` }),
+            },
+            body: JSON.stringify(body),
+        })
+
+        if (!resp.ok) {
+            const err = await resp.text().catch(() => resp.statusText)
+            throw new Error(
+                `OpenAI-compatible API error ${resp.status}: ${err}`
+            )
+        }
+
+        const data = await resp.json()
+        const message = data.choices?.[0]?.message ?? {}
+
+        return {
+            text: message.content ?? '',
+            toolCalls: (message.tool_calls ?? []).map((tc) => ({
+                id: tc.id,
+                name: tc.function.name,
+                args: JSON.parse(tc.function.arguments),
+            })),
+        }
+    },
+})
+
+/** Normalise our message format to OpenAI's */
+const toOpenAIMessage = (msg) => {
+    if (typeof msg.content === 'string') {
+        return { role: msg.role, content: msg.content }
+    }
+    // tool results
+    if (Array.isArray(msg.content)) {
+        return {
+            role: 'tool',
+            tool_call_id: msg.content[0]?.tool_use_id,
+            content: msg.content[0]?.content ?? '',
+        }
+    }
+    return msg
+}

--- a/src/ai/connectors/registry.js
+++ b/src/ai/connectors/registry.js
@@ -1,0 +1,66 @@
+import { makeAnthropic } from './anthropic.js'
+import { makeDemoConnector } from './demo.js'
+import { makeOpenAICompatible } from './openaiCompatible.js'
+
+/**
+ * Provider configurations are stored in the app's datastore under the key
+ * 'aiProviders'. Shape: Array<ProviderConfig>
+ *
+ * @typedef {Object} ProviderConfig
+ * @property {string} id
+ * @property {string} label
+ * @property {'openaiCompatible'|'anthropic'} type
+ * @property {string} baseURL
+ * @property {string} model
+ * @property {boolean} [isLocal]
+ * @property {boolean} [enabled]
+ */
+
+const demoConnector = makeDemoConnector()
+
+/**
+ * Build an LLMConnector from a ProviderConfig.
+ * @param {ProviderConfig} config
+ * @returns {import('./types.js').LLMConnector}
+ */
+export const buildConnector = (config) => {
+    switch (config.type) {
+        case 'openaiCompatible':
+            return makeOpenAICompatible(config)
+        case 'anthropic':
+            return makeAnthropic(config)
+        default:
+            throw new Error(`Unknown provider type: ${config.type}`)
+    }
+}
+
+/**
+ * Build the ordered list of available connectors from provider configs,
+ * always appending the demo connector at the end.
+ * @param {ProviderConfig[]} configs
+ * @returns {import('./types.js').LLMConnector[]}
+ */
+export const buildRegistry = (configs = []) => {
+    const connectors = configs
+        .filter((c) => c.enabled !== false)
+        .map(buildConnector)
+    return [...connectors, demoConnector]
+}
+
+/**
+ * Select the active connector — first enabled real provider, or demo as fallback.
+ * @param {import('./types.js').LLMConnector[]} registry
+ * @param {string|null} [preferredId]
+ * @returns {import('./types.js').LLMConnector}
+ */
+export const selectConnector = (registry, preferredId = null) => {
+    if (preferredId) {
+        const preferred = registry.find((c) => c.id === preferredId)
+        if (preferred) {
+            return preferred
+        }
+    }
+    return registry[0] ?? demoConnector
+}
+
+export { demoConnector }

--- a/src/ai/connectors/types.js
+++ b/src/ai/connectors/types.js
@@ -1,0 +1,57 @@
+/**
+ * @typedef {Object} Message
+ * @property {'user'|'assistant'} role
+ * @property {string|ToolResultContent[]} content
+ */
+
+/**
+ * @typedef {Object} ToolResultContent
+ * @property {'tool_result'} type
+ * @property {string} tool_use_id
+ * @property {string} content
+ */
+
+/**
+ * @typedef {Object} Tool
+ * @property {string} name
+ * @property {string} description
+ * @property {Object} input_schema - JSON Schema for the tool's arguments
+ */
+
+/**
+ * @typedef {Object} ToolCall
+ * @property {string} id
+ * @property {string} name
+ * @property {Object} args
+ */
+
+/**
+ * @typedef {Object} ChatRequest
+ * @property {Message[]} messages
+ * @property {Tool[]} [tools]
+ * @property {'auto'|'any'|'none'} [toolChoice]
+ * @property {Object} [responseSchema] - JSON Schema for constrained decoding
+ * @property {AbortSignal} [signal]
+ */
+
+/**
+ * @typedef {Object} ChatResult
+ * @property {string} text
+ * @property {ToolCall[]} toolCalls
+ */
+
+/**
+ * @typedef {Object} Capabilities
+ * @property {boolean} supportsTools
+ * @property {boolean} supportsStreaming
+ * @property {boolean} isLocal
+ * @property {number} maxContextTokens
+ */
+
+/**
+ * @typedef {Object} LLMConnector
+ * @property {(req: ChatRequest) => Promise<ChatResult>} chat
+ * @property {Capabilities} capabilities
+ * @property {string} id
+ * @property {string} label
+ */

--- a/src/ai/egress/guard.js
+++ b/src/ai/egress/guard.js
@@ -1,0 +1,99 @@
+/**
+ * Egress guard — asserts that no analytics values or geometry leave the browser.
+ *
+ * In dev mode, throws if a suspicious payload is detected.
+ * In production, logs a warning only (fail-open to avoid blocking the app).
+ *
+ * "Analytics values" = numeric data from /api/analytics, /api/events, etc.
+ * "Geometry" = GeoJSON coordinates
+ *
+ * For the PoC (Tier 1, metadata-only), the only content allowed to leave is:
+ *   - User's input text
+ *   - Metadata labels (displayName, name strings from search results)
+ *   - org unit ids, data item ids, period ids
+ */
+
+const isDev = process.env.NODE_ENV === 'development'
+
+/** Fields that would indicate analytics values are in the payload */
+const ANALYTICS_VALUE_KEYS = [
+    'value',
+    'numerator',
+    'denominator',
+    'factor',
+    'multiplier',
+]
+
+/** Simple check: does the object tree contain analytics value fields? */
+const containsAnalyticsValues = (obj, depth = 0) => {
+    if (depth > 5 || obj == null || typeof obj !== 'object') {
+        return false
+    }
+    for (const key of Object.keys(obj)) {
+        if (
+            ANALYTICS_VALUE_KEYS.includes(key) &&
+            typeof obj[key] === 'number'
+        ) {
+            return true
+        }
+        if (containsAnalyticsValues(obj[key], depth + 1)) {
+            return true
+        }
+    }
+    return false
+}
+
+/** Check for GeoJSON geometry */
+const containsGeometry = (obj, depth = 0) => {
+    if (depth > 5 || obj == null || typeof obj !== 'object') {
+        return false
+    }
+    if (
+        obj.type === 'FeatureCollection' ||
+        obj.type === 'Feature' ||
+        obj.coordinates
+    ) {
+        return true
+    }
+    for (const val of Object.values(obj)) {
+        if (containsGeometry(val, depth + 1)) {
+            return true
+        }
+    }
+    return false
+}
+
+/**
+ * Assert that the outbound payload contains no analytics values or geometry.
+ * @param {Object} payload - The object about to be sent to the LLM
+ * @param {string} [context] - Description for error messages
+ */
+export const assertMetadataOnly = (payload, context = 'outbound payload') => {
+    if (containsAnalyticsValues(payload)) {
+        const msg = `[AI Egress Guard] Analytics values detected in ${context}. This violates the metadata-only egress policy.`
+        if (isDev) {
+            throw new Error(msg)
+        } else {
+            console.warn(msg)
+        }
+    }
+
+    if (containsGeometry(payload)) {
+        const msg = `[AI Egress Guard] GeoJSON geometry detected in ${context}. This violates the metadata-only egress policy.`
+        if (isDev) {
+            throw new Error(msg)
+        } else {
+            console.warn(msg)
+        }
+    }
+}
+
+/**
+ * Wrap a message array before sending to the LLM, asserting no sensitive data.
+ * @param {Array} messages
+ * @returns {Array} the same messages (pass-through after check)
+ */
+export const guardMessages = (messages) => {
+    assertMetadataOnly(messages, 'messages array')
+    return messages
+}

--- a/src/ai/tools/addFacilityLayer.js
+++ b/src/ai/tools/addFacilityLayer.js
@@ -1,0 +1,34 @@
+import { addLayer } from '../../actions/layers.js'
+
+/**
+ * @param {Function} dispatch - Redux dispatch
+ * @returns {(args: Object) => Promise<Object>}
+ */
+export const makeAddFacilityLayer =
+    (dispatch) =>
+    async ({ orgUnits, organisationUnitGroupSetId }) => {
+        const config = {
+            layer: 'facility',
+            name: 'Facilities',
+            isLoaded: false,
+            isLoading: false,
+            editCounter: 0,
+            backupPeriodsDates: undefined,
+            rows: [
+                {
+                    dimension: 'ou',
+                    items: orgUnits.map((ou) => ({ id: ou })),
+                },
+            ],
+            ...(organisationUnitGroupSetId && {
+                organisationUnitGroupSet: { id: organisationUnitGroupSetId },
+            }),
+        }
+
+        dispatch(addLayer(config))
+
+        return {
+            success: true,
+            message: `Added facility layer.`,
+        }
+    }

--- a/src/ai/tools/addFacilityLayer.js
+++ b/src/ai/tools/addFacilityLayer.js
@@ -4,9 +4,21 @@ import { addLayer } from '../../actions/layers.js'
  * @param {Function} dispatch - Redux dispatch
  * @returns {(args: Object) => Promise<Object>}
  */
+const isValidOrgUnit = (ou) =>
+    /^LEVEL-\d+$/.test(ou) ||
+    /^USER_ORGUNIT(_CHILDREN|_GRANDCHILDREN)?$/.test(ou) ||
+    /^[A-Za-z0-9]{11}$/.test(ou)
+
 export const makeAddFacilityLayer =
-    (dispatch) =>
+    (dispatch, getState) =>
     async ({ orgUnits, organisationUnitGroupSetId }) => {
+        const badOrgUnit = orgUnits?.find((ou) => !isValidOrgUnit(ou))
+        if (badOrgUnit) {
+            return {
+                success: false,
+                message: `Invalid org unit "${badOrgUnit}". Call resolve_org_units first and use the items from its results.`,
+            }
+        }
         const config = {
             layer: 'facility',
             name: 'Facilities',
@@ -25,10 +37,17 @@ export const makeAddFacilityLayer =
             }),
         }
 
+        const before = getState().map?.mapViews?.map((l) => l.id) ?? []
         dispatch(addLayer(config))
+        const newLayer = getState().map?.mapViews?.find(
+            (l) => !before.includes(l.id)
+        )
 
         return {
             success: true,
-            message: `Added facility layer.`,
+            layerId: newLayer?.id ?? null,
+            message: `Added facility layer. Layer id: ${
+                newLayer?.id ?? 'unknown'
+            }.`,
         }
     }

--- a/src/ai/tools/addOrgUnitLayer.js
+++ b/src/ai/tools/addOrgUnitLayer.js
@@ -4,9 +4,21 @@ import { addLayer } from '../../actions/layers.js'
  * @param {Function} dispatch - Redux dispatch
  * @returns {(args: Object) => Promise<Object>}
  */
+const isValidOrgUnit = (ou) =>
+    /^LEVEL-\d+$/.test(ou) ||
+    /^USER_ORGUNIT(_CHILDREN|_GRANDCHILDREN)?$/.test(ou) ||
+    /^[A-Za-z0-9]{11}$/.test(ou)
+
 export const makeAddOrgUnitLayer =
-    (dispatch) =>
+    (dispatch, getState) =>
     async ({ orgUnits, organisationUnitGroupSetId }) => {
+        const badOrgUnit = orgUnits?.find((ou) => !isValidOrgUnit(ou))
+        if (badOrgUnit) {
+            return {
+                success: false,
+                message: `Invalid org unit "${badOrgUnit}". Call resolve_org_units first and use the items from its results.`,
+            }
+        }
         const config = {
             layer: 'orgUnit',
             name: 'Organisation units',
@@ -25,10 +37,17 @@ export const makeAddOrgUnitLayer =
             }),
         }
 
+        const before = getState().map?.mapViews?.map((l) => l.id) ?? []
         dispatch(addLayer(config))
+        const newLayer = getState().map?.mapViews?.find(
+            (l) => !before.includes(l.id)
+        )
 
         return {
             success: true,
-            message: `Added org unit / boundaries layer.`,
+            layerId: newLayer?.id ?? null,
+            message: `Added org unit / boundaries layer. Layer id: ${
+                newLayer?.id ?? 'unknown'
+            }.`,
         }
     }

--- a/src/ai/tools/addOrgUnitLayer.js
+++ b/src/ai/tools/addOrgUnitLayer.js
@@ -1,0 +1,34 @@
+import { addLayer } from '../../actions/layers.js'
+
+/**
+ * @param {Function} dispatch - Redux dispatch
+ * @returns {(args: Object) => Promise<Object>}
+ */
+export const makeAddOrgUnitLayer =
+    (dispatch) =>
+    async ({ orgUnits, organisationUnitGroupSetId }) => {
+        const config = {
+            layer: 'orgUnit',
+            name: 'Organisation units',
+            isLoaded: false,
+            isLoading: false,
+            editCounter: 0,
+            backupPeriodsDates: undefined,
+            rows: [
+                {
+                    dimension: 'ou',
+                    items: orgUnits.map((ou) => ({ id: ou })),
+                },
+            ],
+            ...(organisationUnitGroupSetId && {
+                organisationUnitGroupSet: { id: organisationUnitGroupSetId },
+            }),
+        }
+
+        dispatch(addLayer(config))
+
+        return {
+            success: true,
+            message: `Added org unit / boundaries layer.`,
+        }
+    }

--- a/src/ai/tools/addThematicLayer.js
+++ b/src/ai/tools/addThematicLayer.js
@@ -7,8 +7,15 @@ import { addLayer } from '../../actions/layers.js'
  * @param {Function} dispatch - Redux dispatch
  * @returns {(args: Object) => Promise<Object>}
  */
+const isValidOrgUnit = (ou) =>
+    /^LEVEL-\d+$/.test(ou) ||
+    /^USER_ORGUNIT(_CHILDREN|_GRANDCHILDREN)?$/.test(ou) ||
+    /^[A-Za-z0-9]{11}$/.test(ou)
+
+const isValidDhis2Uid = (id) => /^[A-Za-z0-9]{11}$/.test(id)
+
 export const makeAddThematicLayer =
-    (dispatch) =>
+    (dispatch, getState) =>
     async ({
         dataItem,
         orgUnits,
@@ -17,16 +24,59 @@ export const makeAddThematicLayer =
         method = 2,
         classes = 5,
     }) => {
-        if (!Array.isArray(orgUnits) || !Array.isArray(periods)) {
+        if (
+            !Array.isArray(orgUnits) ||
+            orgUnits.length === 0 ||
+            !Array.isArray(periods) ||
+            periods.length === 0
+        ) {
             return {
                 success: false,
                 message:
-                    'orgUnits and periods must be resolved arrays before calling add_thematic_layer.',
+                    'You must call resolve_org_units AND resolve_periods first and pass their results. Do not call add_thematic_layer with empty arrays.',
             }
         }
+
+        // Reject hallucinated IDs — the model must call search_data_items and resolve_org_units first
+        if (!dataItem?.id || !isValidDhis2Uid(dataItem.id)) {
+            return {
+                success: false,
+                message: `Invalid data item id "${dataItem?.id}". You must call search_data_items first and use the id from its results. DHIS2 ids are exactly 11 alphanumeric characters.`,
+            }
+        }
+        const badOrgUnit = orgUnits.find((ou) => !isValidOrgUnit(ou))
+        if (badOrgUnit) {
+            return {
+                success: false,
+                message: `Invalid org unit "${badOrgUnit}". You must call resolve_org_units first and use the items from its results. Valid values are LEVEL-N, USER_ORGUNIT, USER_ORGUNIT_CHILDREN, USER_ORGUNIT_GRANDCHILDREN, or an 11-character DHIS2 id.`,
+            }
+        }
+        // Normalize period ids to correct DHIS2 format and fix common hallucinations
+        const normalizePeriodId = (p) => {
+            // Strip "P_" prefix some models add (e.g. "P_2023Q1" → "2023Q1")
+            let n = p.replace(/^P_/i, '')
+            // "2023-Q1" or "2023_Q1" → "2023Q1"
+            n = n.replace(/^(\d{4})[-_]Q([1-4])$/i, '$1Q$2')
+            // "Q1-2023" or "Q1_2023" or "Q1 2023" → "2023Q1"
+            n = n.replace(/^Q([1-4])[-_ ](\d{4})$/i, '$2Q$1')
+            // "2023-01" or "2023_01" → "202301" (month)
+            n = n.replace(/^(\d{4})[-_](\d{2})$/, '$1$2')
+            // Fix common LLM period hallucinations (PREVIOUS_* / CURRENT_* are not valid DHIS2 ids)
+            n = n.replace(/^PREVIOUS_YEAR$/i, 'LAST_YEAR')
+            n = n.replace(/^CURRENT_YEAR$/i, 'THIS_YEAR')
+            n = n.replace(/^PREVIOUS_QUARTER$/i, 'LAST_QUARTER')
+            n = n.replace(/^CURRENT_QUARTER$/i, 'THIS_QUARTER')
+            n = n.replace(/^PREVIOUS_MONTH$/i, 'LAST_MONTH')
+            n = n.replace(/^CURRENT_MONTH$/i, 'THIS_MONTH')
+            return n
+        }
+        const normalizedPeriods = periods.map(normalizePeriodId)
+
+        const dataItemName =
+            dataItem.displayName ?? dataItem.name ?? dataItem.id
         const config = {
             layer: 'thematic',
-            name: dataItem.name ?? dataItem.id,
+            name: dataItemName,
             thematicMapType,
             method,
             classes,
@@ -40,7 +90,7 @@ export const makeAddThematicLayer =
                     items: [
                         {
                             id: dataItem.id,
-                            name: dataItem.name ?? dataItem.id,
+                            name: dataItemName,
                             dimensionItemType: dataItem.dimensionItemType,
                         },
                     ],
@@ -55,17 +105,21 @@ export const makeAddThematicLayer =
             filters: [
                 {
                     dimension: 'pe',
-                    items: periods.map((pe) => ({ id: pe })),
+                    items: normalizedPeriods.map((pe) => ({ id: pe })),
                 },
             ],
         }
 
+        const before = getState().map?.mapViews?.map((l) => l.id) ?? []
         dispatch(addLayer(config))
+        const after = getState().map?.mapViews ?? []
+        const newLayer = after.find((l) => !before.includes(l.id))
 
         return {
             success: true,
-            message: `Added ${thematicMapType.toLowerCase()} layer for ${
-                dataItem.name ?? dataItem.id
+            layerId: newLayer?.id ?? null,
+            message: `Added ${thematicMapType.toLowerCase()} layer for ${dataItemName}. Layer id: ${
+                newLayer?.id ?? 'unknown'
             }.`,
         }
     }

--- a/src/ai/tools/addThematicLayer.js
+++ b/src/ai/tools/addThematicLayer.js
@@ -1,0 +1,71 @@
+import { addLayer } from '../../actions/layers.js'
+
+/**
+ * Build and dispatch a thematic (choropleth/bubble) layer config.
+ * Mirrors exactly what LayerEdit.jsx does on submit.
+ *
+ * @param {Function} dispatch - Redux dispatch
+ * @returns {(args: Object) => Promise<Object>}
+ */
+export const makeAddThematicLayer =
+    (dispatch) =>
+    async ({
+        dataItem,
+        orgUnits,
+        periods,
+        thematicMapType = 'CHOROPLETH',
+        method = 2,
+        classes = 5,
+    }) => {
+        if (!Array.isArray(orgUnits) || !Array.isArray(periods)) {
+            return {
+                success: false,
+                message:
+                    'orgUnits and periods must be resolved arrays before calling add_thematic_layer.',
+            }
+        }
+        const config = {
+            layer: 'thematic',
+            name: dataItem.name ?? dataItem.id,
+            thematicMapType,
+            method,
+            classes,
+            isLoaded: false,
+            isLoading: false,
+            editCounter: 0,
+            backupPeriodsDates: undefined,
+            columns: [
+                {
+                    dimension: 'dx',
+                    items: [
+                        {
+                            id: dataItem.id,
+                            name: dataItem.name ?? dataItem.id,
+                            dimensionItemType: dataItem.dimensionItemType,
+                        },
+                    ],
+                },
+            ],
+            rows: [
+                {
+                    dimension: 'ou',
+                    items: orgUnits.map((ou) => ({ id: ou })),
+                },
+            ],
+            filters: [
+                {
+                    dimension: 'pe',
+                    items: periods.map((pe) => ({ id: pe })),
+                },
+            ],
+        }
+
+        dispatch(addLayer(config))
+
+        return {
+            success: true,
+            message: `Added ${thematicMapType.toLowerCase()} layer for ${
+                dataItem.name ?? dataItem.id
+            }.`,
+        }
+    }

--- a/src/ai/tools/executor.js
+++ b/src/ai/tools/executor.js
@@ -8,6 +8,7 @@ import { makeResolvePeriods } from './resolvePeriods.js'
 import { makeSearchDataItems } from './searchDataItems.js'
 import { makeSearchOrgUnitGroupSets } from './searchOrgUnitGroupSets.js'
 import { makeUpdateLayer } from './updateLayer.js'
+import { makeValidatePeriods } from './validatePeriods.js'
 
 /**
  * Build the tool registry — a map from tool name to async function.
@@ -24,11 +25,12 @@ export const buildToolRegistry = ({ engine, dispatch, getState }) => ({
     search_org_unit_group_sets: makeSearchOrgUnitGroupSets(engine),
     resolve_periods: makeResolvePeriods(),
     list_layers: makeListLayers(getState),
-    add_thematic_layer: makeAddThematicLayer(dispatch),
-    add_facility_layer: makeAddFacilityLayer(dispatch),
-    add_org_unit_layer: makeAddOrgUnitLayer(dispatch),
+    add_thematic_layer: makeAddThematicLayer(dispatch, getState),
+    add_facility_layer: makeAddFacilityLayer(dispatch, getState),
+    add_org_unit_layer: makeAddOrgUnitLayer(dispatch, getState),
     update_layer: makeUpdateLayer(dispatch, getState),
     remove_layer: makeRemoveLayer(dispatch, getState),
+    validate_periods: makeValidatePeriods(),
 })
 
 /**

--- a/src/ai/tools/executor.js
+++ b/src/ai/tools/executor.js
@@ -1,0 +1,69 @@
+import { makeAddFacilityLayer } from './addFacilityLayer.js'
+import { makeAddOrgUnitLayer } from './addOrgUnitLayer.js'
+import { makeAddThematicLayer } from './addThematicLayer.js'
+import { makeListLayers } from './listLayers.js'
+import { makeRemoveLayer } from './removeLayer.js'
+import { makeResolveOrgUnits } from './resolveOrgUnits.js'
+import { makeResolvePeriods } from './resolvePeriods.js'
+import { makeSearchDataItems } from './searchDataItems.js'
+import { makeSearchOrgUnitGroupSets } from './searchOrgUnitGroupSets.js'
+import { makeUpdateLayer } from './updateLayer.js'
+
+/**
+ * Build the tool registry — a map from tool name to async function.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.engine - @dhis2/app-runtime data engine
+ * @param {Function} deps.dispatch - Redux dispatch
+ * @param {Function} deps.getState - Redux getState
+ * @returns {Record<string, (args: Object) => Promise<Object>>}
+ */
+export const buildToolRegistry = ({ engine, dispatch, getState }) => ({
+    search_data_items: makeSearchDataItems(engine),
+    resolve_org_units: makeResolveOrgUnits(engine),
+    search_org_unit_group_sets: makeSearchOrgUnitGroupSets(engine),
+    resolve_periods: makeResolvePeriods(),
+    list_layers: makeListLayers(getState),
+    add_thematic_layer: makeAddThematicLayer(dispatch),
+    add_facility_layer: makeAddFacilityLayer(dispatch),
+    add_org_unit_layer: makeAddOrgUnitLayer(dispatch),
+    update_layer: makeUpdateLayer(dispatch, getState),
+    remove_layer: makeRemoveLayer(dispatch, getState),
+})
+
+/**
+ * Execute a tool call and return a stringified result.
+ * Validates the tool name; passes args through as-is (schema validation is
+ * the LLM connector's responsibility via constrained decoding).
+ *
+ * @param {Record<string, Function>} registry
+ * @param {{ id: string, name: string, args: Object }} toolCall
+ * @returns {Promise<{ tool_use_id: string, content: string }>}
+ */
+export const executeToolCall = async (registry, toolCall) => {
+    const fn = registry[toolCall.name]
+
+    if (!fn) {
+        return {
+            tool_use_id: toolCall.id,
+            content: JSON.stringify({
+                error: `Unknown tool "${
+                    toolCall.name
+                }". Available tools: ${Object.keys(registry).join(', ')}`,
+            }),
+        }
+    }
+
+    try {
+        const result = await fn(toolCall.args)
+        return {
+            tool_use_id: toolCall.id,
+            content: JSON.stringify(result),
+        }
+    } catch (err) {
+        return {
+            tool_use_id: toolCall.id,
+            content: JSON.stringify({ error: err.message }),
+        }
+    }
+}

--- a/src/ai/tools/listLayers.js
+++ b/src/ai/tools/listLayers.js
@@ -1,0 +1,57 @@
+/**
+ * @param {() => Object} getState - Redux getState
+ * @returns {() => Promise<Object>}
+ */
+export const makeListLayers = (getState) => async () => {
+    const { map } = getState()
+    const mapViews = map?.mapViews ?? []
+
+    if (mapViews.length === 0) {
+        return { layers: [], message: 'No layers on the map currently.' }
+    }
+
+    const layers = mapViews.map((layer) => ({
+        id: layer.id,
+        type: layer.layer,
+        summary: buildSummary(layer),
+    }))
+
+    return { layers, count: layers.length }
+}
+
+const buildSummary = (layer) => {
+    const parts = []
+
+    switch (layer.layer) {
+        case 'thematic': {
+            const dx = layer.columns?.[0]?.items?.[0]
+            const pe = layer.filters?.find((f) => f.dimension === 'pe')
+                ?.items?.[0]
+            if (dx?.name) {
+                parts.push(dx.name)
+            }
+            if (layer.thematicMapType) {
+                parts.push(layer.thematicMapType)
+            }
+            if (pe?.id) {
+                parts.push(pe.id)
+            }
+            break
+        }
+        case 'facility': {
+            const gs = layer.organisationUnitGroupSet
+            parts.push('facility layer')
+            if (gs?.displayName) {
+                parts.push(`styled by ${gs.displayName}`)
+            }
+            break
+        }
+        case 'orgUnit':
+            parts.push('org unit / boundaries layer')
+            break
+        default:
+            parts.push(layer.layer ?? 'unknown type')
+    }
+
+    return parts.join(' · ')
+}

--- a/src/ai/tools/removeLayer.js
+++ b/src/ai/tools/removeLayer.js
@@ -2,7 +2,6 @@ import { removeLayer } from '../../actions/layers.js'
 
 /**
  * Remove a layer by ID or by name pattern.
- * The confirm flag must be set to true — the agent must ask the user first.
  *
  * @param {Function} dispatch - Redux dispatch
  * @param {Function} [getState] - Redux getState (required for namePattern lookup)
@@ -10,16 +9,7 @@ import { removeLayer } from '../../actions/layers.js'
  */
 export const makeRemoveLayer =
     (dispatch, getState) =>
-    async ({ layerId, namePattern, confirmed }) => {
-        if (!confirmed) {
-            return {
-                success: false,
-                needsConfirmation: true,
-                message:
-                    'Please confirm with the user before removing the layer. Set confirmed=true once the user agrees.',
-            }
-        }
-
+    async ({ layerId, namePattern }) => {
         let id = layerId
         if (!id && namePattern && getState) {
             const state = getState()

--- a/src/ai/tools/removeLayer.js
+++ b/src/ai/tools/removeLayer.js
@@ -1,0 +1,48 @@
+import { removeLayer } from '../../actions/layers.js'
+
+/**
+ * Remove a layer by ID or by name pattern.
+ * The confirm flag must be set to true — the agent must ask the user first.
+ *
+ * @param {Function} dispatch - Redux dispatch
+ * @param {Function} [getState] - Redux getState (required for namePattern lookup)
+ * @returns {(args: Object) => Promise<Object>}
+ */
+export const makeRemoveLayer =
+    (dispatch, getState) =>
+    async ({ layerId, namePattern, confirmed }) => {
+        if (!confirmed) {
+            return {
+                success: false,
+                needsConfirmation: true,
+                message:
+                    'Please confirm with the user before removing the layer. Set confirmed=true once the user agrees.',
+            }
+        }
+
+        let id = layerId
+        if (!id && namePattern && getState) {
+            const state = getState()
+            const mapViews = state.map?.mapViews ?? []
+            const layer = mapViews.find((l) =>
+                l.name?.toLowerCase().includes(namePattern.toLowerCase())
+            )
+            if (!layer) {
+                return {
+                    success: false,
+                    message: `No layer found matching "${namePattern}".`,
+                }
+            }
+            id = layer.id
+        }
+
+        if (!id) {
+            return {
+                success: false,
+                message: 'Provide layerId or namePattern.',
+            }
+        }
+
+        dispatch(removeLayer(id))
+        return { success: true, message: `Layer removed.` }
+    }

--- a/src/ai/tools/resolveOrgUnits.js
+++ b/src/ai/tools/resolveOrgUnits.js
@@ -1,0 +1,195 @@
+/**
+ * Resolve a natural-language org unit description to DHIS2 org unit items.
+ *
+ * Handles:
+ *   - User tokens: "my org unit", "my facilities", "my children"
+ *   - Level references: "by district", "all chiefdoms", "regional level"
+ *     → looks up the instance's level list, never hard-codes numbers
+ *   - Parent + level: "districts in Northern region"
+ *   - Named unit: "Northern region" → resolve id
+ *   - Fallback: ask one clarifying question
+ */
+
+const USER_TOKEN_PATTERNS = [
+    { pattern: /\bmy\s+facilit/i, token: 'USER_ORGUNIT_CHILDREN' },
+    { pattern: /\bmy\s+unit/i, token: 'USER_ORGUNIT' },
+    { pattern: /\bmy\s+children/i, token: 'USER_ORGUNIT_CHILDREN' },
+    { pattern: /\bmy\s+grandchildren/i, token: 'USER_ORGUNIT_GRANDCHILDREN' },
+    { pattern: /\bmy\b/i, token: 'USER_ORGUNIT' },
+]
+
+const LEVEL_KEYWORDS = [
+    'national',
+    'region',
+    'regional',
+    'province',
+    'provincial',
+    'district',
+    'chiefdom',
+    'facility',
+    'facilities',
+    'sub-district',
+    'subdistrict',
+    'county',
+    'ward',
+    'village',
+    'community',
+]
+
+/**
+ * @param {Object} engine - @dhis2/app-runtime data engine
+ * @returns {(args: {description: string, parentId?: string}) => Promise<Object>}
+ */
+export const makeResolveOrgUnits =
+    (engine) =>
+    async ({ description, parentId }) => {
+        // 1. Check for user tokens
+        for (const { pattern, token } of USER_TOKEN_PATTERNS) {
+            if (pattern.test(description)) {
+                const items = [token]
+                if (parentId) {
+                    items.unshift(parentId)
+                }
+                return { resolved: true, items, description }
+            }
+        }
+
+        // 2. Fetch the instance's org unit levels for name→level mapping
+        const { levels } = await engine.query({
+            levels: {
+                resource: 'organisationUnitLevels',
+                params: { fields: 'id,level,displayName', order: 'level:asc' },
+            },
+        })
+
+        const levelList = levels?.organisationUnitLevels ?? []
+
+        // 3. Try to match a level keyword
+        const matchedLevel = levelList.find((lvl) =>
+            description.toLowerCase().includes(lvl.displayName.toLowerCase())
+        )
+
+        if (!matchedLevel) {
+            // fallback: check generic keywords
+            const genericMatch = LEVEL_KEYWORDS.find((kw) =>
+                description.toLowerCase().includes(kw)
+            )
+            if (!genericMatch) {
+                // 4. Try resolving as a named org unit
+                return resolveNamedOrgUnit(engine, description, parentId)
+            }
+            // generic keyword but no level match → return candidates
+            return {
+                resolved: false,
+                needsClarification: true,
+                message: `I found the keyword "${genericMatch}" but couldn't match it to an administrative level in this DHIS2 instance. Available levels: ${levelList
+                    .map((l) => l.displayName)
+                    .join(', ')}. Which level did you mean?`,
+                levelCandidates: levelList.map((l) => ({
+                    id: l.id,
+                    level: l.level,
+                    displayName: l.displayName,
+                    token: `LEVEL-${l.level}`,
+                })),
+            }
+        }
+
+        const items = [`LEVEL-${matchedLevel.level}`]
+        if (parentId) {
+            items.push(parentId)
+        } else {
+            // Check if user mentioned a parent unit name like "districts in Northern region"
+            const parentResult = await tryExtractParent(
+                engine,
+                description,
+                levelList
+            )
+            if (parentResult) {
+                items.push(parentResult)
+            }
+        }
+
+        return {
+            resolved: true,
+            items,
+            description,
+            levelName: matchedLevel.displayName,
+        }
+    }
+
+const resolveNamedOrgUnit = async (engine, description, parentId) => {
+    const { orgUnits } = await engine.query({
+        orgUnits: {
+            resource: 'organisationUnits',
+            params: {
+                query: description,
+                fields: 'id,displayName,level,path',
+                pageSize: 5,
+            },
+        },
+    })
+
+    const units = orgUnits?.organisationUnits ?? []
+
+    if (units.length === 0) {
+        return {
+            resolved: false,
+            needsClarification: true,
+            message: `No org unit found matching "${description}". Please check the name or try a different description.`,
+            candidates: [],
+        }
+    }
+
+    if (units.length === 1) {
+        const items = [units[0].id]
+        if (parentId) {
+            items.push(parentId)
+        }
+        return {
+            resolved: true,
+            items,
+            description,
+            resolvedName: units[0].displayName,
+        }
+    }
+
+    return {
+        resolved: false,
+        needsClarification: true,
+        message: `Multiple org units match "${description}". Which one did you mean?`,
+        candidates: units.map(({ id, displayName, level }) => ({
+            id,
+            displayName,
+            level,
+        })),
+    }
+}
+
+/** Try to extract a parent org unit from a phrase like "districts in Northern region" */
+const tryExtractParent = async (engine, description, levelList) => {
+    const inMatch = description.match(/\bin\s+(.+)$/i)
+    if (!inMatch) {
+        return null
+    }
+
+    const parentPhrase = inMatch[1].trim()
+    const isLevelName = levelList.some((l) =>
+        parentPhrase.toLowerCase().includes(l.displayName.toLowerCase())
+    )
+    if (isLevelName) {
+        return null
+    }
+
+    const { orgUnits } = await engine.query({
+        orgUnits: {
+            resource: 'organisationUnits',
+            params: {
+                query: parentPhrase,
+                fields: 'id,displayName',
+                pageSize: 1,
+            },
+        },
+    })
+
+    return orgUnits?.organisationUnits?.[0]?.id ?? null
+}

--- a/src/ai/tools/resolveOrgUnits.js
+++ b/src/ai/tools/resolveOrgUnits.js
@@ -94,6 +94,29 @@ export const makeResolveOrgUnits =
             }
         }
 
+        // Check if description has a named qualifier alongside the level keyword.
+        // e.g. "Bo district" → strip "district" and stop words → "Bo" → resolve as specific OU at that level.
+        // This avoids returning LEVEL-N for queries like "facilities for Bo district".
+        const levelKeyword = matchedLevel.displayName
+        const namedPart = description
+            .replace(new RegExp(`\\b${levelKeyword}s?\\b`, 'gi'), '')
+            .replace(
+                /\b(for|in|of|by|the|all|a|an|health|facilit\w*|boundar\w*|show|add|display)\b/gi,
+                ''
+            )
+            .trim()
+
+        if (namedPart && namedPart.split(/\s+/).length <= 3) {
+            const namedResult = await resolveNamedOrgUnitAtLevel(engine, {
+                description: namedPart,
+                level: matchedLevel.level,
+                parentId,
+            })
+            if (namedResult.resolved) {
+                return namedResult
+            }
+        }
+
         const items = [`LEVEL-${matchedLevel.level}`]
         if (parentId) {
             items.push(parentId)
@@ -140,6 +163,23 @@ const resolveNamedOrgUnit = async (engine, description, parentId) => {
         }
     }
 
+    // Exact display name match wins regardless of how many results the query returned
+    const exact = units.find(
+        (u) => u.displayName.toLowerCase() === description.toLowerCase()
+    )
+    if (exact) {
+        const items = [exact.id]
+        if (parentId) {
+            items.push(parentId)
+        }
+        return {
+            resolved: true,
+            items,
+            description,
+            resolvedName: exact.displayName,
+        }
+    }
+
     if (units.length === 1) {
         const items = [units[0].id]
         if (parentId) {
@@ -162,6 +202,44 @@ const resolveNamedOrgUnit = async (engine, description, parentId) => {
             displayName,
             level,
         })),
+    }
+}
+
+/** Resolve a named OU filtered to a specific level — avoids ambiguity when "Bo district" matches chiefdoms too. */
+const resolveNamedOrgUnitAtLevel = async (
+    engine,
+    { description, level, parentId }
+) => {
+    const { orgUnits } = await engine.query({
+        orgUnits: {
+            resource: 'organisationUnits',
+            params: {
+                query: description,
+                fields: 'id,displayName,level',
+                filter: `level:eq:${level}`,
+                pageSize: 5,
+            },
+        },
+    })
+
+    const units = orgUnits?.organisationUnits ?? []
+    if (units.length === 0) {
+        return { resolved: false }
+    }
+
+    const exact = units.find(
+        (u) => u.displayName.toLowerCase() === description.toLowerCase()
+    )
+    const best = exact ?? units[0]
+    const items = [best.id]
+    if (parentId) {
+        items.push(parentId)
+    }
+    return {
+        resolved: true,
+        items,
+        description,
+        resolvedName: best.displayName,
     }
 }
 

--- a/src/ai/tools/resolvePeriods.js
+++ b/src/ai/tools/resolvePeriods.js
@@ -36,6 +36,43 @@ const PERIOD_MAP = [
 // Match a bare 4-digit year like "2024" or "in 2023"
 const FIXED_YEAR_PATTERN = /\b(20\d{2})\b/
 
+// Match quarter references: "Q1 2023", "2023 Q1", "Q2 of 2024", "2023-Q3", "2023Q4"
+const QUARTER_PATTERN =
+    /\b(?:Q([1-4])\s*(?:of\s*)?(\d{4})|(\d{4})[\s-]?Q([1-4]))\b/i
+
+// Match specific month: "January 2023", "Jan 2024", "2023-01", etc.
+const MONTH_NAMES = [
+    'january',
+    'february',
+    'march',
+    'april',
+    'may',
+    'june',
+    'july',
+    'august',
+    'september',
+    'october',
+    'november',
+    'december',
+]
+const MONTH_ABBR = [
+    'jan',
+    'feb',
+    'mar',
+    'apr',
+    'may',
+    'jun',
+    'jul',
+    'aug',
+    'sep',
+    'oct',
+    'nov',
+    'dec',
+]
+const MONTH_NAME_PATTERN =
+    /\b(january|february|march|april|may|june|july|august|september|october|november|december|jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\s+(\d{4})\b/i
+const NUMERIC_MONTH_PATTERN = /\b(\d{4})[-/](\d{2})\b/
+
 /**
  * @returns {(args: {description: string}) => Promise<Object>}
  */
@@ -49,6 +86,47 @@ export const makeResolvePeriods =
             }
         }
 
+        // Try quarter: "Q1 2023" or "2023Q1" or "2023-Q1"
+        const qMatch = description.match(QUARTER_PATTERN)
+        if (qMatch) {
+            const quarter = qMatch[1] ?? qMatch[4]
+            const year = qMatch[2] ?? qMatch[3]
+            return {
+                resolved: true,
+                periods: [`${year}Q${quarter}`],
+                description,
+            }
+        }
+
+        // Try named month: "January 2023"
+        const monthNameMatch = description.match(MONTH_NAME_PATTERN)
+        if (monthNameMatch) {
+            const monthStr = monthNameMatch[1].toLowerCase()
+            const year = monthNameMatch[2]
+            let monthNum = MONTH_NAMES.indexOf(monthStr) + 1
+            if (monthNum === 0) {
+                monthNum = MONTH_ABBR.indexOf(monthStr) + 1
+            }
+            if (monthNum > 0) {
+                const mm = String(monthNum).padStart(2, '0')
+                return {
+                    resolved: true,
+                    periods: [`${year}${mm}`],
+                    description,
+                }
+            }
+        }
+
+        // Try numeric month: "2023-01"
+        const numMonthMatch = description.match(NUMERIC_MONTH_PATTERN)
+        if (numMonthMatch) {
+            return {
+                resolved: true,
+                periods: [`${numMonthMatch[1]}${numMonthMatch[2]}`],
+                description,
+            }
+        }
+
         // Try fixed year
         const yearMatch = description.match(FIXED_YEAR_PATTERN)
         if (yearMatch) {
@@ -58,7 +136,7 @@ export const makeResolvePeriods =
         return {
             resolved: false,
             periods: [],
-            message: `Could not resolve "${description}" to a DHIS2 period. Try phrases like "last 12 months", "this year", "last quarter", or a year like "2024".`,
+            message: `Could not resolve "${description}" to a DHIS2 period. Try phrases like "last 12 months", "this year", "last quarter", "Q1 2023", "January 2024", or a year like "2024".`,
             suggestions: PERIOD_MAP.slice(0, 6).map((p) => p.id),
         }
     }

--- a/src/ai/tools/resolvePeriods.js
+++ b/src/ai/tools/resolvePeriods.js
@@ -1,0 +1,64 @@
+/**
+ * Resolve natural-language period descriptions to DHIS2 relative period ids.
+ * Resolved entirely locally — nothing leaves the browser.
+ *
+ * Returns standard DHIS2 relative period ids like LAST_12_MONTHS, THIS_YEAR, etc.
+ */
+
+const PERIOD_MAP = [
+    {
+        patterns: [/last\s+12\s+months?/i, /past\s+12\s+months?/i],
+        id: 'LAST_12_MONTHS',
+    },
+    {
+        patterns: [/last\s+6\s+months?/i, /past\s+6\s+months?/i],
+        id: 'LAST_6_MONTHS',
+    },
+    { patterns: [/last\s+3\s+months?/i], id: 'LAST_3_MONTHS' },
+    { patterns: [/this\s+month/i, /current\s+month/i], id: 'THIS_MONTH' },
+    { patterns: [/last\s+month/i, /previous\s+month/i], id: 'LAST_MONTH' },
+    { patterns: [/this\s+quarter/i, /current\s+quarter/i], id: 'THIS_QUARTER' },
+    {
+        patterns: [/last\s+quarter/i, /previous\s+quarter/i],
+        id: 'LAST_QUARTER',
+    },
+    { patterns: [/this\s+year/i, /current\s+year/i], id: 'THIS_YEAR' },
+    { patterns: [/last\s+year/i, /previous\s+year/i], id: 'LAST_YEAR' },
+    { patterns: [/last\s+5\s+years?/i], id: 'LAST_5_YEARS' },
+    { patterns: [/last\s+2\s+years?/i], id: 'LAST_2_YEARS' },
+    { patterns: [/this\s+financial\s+year/i], id: 'THIS_FINANCIAL_YEAR' },
+    { patterns: [/last\s+financial\s+year/i], id: 'LAST_FINANCIAL_YEAR' },
+    { patterns: [/last\s+week/i], id: 'LAST_WEEK' },
+    { patterns: [/this\s+week/i], id: 'THIS_WEEK' },
+    { patterns: [/last\s+52\s+weeks?/i], id: 'LAST_52_WEEKS' },
+]
+
+// Match a bare 4-digit year like "2024" or "in 2023"
+const FIXED_YEAR_PATTERN = /\b(20\d{2})\b/
+
+/**
+ * @returns {(args: {description: string}) => Promise<Object>}
+ */
+export const makeResolvePeriods =
+    () =>
+    async ({ description }) => {
+        // Try relative period patterns first
+        for (const { patterns, id } of PERIOD_MAP) {
+            if (patterns.some((p) => p.test(description))) {
+                return { resolved: true, periods: [id], description }
+            }
+        }
+
+        // Try fixed year
+        const yearMatch = description.match(FIXED_YEAR_PATTERN)
+        if (yearMatch) {
+            return { resolved: true, periods: [yearMatch[1]], description }
+        }
+
+        return {
+            resolved: false,
+            periods: [],
+            message: `Could not resolve "${description}" to a DHIS2 period. Try phrases like "last 12 months", "this year", "last quarter", or a year like "2024".`,
+            suggestions: PERIOD_MAP.slice(0, 6).map((p) => p.id),
+        }
+    }

--- a/src/ai/tools/schemas.js
+++ b/src/ai/tools/schemas.js
@@ -18,23 +18,13 @@ export const TOOL_SCHEMAS = [
                     description:
                         'Name or partial name of the indicator/data element, e.g. "malaria incidence"',
                 },
-                dimensionItemType: {
-                    type: 'string',
-                    enum: [
-                        'INDICATOR',
-                        'DATA_ELEMENT',
-                        'DATA_ELEMENT_OPERAND',
-                        'REPORTING_RATE',
-                    ],
-                    description: 'Optional: filter by type',
-                },
             },
         },
     },
     {
         name: 'resolve_org_units',
         description:
-            'Resolve a natural-language org unit description to DHIS2 org unit items (ids and/or level/group tokens). Always call this before any add_*_layer tool. Never invent org unit ids.',
+            'Resolve a natural-language org unit description to DHIS2 org unit items (ids and/or level/group tokens). Always call this before any add_*_layer or update_layer call. This tool only resolves — it does NOT apply changes to the map. After getting the items, you must call add_*_layer or update_layer to apply them.',
         input_schema: {
             type: 'object',
             required: ['description'],
@@ -71,7 +61,7 @@ export const TOOL_SCHEMAS = [
     {
         name: 'resolve_periods',
         description:
-            'Resolve a natural-language period description to DHIS2 relative period ids. Resolved locally — nothing leaves the browser. Returns an array of period id strings.',
+            'Resolve a natural-language period description to DHIS2 relative period ids. Returns an array of period id strings. This tool only resolves — it does NOT apply changes. After getting period ids, you must call add_thematic_layer or update_layer to apply them.',
         input_schema: {
             type: 'object',
             required: ['description'],
@@ -106,7 +96,11 @@ export const TOOL_SCHEMAS = [
                     required: ['id', 'dimensionItemType'],
                     properties: {
                         id: { type: 'string' },
-                        name: { type: 'string' },
+                        name: {
+                            type: 'string',
+                            description:
+                                'Use the displayName from search_data_items results.',
+                        },
                         dimensionItemType: {
                             type: 'string',
                             enum: [
@@ -196,7 +190,7 @@ export const TOOL_SCHEMAS = [
     {
         name: 'update_layer',
         description:
-            'Update properties of an existing layer. Call list_layers first to get the layer id.',
+            'Update properties of an existing layer. Call list_layers first to get the layer id. After calling this tool, report success directly — do not ask the user to confirm.',
         input_schema: {
             type: 'object',
             required: ['layerId', 'changes'],
@@ -208,7 +202,29 @@ export const TOOL_SCHEMAS = [
                 changes: {
                     type: 'object',
                     description:
-                        'Properties to update. For periods: {periods: ["LAST_6_MONTHS"]}. For type: {thematicMapType: "BUBBLE"}.',
+                        'Properties to change. Only include keys you want to change.',
+                    properties: {
+                        periods: {
+                            type: 'array',
+                            items: { type: 'string' },
+                            description:
+                                'New period ids, e.g. ["2023"] or ["LAST_6_MONTHS"]',
+                        },
+                        classes: {
+                            type: 'integer',
+                            description:
+                                'Number of classification classes (1–9)',
+                        },
+                        thematicMapType: {
+                            type: 'string',
+                            enum: ['CHOROPLETH', 'BUBBLE'],
+                        },
+                        orgUnits: {
+                            type: 'array',
+                            items: { type: 'string' },
+                            description: 'Replacement org unit ids / tokens',
+                        },
+                    },
                 },
             },
         },
@@ -216,14 +232,35 @@ export const TOOL_SCHEMAS = [
     {
         name: 'remove_layer',
         description:
-            'Remove a layer from the map. Call list_layers first to get the layer id. Always confirm with the user before calling this.',
+            'Remove a layer from the map. The user asking to remove a layer IS confirmation — call this tool immediately, do not ask again. Provide either layerId (from list_layers) or namePattern (a substring of the layer name).',
         input_schema: {
             type: 'object',
-            required: ['layerId'],
             properties: {
                 layerId: {
                     type: 'string',
                     description: 'Layer id from list_layers',
+                },
+                namePattern: {
+                    type: 'string',
+                    description:
+                        'Substring of the layer name to match, e.g. "ANC 1" or "malaria". Used when you do not have the layerId.',
+                },
+            },
+        },
+    },
+    {
+        name: 'validate_periods',
+        description:
+            'Validate DHIS2 period IDs before using them in add_thematic_layer or update_layer. Returns valid=true for recognized ids, false with a suggestion for invalid ones. Use when you are unsure whether a period id is correctly formatted.',
+        input_schema: {
+            type: 'object',
+            required: ['periods'],
+            properties: {
+                periods: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description:
+                        'Array of period id strings to validate, e.g. ["LAST_YEAR"] or ["2023Q1"]',
                 },
             },
         },

--- a/src/ai/tools/schemas.js
+++ b/src/ai/tools/schemas.js
@@ -1,0 +1,241 @@
+/**
+ * JSON Schema declarations for all AI tools.
+ * These are what the LLM sees — no implementation details here.
+ * Implementations are in the individual tool files.
+ */
+
+export const TOOL_SCHEMAS = [
+    {
+        name: 'search_data_items',
+        description:
+            'Search for DHIS2 data items (indicators, data elements, etc.) by name. Returns up to 10 candidates with id, displayName, and dimensionItemType. Always call this before add_thematic_layer to resolve a data item name to an id.',
+        input_schema: {
+            type: 'object',
+            required: ['query'],
+            properties: {
+                query: {
+                    type: 'string',
+                    description:
+                        'Name or partial name of the indicator/data element, e.g. "malaria incidence"',
+                },
+                dimensionItemType: {
+                    type: 'string',
+                    enum: [
+                        'INDICATOR',
+                        'DATA_ELEMENT',
+                        'DATA_ELEMENT_OPERAND',
+                        'REPORTING_RATE',
+                    ],
+                    description: 'Optional: filter by type',
+                },
+            },
+        },
+    },
+    {
+        name: 'resolve_org_units',
+        description:
+            'Resolve a natural-language org unit description to DHIS2 org unit items (ids and/or level/group tokens). Always call this before any add_*_layer tool. Never invent org unit ids.',
+        input_schema: {
+            type: 'object',
+            required: ['description'],
+            properties: {
+                description: {
+                    type: 'string',
+                    description:
+                        'Natural language description, e.g. "by district", "Northern region", "my facilities", "all chiefdoms"',
+                },
+                parentId: {
+                    type: 'string',
+                    description:
+                        'Optional: restrict to children of this org unit id',
+                },
+            },
+        },
+    },
+    {
+        name: 'search_org_unit_group_sets',
+        description:
+            'Search for org unit group sets by name. Returns candidates with id and displayName. Use to resolve "facility type", "ownership", etc. for facility/org-unit layer styling.',
+        input_schema: {
+            type: 'object',
+            required: ['query'],
+            properties: {
+                query: {
+                    type: 'string',
+                    description:
+                        'Name or partial name, e.g. "facility type", "ownership"',
+                },
+            },
+        },
+    },
+    {
+        name: 'resolve_periods',
+        description:
+            'Resolve a natural-language period description to DHIS2 relative period ids. Resolved locally — nothing leaves the browser. Returns an array of period id strings.',
+        input_schema: {
+            type: 'object',
+            required: ['description'],
+            properties: {
+                description: {
+                    type: 'string',
+                    description:
+                        'e.g. "last 12 months", "this year", "last quarter", "last 6 months"',
+                },
+            },
+        },
+    },
+    {
+        name: 'list_layers',
+        description:
+            'List the current layers on the map. Returns an array of {id, type, summary}. Call this before update_layer or remove_layer.',
+        input_schema: {
+            type: 'object',
+            properties: {},
+        },
+    },
+    {
+        name: 'add_thematic_layer',
+        description:
+            'Add a thematic (choropleth or bubble) layer to the map. Requires resolved data item id, org unit items, and period ids from the search/resolve tools.',
+        input_schema: {
+            type: 'object',
+            required: ['dataItem', 'orgUnits', 'periods'],
+            properties: {
+                dataItem: {
+                    type: 'object',
+                    required: ['id', 'dimensionItemType'],
+                    properties: {
+                        id: { type: 'string' },
+                        name: { type: 'string' },
+                        dimensionItemType: {
+                            type: 'string',
+                            enum: [
+                                'INDICATOR',
+                                'DATA_ELEMENT',
+                                'DATA_ELEMENT_OPERAND',
+                                'REPORTING_RATE',
+                            ],
+                        },
+                    },
+                },
+                orgUnits: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description:
+                        'Array of org unit ids and/or tokens: LEVEL-<n>, OU_GROUP-<id>, USER_ORGUNIT, USER_ORGUNIT_CHILDREN, USER_ORGUNIT_GRANDCHILDREN',
+                },
+                periods: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description:
+                        'Array of period ids, e.g. ["LAST_12_MONTHS"] or ["2024"]',
+                },
+                thematicMapType: {
+                    type: 'string',
+                    enum: ['CHOROPLETH', 'BUBBLE'],
+                    default: 'CHOROPLETH',
+                },
+                method: {
+                    type: 'integer',
+                    description:
+                        'Classification method: 2=equal intervals (default), 3=equal counts, 1=natural breaks',
+                    default: 2,
+                },
+                classes: {
+                    type: 'integer',
+                    description: 'Number of classification classes (default 5)',
+                    default: 5,
+                },
+            },
+        },
+    },
+    {
+        name: 'add_facility_layer',
+        description:
+            'Add a facility layer showing health facilities as points on the map.',
+        input_schema: {
+            type: 'object',
+            required: ['orgUnits'],
+            properties: {
+                orgUnits: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description:
+                        'Org unit items — ids and/or tokens. For "my facilities" use USER_ORGUNIT_CHILDREN.',
+                },
+                organisationUnitGroupSetId: {
+                    type: 'string',
+                    description:
+                        'Optional: group set id for styling facilities by type/ownership etc.',
+                },
+            },
+        },
+    },
+    {
+        name: 'add_org_unit_layer',
+        description:
+            'Add an org unit layer showing administrative boundaries. Also use for "show the boundaries" requests.',
+        input_schema: {
+            type: 'object',
+            required: ['orgUnits'],
+            properties: {
+                orgUnits: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description:
+                        'Org unit items — ids and/or level tokens like LEVEL-2',
+                },
+                organisationUnitGroupSetId: {
+                    type: 'string',
+                    description:
+                        'Optional: group set id for colouring boundaries by ownership etc.',
+                },
+            },
+        },
+    },
+    {
+        name: 'update_layer',
+        description:
+            'Update properties of an existing layer. Call list_layers first to get the layer id.',
+        input_schema: {
+            type: 'object',
+            required: ['layerId', 'changes'],
+            properties: {
+                layerId: {
+                    type: 'string',
+                    description: 'Layer id from list_layers',
+                },
+                changes: {
+                    type: 'object',
+                    description:
+                        'Properties to update. For periods: {periods: ["LAST_6_MONTHS"]}. For type: {thematicMapType: "BUBBLE"}.',
+                },
+            },
+        },
+    },
+    {
+        name: 'remove_layer',
+        description:
+            'Remove a layer from the map. Call list_layers first to get the layer id. Always confirm with the user before calling this.',
+        input_schema: {
+            type: 'object',
+            required: ['layerId'],
+            properties: {
+                layerId: {
+                    type: 'string',
+                    description: 'Layer id from list_layers',
+                },
+            },
+        },
+    },
+]
+
+/** Subset of tools used for read/list-only intents */
+export const READ_TOOLS = TOOL_SCHEMAS.filter((t) =>
+    ['list_layers', 'search_data_items', 'resolve_org_units'].includes(t.name)
+)
+
+/** Map from tool name to schema */
+export const TOOL_SCHEMA_MAP = Object.fromEntries(
+    TOOL_SCHEMAS.map((t) => [t.name, t])
+)

--- a/src/ai/tools/searchDataItems.js
+++ b/src/ai/tools/searchDataItems.js
@@ -1,0 +1,61 @@
+const MAX_RESULTS = 10
+
+// Only aggregate types can be used in thematic layers.
+// PROGRAM_INDICATOR / PROGRAM_DATA_ELEMENT are tracker-scoped and not valid here.
+const AGGREGATE_TYPES = [
+    'INDICATOR',
+    'DATA_ELEMENT',
+    'EXPRESSION_DIMENSION_ITEM',
+]
+
+/**
+ * @param {Object} engine - @dhis2/app-runtime data engine
+ * @returns {(args: {query: string, dimensionItemType?: string}) => Promise<Object>}
+ */
+export const makeSearchDataItems =
+    (engine) =>
+    async ({ query, dimensionItemType }) => {
+        const filters = [`displayName:ilike:${query}`]
+        if (dimensionItemType && AGGREGATE_TYPES.includes(dimensionItemType)) {
+            filters.push(`dimensionItemType:eq:${dimensionItemType}`)
+        } else {
+            // Always restrict to aggregate types — tracker-level items can't be mapped
+            filters.push(`dimensionItemType:in:[${AGGREGATE_TYPES.join(',')}]`)
+        }
+
+        const { dataItems } = await engine.query({
+            dataItems: {
+                resource: 'dataItems',
+                params: {
+                    filter: filters,
+                    fields: 'id,displayName,dimensionItemType',
+                    pageSize: MAX_RESULTS,
+                },
+            },
+        })
+
+        const items = dataItems?.dataItems ?? []
+
+        if (items.length === 0) {
+            return {
+                found: false,
+                message: `No data items found matching "${query}". Try a different search term.`,
+                candidates: [],
+            }
+        }
+
+        return {
+            found: true,
+            candidates: items.map(
+                ({ id, displayName, dimensionItemType: type }) => ({
+                    id,
+                    displayName,
+                    dimensionItemType: type,
+                })
+            ),
+            message:
+                items.length === 1
+                    ? `Found: ${items[0].displayName}`
+                    : `Found ${items.length} matches. Use the most relevant one.`,
+        }
+    }

--- a/src/ai/tools/searchDataItems.js
+++ b/src/ai/tools/searchDataItems.js
@@ -14,14 +14,12 @@ const AGGREGATE_TYPES = [
  */
 export const makeSearchDataItems =
     (engine) =>
-    async ({ query, dimensionItemType }) => {
-        const filters = [`displayName:ilike:${query}`]
-        if (dimensionItemType && AGGREGATE_TYPES.includes(dimensionItemType)) {
-            filters.push(`dimensionItemType:eq:${dimensionItemType}`)
-        } else {
-            // Always restrict to aggregate types — tracker-level items can't be mapped
-            filters.push(`dimensionItemType:in:[${AGGREGATE_TYPES.join(',')}]`)
-        }
+    async ({ query }) => {
+        // Always search across all aggregate types — the model can't know the type before searching
+        const filters = [
+            `displayName:ilike:${query}`,
+            `dimensionItemType:in:[${AGGREGATE_TYPES.join(',')}]`,
+        ]
 
         const { dataItems } = await engine.query({
             dataItems: {

--- a/src/ai/tools/searchOrgUnitGroupSets.js
+++ b/src/ai/tools/searchOrgUnitGroupSets.js
@@ -1,0 +1,40 @@
+/**
+ * @param {Object} engine - @dhis2/app-runtime data engine
+ * @returns {(args: {query: string}) => Promise<Object>}
+ */
+export const makeSearchOrgUnitGroupSets =
+    (engine) =>
+    async ({ query }) => {
+        const { groupSets } = await engine.query({
+            groupSets: {
+                resource: 'organisationUnitGroupSets',
+                params: {
+                    filter: `displayName:ilike:${query}`,
+                    fields: 'id,displayName',
+                    pageSize: 10,
+                },
+            },
+        })
+
+        const items = groupSets?.organisationUnitGroupSets ?? []
+
+        if (items.length === 0) {
+            return {
+                found: false,
+                message: `No org unit group sets found matching "${query}".`,
+                candidates: [],
+            }
+        }
+
+        return {
+            found: true,
+            candidates: items.map(({ id, displayName }) => ({
+                id,
+                displayName,
+            })),
+            message:
+                items.length === 1
+                    ? `Found: ${items[0].displayName} (id: ${items[0].id})`
+                    : `Found ${items.length} matches.`,
+        }
+    }

--- a/src/ai/tools/updateLayer.js
+++ b/src/ai/tools/updateLayer.js
@@ -1,4 +1,7 @@
 import { updateLayer } from '../../actions/layers.js'
+import { makeValidatePeriods } from './validatePeriods.js'
+
+const _validatePeriods = makeValidatePeriods()
 
 /**
  * Merge changes into an existing layer and re-trigger loading.
@@ -12,12 +15,35 @@ export const makeUpdateLayer =
     (dispatch, getState) =>
     async ({ layerId, changes }) => {
         const { map } = getState()
-        const layer = (map?.mapViews ?? []).find((l) => l.id === layerId)
+        const mapViews = map?.mapViews ?? []
+
+        // Try exact ID match first, then fall back to name substring match
+        const layer =
+            mapViews.find((l) => l.id === layerId) ??
+            mapViews.find((l) =>
+                l.name?.toLowerCase().includes(layerId.toLowerCase())
+            )
 
         if (!layer) {
             return {
                 success: false,
-                message: `No layer found with id "${layerId}". Call list_layers to see available layers.`,
+                message: `No layer found matching "${layerId}". Call list_layers to see available layers and their ids.`,
+            }
+        }
+
+        // Validate periods before applying — catch hallucinated IDs early
+        if (changes.periods?.length) {
+            const validation = await _validatePeriods({
+                periods: changes.periods,
+            })
+            if (!validation.allValid) {
+                const bad = validation.results.filter((r) => !r.valid)
+                return {
+                    success: false,
+                    message:
+                        bad.map((r) => r.suggestion).join(' ') +
+                        ' Call resolve_periods with a natural language description to get valid ids.',
+                }
             }
         }
 
@@ -59,12 +85,27 @@ const applyChanges = (layer, changes) => {
 
     // Period change: replace the pe filter
     if (changes.periods) {
+        const normalizePeriodId = (p) => {
+            let n = p.replace(/^P_/i, '')
+            n = n.replace(/^(\d{4})[-_]Q([1-4])$/i, '$1Q$2')
+            n = n.replace(/^Q([1-4])[-_ ](\d{4})$/i, '$2Q$1')
+            n = n.replace(/^(\d{4})[-_](\d{2})$/, '$1$2')
+            n = n.replace(/^PREVIOUS_YEAR$/i, 'LAST_YEAR')
+            n = n.replace(/^CURRENT_YEAR$/i, 'THIS_YEAR')
+            n = n.replace(/^PREVIOUS_QUARTER$/i, 'LAST_QUARTER')
+            n = n.replace(/^CURRENT_QUARTER$/i, 'THIS_QUARTER')
+            n = n.replace(/^PREVIOUS_MONTH$/i, 'LAST_MONTH')
+            n = n.replace(/^CURRENT_MONTH$/i, 'THIS_MONTH')
+            return n
+        }
         const existingFilters = layer.filters ?? []
         patch.filters = [
             ...existingFilters.filter((f) => f.dimension !== 'pe'),
             {
                 dimension: 'pe',
-                items: changes.periods.map((pe) => ({ id: pe })),
+                items: changes.periods.map((pe) => ({
+                    id: normalizePeriodId(pe),
+                })),
             },
         ]
     }

--- a/src/ai/tools/updateLayer.js
+++ b/src/ai/tools/updateLayer.js
@@ -1,0 +1,92 @@
+import { updateLayer } from '../../actions/layers.js'
+
+/**
+ * Merge changes into an existing layer and re-trigger loading.
+ * Mirrors the LayerEdit.jsx submit pattern: spread changes + flip isLoaded.
+ *
+ * @param {Function} dispatch - Redux dispatch
+ * @param {() => Object} getState - Redux getState
+ * @returns {(args: Object) => Promise<Object>}
+ */
+export const makeUpdateLayer =
+    (dispatch, getState) =>
+    async ({ layerId, changes }) => {
+        const { map } = getState()
+        const layer = (map?.mapViews ?? []).find((l) => l.id === layerId)
+
+        if (!layer) {
+            return {
+                success: false,
+                message: `No layer found with id "${layerId}". Call list_layers to see available layers.`,
+            }
+        }
+
+        const mergedChanges = applyChanges(layer, changes)
+
+        const config = {
+            ...layer,
+            ...mergedChanges,
+            editCounter: (layer.editCounter ?? 0) + 1,
+            isLoaded: false,
+            isLoading: false,
+            backupPeriodsDates: undefined,
+        }
+
+        dispatch(updateLayer(config))
+
+        return {
+            success: true,
+            message: `Updated layer "${layerId}".`,
+        }
+    }
+
+/**
+ * Translate high-level change descriptions to layer config patches.
+ * Handles the common cases the LLM will produce.
+ */
+const applyChanges = (layer, changes) => {
+    const patch = {}
+
+    if (changes.thematicMapType) {
+        patch.thematicMapType = changes.thematicMapType
+    }
+    if (changes.method !== undefined) {
+        patch.method = changes.method
+    }
+    if (changes.classes !== undefined) {
+        patch.classes = changes.classes
+    }
+
+    // Period change: replace the pe filter
+    if (changes.periods) {
+        const existingFilters = layer.filters ?? []
+        patch.filters = [
+            ...existingFilters.filter((f) => f.dimension !== 'pe'),
+            {
+                dimension: 'pe',
+                items: changes.periods.map((pe) => ({ id: pe })),
+            },
+        ]
+    }
+
+    // Org unit change: replace the ou row
+    if (changes.orgUnits) {
+        const existingRows = layer.rows ?? []
+        patch.rows = [
+            ...existingRows.filter((r) => r.dimension !== 'ou'),
+            {
+                dimension: 'ou',
+                items: changes.orgUnits.map((ou) => ({ id: ou })),
+            },
+        ]
+    }
+
+    // Group set change
+    if (changes.organisationUnitGroupSetId !== undefined) {
+        patch.organisationUnitGroupSet = changes.organisationUnitGroupSetId
+            ? { id: changes.organisationUnitGroupSetId }
+            : undefined
+    }
+
+    return patch
+}

--- a/src/ai/tools/validatePeriods.js
+++ b/src/ai/tools/validatePeriods.js
@@ -1,0 +1,102 @@
+/**
+ * Validate DHIS2 period IDs before passing them to add/update layer tools.
+ * Pure client-side — no API calls needed.
+ */
+
+const RELATIVE_PERIODS = new Set([
+    'THIS_WEEK',
+    'LAST_WEEK',
+    'LAST_4_WEEKS',
+    'LAST_12_WEEKS',
+    'LAST_52_WEEKS',
+    'THIS_MONTH',
+    'LAST_MONTH',
+    'LAST_3_MONTHS',
+    'LAST_6_MONTHS',
+    'LAST_12_MONTHS',
+    'LAST_6_BIMONTHS',
+    'THIS_BIMONTH',
+    'LAST_BIMONTH',
+    'THIS_QUARTER',
+    'LAST_QUARTER',
+    'LAST_4_QUARTERS',
+    'THIS_SIX_MONTH',
+    'LAST_SIX_MONTH',
+    'LAST_2_SIXMONTHS',
+    'THIS_YEAR',
+    'LAST_YEAR',
+    'LAST_5_YEARS',
+    'LAST_10_YEARS',
+    'THIS_FINANCIAL_YEAR',
+    'LAST_FINANCIAL_YEAR',
+    'LAST_5_FINANCIAL_YEARS',
+])
+
+// Fixed period patterns (regex applied after uppercasing)
+const FIXED_PATTERNS = [
+    /^\d{4}$/, // year: 2023
+    /^\d{4}Q[1-4]$/, // quarter: 2023Q1
+    /^\d{4}(0[1-9]|1[0-2])$/, // month: 202301–202312
+    /^\d{4}W([1-9]|[1-4]\d|5[0-3])$/, // week: 2023W1–2023W53
+    /^\d{4}0[1-6]B$/, // bimonth: 202301B–202306B
+    /^\d{4}S[12]$/, // six-month: 2023S1, 2023S2
+    /^\d{4}(April|July|Oct|Nov)$/, // financial year variants
+]
+
+const isValidPeriod = (id) => {
+    if (RELATIVE_PERIODS.has(id)) {
+        return true
+    }
+    return FIXED_PATTERNS.some((re) => re.test(id))
+}
+
+const getSuggestion = (id) => {
+    const up = id.toUpperCase()
+    // Looks like a natural language description — call resolve_periods
+    if (/\s/.test(id) || /FLOATING|CUSTOM|ROLLING/i.test(id)) {
+        return `"${id}" is not a valid DHIS2 period id. Call resolve_periods with a natural language description like "last year" or "last 5 years".`
+    }
+    // Might be a variant of a relative period
+    if (/^(PREVIOUS|CURRENT)_/.test(up)) {
+        const corrected = up
+            .replace(/^PREVIOUS_/, 'LAST_')
+            .replace(/^CURRENT_/, 'THIS_')
+        if (RELATIVE_PERIODS.has(corrected)) {
+            return `Did you mean "${corrected}"? Use LAST_ instead of PREVIOUS_ and THIS_ instead of CURRENT_.`
+        }
+    }
+    return `"${id}" is not a recognized DHIS2 period id. Call resolve_periods with a natural language period description to get a valid id.`
+}
+
+/**
+ * @returns {(args: { periods: string[] }) => Promise<Object>}
+ */
+export const makeValidatePeriods =
+    () =>
+    async ({ periods }) => {
+        if (!Array.isArray(periods) || periods.length === 0) {
+            return {
+                allValid: false,
+                error: 'periods must be a non-empty array of period id strings.',
+            }
+        }
+
+        const results = periods.map((id) => {
+            const valid = isValidPeriod(id)
+            return valid
+                ? { period: id, valid: true }
+                : { period: id, valid: false, suggestion: getSuggestion(id) }
+        })
+
+        const allValid = results.every((r) => r.valid)
+        return {
+            allValid,
+            results,
+            ...(allValid
+                ? { message: 'All period ids are valid.' }
+                : {
+                      message:
+                          'One or more period ids are invalid. Fix them before calling add_thematic_layer or update_layer.',
+                  }),
+        }
+    }

--- a/src/ai/ui/AssistantPanel.jsx
+++ b/src/ai/ui/AssistantPanel.jsx
@@ -1,12 +1,6 @@
 import { useDataEngine } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
-import {
-    Button,
-    CircularLoader,
-    IconChevronRight24,
-    IconRedo16,
-    TextArea,
-} from '@dhis2/ui'
+import { Button, CircularLoader, IconRedo16, TextArea } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector, useStore } from 'react-redux'
@@ -24,7 +18,7 @@ const isEnabled = () =>
         localStorage.getItem(FEATURE_FLAG) === 'true' ||
         process.env.NODE_ENV === 'development')
 
-const AssistantPanel = ({ open, onClose }) => {
+const AssistantPanel = ({ open }) => {
     const dispatch = useDispatch()
     const reduxStore = useStore()
     const engine = useDataEngine()
@@ -35,9 +29,46 @@ const AssistantPanel = ({ open, onClose }) => {
     const [inputText, setInputText] = useState('')
     const [status, setStatus] = useState('idle')
     const [statusText, setStatusText] = useState('')
-    const [activeProvider] = useState('demo')
-    const [registry] = useState(() => buildRegistry([]))
+    const [activeProvider, setActiveProvider] = useState('ollama-3b')
+    const [registry] = useState(() =>
+        buildRegistry([
+            {
+                id: 'ollama-3b',
+                label: 'Ollama · qwen2.5:3b',
+                type: 'openaiCompatible',
+                baseURL: 'http://localhost:11434/v1',
+                model: 'qwen2.5:3b',
+                isLocal: true,
+                enabled: true,
+            },
+            {
+                id: 'ollama-7b',
+                label: 'Ollama · qwen2.5:7b',
+                type: 'openaiCompatible',
+                baseURL: 'http://localhost:11434/v1',
+                model: 'qwen2.5:7b',
+                isLocal: true,
+                enabled: true,
+            },
+            // Dev-only: Vite strips this entire block in production builds so the
+            // API key is never inlined into the bundle.
+            ...(import.meta.env.DEV && import.meta.env.DHIS2_ANTHROPIC_API_KEY
+                ? [
+                      {
+                          id: 'claude',
+                          label: 'Claude (Anthropic)',
+                          type: 'anthropic',
+                          baseURL: '/anthropic-proxy',
+                          model: 'claude-sonnet-4-6',
+                          apiKey: import.meta.env.DHIS2_ANTHROPIC_API_KEY,
+                          enabled: true,
+                      },
+                  ]
+                : []),
+        ])
+    )
     const connector = selectConnector(registry, activeProvider)
+    const selectableConnectors = registry.filter((c) => c.id !== 'demo')
     const isDemo = connector.id === 'demo'
 
     const toolRegistry = buildToolRegistry({
@@ -56,6 +87,7 @@ const AssistantPanel = ({ open, onClose }) => {
             setStatus('thinking')
             setStatusText('')
             setInputText('')
+            setHistory((prev) => [...prev, { role: 'user', content: userText }])
 
             const onUpdate = (update) => {
                 if (update.type === 'thinking') {
@@ -100,7 +132,7 @@ const AssistantPanel = ({ open, onClose }) => {
         setStatusText('')
     }, [])
 
-    const handleKeyDown = (e) => {
+    const handleKeyDown = (_payload, e) => {
         if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault()
             handleSend(inputText)
@@ -150,11 +182,24 @@ const AssistantPanel = ({ open, onClose }) => {
                     <div className={styles.title}>
                         {i18n.t('Map assistant')}
                     </div>
-                    <div className={styles.providerText}>
-                        {isDemo
-                            ? i18n.t('Demo mode — no AI model connected')
-                            : connector.label}
-                    </div>
+                    {isDemo ? (
+                        <div className={styles.providerText}>
+                            {i18n.t('Demo mode — no AI model connected')}
+                        </div>
+                    ) : (
+                        <select
+                            className={styles.modelSelect}
+                            value={activeProvider}
+                            onChange={(e) => setActiveProvider(e.target.value)}
+                            disabled={status === 'thinking'}
+                        >
+                            {selectableConnectors.map((c) => (
+                                <option key={c.id} value={c.id}>
+                                    {c.label}
+                                </option>
+                            ))}
+                        </select>
+                    )}
                 </div>
                 {history.length > 0 && (
                     <button
@@ -166,13 +211,6 @@ const AssistantPanel = ({ open, onClose }) => {
                         <IconRedo16 />
                     </button>
                 )}
-                <button
-                    className={styles.closeBtn}
-                    onClick={onClose}
-                    aria-label={i18n.t('Close assistant')}
-                >
-                    <IconChevronRight24 />
-                </button>
             </div>
 
             <div
@@ -324,7 +362,6 @@ const AssistantPanel = ({ open, onClose }) => {
 
 AssistantPanel.propTypes = {
     open: PropTypes.bool.isRequired,
-    onClose: PropTypes.func.isRequired,
 }
 
 export { isEnabled }

--- a/src/ai/ui/AssistantPanel.jsx
+++ b/src/ai/ui/AssistantPanel.jsx
@@ -1,0 +1,331 @@
+import { useDataEngine } from '@dhis2/app-runtime'
+import i18n from '@dhis2/d2-i18n'
+import {
+    Button,
+    CircularLoader,
+    IconChevronRight24,
+    IconRedo16,
+    TextArea,
+} from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { useDispatch, useSelector, useStore } from 'react-redux'
+import { runAgentLoop } from '../agent/loop.js'
+import { DEMO_SCRIPTS } from '../connectors/demoScripts.js'
+import { buildRegistry, selectConnector } from '../connectors/registry.js'
+import { buildToolRegistry } from '../tools/executor.js'
+import styles from './styles/AssistantPanel.module.css'
+
+const FEATURE_FLAG = 'DHIS2_AI_ASSISTANT'
+
+const isEnabled = () =>
+    typeof window !== 'undefined' &&
+    (window.__DHIS2_AI_ASSISTANT__ === true ||
+        localStorage.getItem(FEATURE_FLAG) === 'true' ||
+        process.env.NODE_ENV === 'development')
+
+const AssistantPanel = ({ open, onClose }) => {
+    const dispatch = useDispatch()
+    const reduxStore = useStore()
+    const engine = useDataEngine()
+    const getStateRef = useRef(null)
+    getStateRef.current = reduxStore.getState
+
+    const [history, setHistory] = useState([])
+    const [inputText, setInputText] = useState('')
+    const [status, setStatus] = useState('idle')
+    const [statusText, setStatusText] = useState('')
+    const [activeProvider] = useState('demo')
+    const [registry] = useState(() => buildRegistry([]))
+    const connector = selectConnector(registry, activeProvider)
+    const isDemo = connector.id === 'demo'
+
+    const toolRegistry = buildToolRegistry({
+        engine,
+        dispatch,
+        getState: () => getStateRef.current(),
+    })
+
+    const handleSend = useCallback(
+        async (text) => {
+            const userText = text.trim()
+            if (!userText || status === 'thinking') {
+                return
+            }
+
+            setStatus('thinking')
+            setStatusText('')
+            setInputText('')
+
+            const onUpdate = (update) => {
+                if (update.type === 'thinking') {
+                    setStatusText(i18n.t('Thinking…'))
+                }
+                if (update.type === 'tool_call') {
+                    setStatusText(
+                        i18n.t('Running {{name}}…', { name: update.name })
+                    )
+                }
+                if (update.type === 'text') {
+                    setStatusText('')
+                }
+            }
+
+            try {
+                console.log('[AI] starting agent loop for:', userText)
+                const result = await runAgentLoop({
+                    connector,
+                    toolRegistry,
+                    history,
+                    userText,
+                    onUpdate,
+                })
+                console.log('[AI] loop complete. reply:', result.reply)
+                setHistory(result.history)
+                setStatus('idle')
+                setStatusText('')
+            } catch (err) {
+                console.error('[AI] loop error:', err)
+                setStatus('error')
+                setStatusText(err.message)
+            }
+        },
+        [connector, history, status, toolRegistry]
+    )
+
+    const handleReset = useCallback(() => {
+        setHistory([])
+        setInputText('')
+        setStatus('idle')
+        setStatusText('')
+    }, [])
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault()
+            handleSend(inputText)
+        }
+    }
+
+    const transcriptRef = useRef(null)
+    useEffect(() => {
+        if (transcriptRef.current) {
+            transcriptRef.current.scrollTop = transcriptRef.current.scrollHeight
+        }
+    }, [history, status])
+
+    const mapViews = useSelector((state) => state.map?.mapViews ?? [])
+
+    // Track which scripts have been triggered via history
+    const usedLabels = new Set(
+        history
+            .filter((m) => m.role === 'user' && typeof m.content === 'string')
+            .map((m) => m.content)
+    )
+
+    // A script's layer is "present" if a layer with a matching name exists in Redux.
+    // This detects manual removal as well as AI-driven removal.
+    const isLayerPresent = (script) => {
+        const pattern = script.removeSteps?.[0]?.args?.namePattern
+        if (!pattern) {
+            return false
+        }
+        return mapViews.some((l) =>
+            l.name?.toLowerCase().includes(pattern.toLowerCase())
+        )
+    }
+
+    const unusedScripts = DEMO_SCRIPTS.filter((s) => !usedLabels.has(s.label))
+    const removableScripts = DEMO_SCRIPTS.filter(
+        (s) => usedLabels.has(s.label) && isLayerPresent(s)
+    )
+    if (!open) {
+        return null
+    }
+
+    return (
+        <div className={styles.panel}>
+            <div className={styles.header}>
+                <div className={styles.titleArea}>
+                    <div className={styles.title}>
+                        {i18n.t('Map assistant')}
+                    </div>
+                    <div className={styles.providerText}>
+                        {isDemo
+                            ? i18n.t('Demo mode — no AI model connected')
+                            : connector.label}
+                    </div>
+                </div>
+                {history.length > 0 && (
+                    <button
+                        className={styles.closeBtn}
+                        onClick={handleReset}
+                        title={i18n.t('New conversation')}
+                        aria-label={i18n.t('New conversation')}
+                    >
+                        <IconRedo16 />
+                    </button>
+                )}
+                <button
+                    className={styles.closeBtn}
+                    onClick={onClose}
+                    aria-label={i18n.t('Close assistant')}
+                >
+                    <IconChevronRight24 />
+                </button>
+            </div>
+
+            <div
+                className={styles.transcript}
+                ref={transcriptRef}
+                role="log"
+                aria-live="polite"
+            >
+                {history.length === 0 && (
+                    <div className={styles.emptyState}>
+                        <p>
+                            {i18n.t(
+                                'Add, edit, or remove map layers using plain language.'
+                            )}
+                        </p>
+                        <div className={styles.examplesLabel}>
+                            {i18n.t('Try an example')}
+                        </div>
+                        <div className={styles.chips}>
+                            {DEMO_SCRIPTS.map((s) => (
+                                <button
+                                    key={s.label}
+                                    className={styles.chip}
+                                    onClick={() => handleSend(s.label)}
+                                >
+                                    {s.label}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {history
+                    .filter(
+                        (m) =>
+                            (m.role === 'user' || m.role === 'assistant') &&
+                            typeof m.content === 'string' &&
+                            m.content.trim() !== ''
+                    )
+                    .map((msg, i) => (
+                        <div
+                            key={i}
+                            className={
+                                msg.role === 'user'
+                                    ? styles.userMsg
+                                    : styles.assistantMsg
+                            }
+                        >
+                            <span className={styles.msgLabel}>
+                                {msg.role === 'user'
+                                    ? i18n.t('You')
+                                    : i18n.t('Assistant')}
+                            </span>
+                            <span className={styles.msgText}>
+                                {msg.content}
+                            </span>
+                        </div>
+                    ))}
+
+                {status === 'thinking' && (
+                    <div className={styles.statusRow}>
+                        <CircularLoader small />
+                        <span>{statusText}</span>
+                    </div>
+                )}
+                {status === 'error' && (
+                    <div className={styles.errorRow}>{statusText}</div>
+                )}
+
+                {isDemo &&
+                    status === 'idle' &&
+                    history.length > 0 &&
+                    (removableScripts.length > 0 ||
+                        unusedScripts.length > 0) && (
+                        <div className={styles.postCompletion}>
+                            {removableScripts.length > 0 && (
+                                <>
+                                    <div className={styles.examplesLabel}>
+                                        {i18n.t('Remove a layer')}
+                                    </div>
+                                    <div className={styles.chips}>
+                                        {removableScripts.map((s) => (
+                                            <button
+                                                key={s.removeLabel}
+                                                className={`${styles.chip} ${styles.chipRemove}`}
+                                                onClick={() =>
+                                                    handleSend(s.removeLabel)
+                                                }
+                                            >
+                                                {s.removeLabel}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </>
+                            )}
+                            {unusedScripts.length > 0 && (
+                                <>
+                                    <div className={styles.examplesLabel}>
+                                        {i18n.t('Try another example')}
+                                    </div>
+                                    <div className={styles.chips}>
+                                        {unusedScripts.map((s) => (
+                                            <button
+                                                key={s.label}
+                                                className={styles.chip}
+                                                onClick={() =>
+                                                    handleSend(s.label)
+                                                }
+                                            >
+                                                {s.label}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    )}
+            </div>
+
+            <div className={styles.inputRow}>
+                <TextArea
+                    value={inputText}
+                    onChange={({ value }) => setInputText(value)}
+                    onKeyDown={handleKeyDown}
+                    placeholder={
+                        isDemo
+                            ? i18n.t('Try one of the examples above…')
+                            : i18n.t('Ask me to add, edit, or remove a layer…')
+                    }
+                    rows={2}
+                    disabled={status === 'thinking'}
+                    resize="none"
+                    dense
+                />
+                <div className={styles.sendRow}>
+                    <Button
+                        primary
+                        small
+                        onClick={() => handleSend(inputText)}
+                        disabled={!inputText.trim() || status === 'thinking'}
+                    >
+                        {i18n.t('Send')}
+                    </Button>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+AssistantPanel.propTypes = {
+    open: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+}
+
+export { isEnabled }
+export default AssistantPanel

--- a/src/ai/ui/styles/AssistantPanel.module.css
+++ b/src/ai/ui/styles/AssistantPanel.module.css
@@ -39,6 +39,23 @@
     white-space: nowrap;
 }
 
+.modelSelect {
+    font-size: 11px;
+    color: var(--colors-grey600);
+    background: none;
+    border: none;
+    padding: 0;
+    margin-top: 1px;
+    cursor: pointer;
+    font-family: inherit;
+    max-width: 100%;
+}
+
+.modelSelect:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
 .closeBtn {
     background: none;
     border: none;

--- a/src/ai/ui/styles/AssistantPanel.module.css
+++ b/src/ai/ui/styles/AssistantPanel.module.css
@@ -1,0 +1,211 @@
+.panel {
+    display: flex;
+    flex-direction: column;
+    width: var(--right-panel-width);
+    height: 100%;
+    background-color: var(--colors-grey200);
+    border-left: 1px solid var(--colors-grey400);
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacers-dp8);
+    padding: var(--spacers-dp8) var(--spacers-dp8) var(--spacers-dp8)
+        var(--spacers-dp16);
+    background: var(--colors-white);
+    border-bottom: 1px solid var(--colors-grey400);
+    flex-shrink: 0;
+}
+
+.titleArea {
+    flex: 1;
+    min-width: 0;
+}
+
+.title {
+    font-size: 15px;
+    font-weight: 500;
+    color: var(--colors-grey900);
+    line-height: 1.3;
+}
+
+.providerText {
+    font-size: 11px;
+    color: var(--colors-grey600);
+    margin-top: 1px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.closeBtn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+    color: var(--colors-grey600);
+    display: flex;
+    align-items: center;
+    border-radius: 3px;
+    flex-shrink: 0;
+}
+
+.closeBtn:hover {
+    background: var(--colors-grey200);
+    color: var(--colors-grey900);
+}
+
+.transcript {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--spacers-dp16);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacers-dp8);
+}
+
+.emptyState {
+    color: var(--colors-grey700);
+    line-height: 1.5;
+    font-size: 14px;
+}
+
+.emptyState p {
+    margin: 0 0 var(--spacers-dp8);
+}
+
+.examplesLabel {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--colors-grey600);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin: var(--spacers-dp8) 0 var(--spacers-dp4);
+}
+
+.chips {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacers-dp4);
+}
+
+.chip {
+    display: block;
+    width: 100%;
+    padding: 5px var(--spacers-dp8);
+    background: transparent;
+    border: 1px solid var(--colors-grey400);
+    border-radius: 3px;
+    font-size: 14px;
+    font-family: inherit;
+    color: var(--colors-grey900);
+    cursor: pointer;
+    text-align: left;
+    line-height: 1.4;
+}
+
+.chip:hover {
+    background: var(--colors-grey300, #d5d7d9);
+}
+
+.chip:focus {
+    outline: 3px solid var(--colors-blue600, #2986cc);
+    outline-offset: -3px;
+}
+
+.chip:focus:not(:focus-visible) {
+    outline: none;
+}
+
+.chipRemove {
+    color: var(--colors-red700, #c62828);
+    border-color: var(--colors-red300, #ef9a9a);
+}
+
+.chipRemove:hover {
+    background: var(--colors-red050, #ffebee);
+}
+
+.userMsg {
+    align-self: flex-end;
+    max-width: 88%;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 2px;
+}
+
+.assistantMsg {
+    align-self: flex-start;
+    max-width: 88%;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+}
+
+.msgLabel {
+    font-size: 11px;
+    color: var(--colors-grey600);
+    font-weight: 500;
+    padding: 0 2px;
+}
+
+.msgText {
+    border-radius: 4px;
+    padding: var(--spacers-dp8) 12px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    font-size: 14px;
+    color: var(--colors-grey900);
+}
+
+.userMsg .msgText {
+    background: var(--colors-white);
+    border: 1px solid var(--colors-grey400);
+}
+
+.assistantMsg .msgText {
+    background: transparent;
+    padding-left: 0;
+}
+
+.statusRow {
+    display: flex;
+    align-items: center;
+    gap: var(--spacers-dp8);
+    color: var(--colors-grey600);
+    font-size: 13px;
+    padding: var(--spacers-dp4) 0;
+}
+
+.errorRow {
+    border-left: 3px solid var(--colors-red600, #e53935);
+    border-radius: 2px;
+    padding: var(--spacers-dp8);
+    color: var(--colors-red700, #c62828);
+    font-size: 13px;
+    background: var(--colors-red100, #ffebee);
+}
+
+.inputRow {
+    padding: var(--spacers-dp8) var(--spacers-dp16) var(--spacers-dp16);
+    border-top: 1px solid var(--colors-grey400);
+    background: var(--colors-white);
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacers-dp8);
+}
+
+.postCompletion {
+    margin-top: var(--spacers-dp8);
+    padding-top: var(--spacers-dp8);
+    border-top: 1px solid var(--colors-grey400);
+}
+
+.sendRow {
+    display: flex;
+    justify-content: flex-end;
+}

--- a/src/components/app/App.jsx
+++ b/src/components/app/App.jsx
@@ -1,6 +1,9 @@
 import cx from 'classnames'
 import React, { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
+import AssistantPanel, {
+    isEnabled as isAiEnabled,
+} from '../../ai/ui/AssistantPanel.jsx'
 import { useLayersLoader } from '../../hooks/useLayersLoader.js'
 import BottomPanel from '../datatable/BottomPanel.jsx'
 import DownloadModeMenu from '../download/DownloadMenubar.jsx'
@@ -14,6 +17,8 @@ import './App.css'
 import styles from './styles/App.module.css'
 import { useLoadDataStore } from './useLoadDataStore.js'
 import { useLoadMap } from './useLoadMap.js'
+
+const aiEnabled = isAiEnabled()
 
 const App = () => {
     useEffect(() => {
@@ -34,6 +39,7 @@ const App = () => {
 
     const [interpretationsRenderCount, setInterpretationsRenderCount] =
         useState(1)
+    const [assistantOpen, setAssistantOpen] = useState(false)
 
     const dataTableOpen = useSelector((state) => !!state.dataTable)
     const downloadModeOpen = useSelector((state) => !!state.ui.downloadMode)
@@ -50,7 +56,12 @@ const App = () => {
             {downloadModeOpen ? (
                 <DownloadModeMenu />
             ) : (
-                <AppMenu onFileMenuAction={onFileMenuAction} />
+                <AppMenu
+                    onFileMenuAction={onFileMenuAction}
+                    aiEnabled={aiEnabled}
+                    assistantOpen={assistantOpen}
+                    onAssistantToggle={() => setAssistantOpen((o) => !o)}
+                />
             )}
             <div
                 className={cx(styles.content, {
@@ -65,6 +76,12 @@ const App = () => {
                 {!downloadModeOpen && (
                     <DetailsPanel
                         interpretationsRenderCount={interpretationsRenderCount}
+                    />
+                )}
+                {aiEnabled && !downloadModeOpen && (
+                    <AssistantPanel
+                        open={assistantOpen}
+                        onClose={() => setAssistantOpen(false)}
                     />
                 )}
             </div>

--- a/src/components/app/AppMenu.jsx
+++ b/src/components/app/AppMenu.jsx
@@ -1,12 +1,20 @@
 import { Toolbar, HoverMenuBar } from '@dhis2/analytics'
+import i18n from '@dhis2/d2-i18n'
+import { IconChevronLeft24, IconChevronRight24 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import DownloadButton from '../download/DownloadButton.jsx'
 import InterpretationsToggle from '../interpretations/InterpretationsToggle.jsx'
 import AddLayerButton from '../layers/overlays/AddLayerButton.jsx'
 import FileMenu from './FileMenu.jsx'
+import styles from './styles/MenuButton.module.css'
 
-const AppMenu = ({ onFileMenuAction }) => (
+const AppMenu = ({
+    onFileMenuAction,
+    aiEnabled,
+    assistantOpen,
+    onAssistantToggle,
+}) => (
     <Toolbar>
         <AddLayerButton />
         <HoverMenuBar>
@@ -14,11 +22,20 @@ const AppMenu = ({ onFileMenuAction }) => (
             <DownloadButton />
         </HoverMenuBar>
         <InterpretationsToggle />
+        {aiEnabled && (
+            <button className={styles.menuButton} onClick={onAssistantToggle}>
+                {assistantOpen ? <IconChevronRight24 /> : <IconChevronLeft24 />}
+                {i18n.t('AI assistant')}
+            </button>
+        )}
     </Toolbar>
 )
 
 AppMenu.propTypes = {
     onFileMenuAction: PropTypes.func.isRequired,
+    aiEnabled: PropTypes.bool,
+    assistantOpen: PropTypes.bool,
+    onAssistantToggle: PropTypes.func,
 }
 
 export default AppMenu

--- a/src/components/app/styles/MenuButton.module.css
+++ b/src/components/app/styles/MenuButton.module.css
@@ -1,0 +1,33 @@
+/* Matches @dhis2/analytics MenuButton.styles.js exactly */
+.menuButton {
+    all: unset;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacers-dp8);
+    font-size: 14px;
+    line-height: 14px;
+    padding: 0 12px;
+    color: var(--colors-grey900);
+    cursor: pointer;
+    user-select: none;
+}
+
+.menuButton:hover:not(:disabled),
+.menuButton:active:not(:disabled) {
+    background-color: var(--colors-grey200);
+}
+
+.menuButton:focus {
+    outline: 3px solid var(--colors-blue600, #2986cc);
+    outline-offset: -3px;
+}
+
+.menuButton:focus:not(:focus-visible) {
+    outline: none;
+}
+
+.menuButton:disabled {
+    color: var(--colors-grey500);
+    cursor: not-allowed;
+}


### PR DESCRIPTION
Mockup

DO NOT MERGE

### Description

DHIS2 users of analytics apps could manage their maps and charts in plain language — starting in the Maps app with _add / edit / remove a layer_ and _answer questions about the available metadata and how the app works_, and later _analyse what the map shows_.

Because DHIS2 instances hold sensitive health data, two principles govern every choice. First, **the customer decides what leaves their server**: an administrator can restrict what any AI provider sees — down to "nothing leaves; only a self-hosted model may be used" — even at the cost of capability. Second, **no vendor lock-in**: customers use whatever AI they host or pay for, with at least one open-source/self-hosted option and one mainstream cloud option, and new providers added by writing one small adapter.

The assistant appears in two forms. **Tier 1 — embedded** in each analytics app (Maps, Data Visualizer, Event Visualizer), driving that app directly; this is where we start. **Tier 2 — cross-app** on a dashboard, where one assistant composes an entire dashboard — finding existing saved content or creating new maps and charts — without the user touching a dialog. Both run on the same shared machinery — provider connectors, a server-side broker, an egress-policy engine, and a tool/executor layer — so security and provider rules are defined and audited once.

The first deliverable is a **proof of concept in the Maps app**: add, edit, and remove layers, plus answer questions about the instance's metadata and DHIS2 documentation, against two interchangeable providers — a small self-hosted model and a cloud model. It is built so **no health figures ever leave the browser**: adding a layer and answering "what malaria indicators do we have?" both need only names and labels, never values. This validates the two hardest constraints — provider-swapping and data-minimisation — before any sensitive data is in scope. _Analyse the map_ requires values to leave, so it follows once the egress-policy engine exists. The end state extracts the shared machinery into a library the other analytics apps can consume.

The single most important design property: **the assistant manipulates the real app, not a parallel one.** Its tools dispatch the same actions a user's clicks do, so an AI-built layer is an ordinary layer the user can then edit or delete by hand.


---

### Screenshots

<img width="1541" height="905" alt="image" src="https://github.com/user-attachments/assets/e551cf4b-886c-4592-af39-2fd7d5ec1f81" />
