### PR TITLE
fix: prevent duplicate datastore requests on load

### DIFF
--- a/src/components/app/__tests__/useLoadDataStore.spec.js
+++ b/src/components/app/__tests__/useLoadDataStore.spec.js
@@ -1,4 +1,11 @@
 import { renderHook, waitFor } from '@testing-library/react'
+import { initLayerSources } from '../../../actions/layerSources.js'
+import {
+    earthEngineLayersIds,
+    earthEngineLayersDefaultIds,
+    earthEngineLayersUpdates,
+} from '../../../constants/earthEngineLayers/index.js'
+import { MAPS_APP_NAMESPACE } from '../../../constants/settings.js'
 import { useLoadDataStore } from '../useLoadDataStore.js'
 
 const mockDispatch = jest.fn()
@@ -12,17 +19,38 @@ jest.mock('@dhis2/app-runtime', () => ({
     useDataEngine: () => mockEngine,
 }))
 
+const defaultIds = earthEngineLayersDefaultIds()
+
+// Build an engine mock that answers the two distinct queries the hook makes:
+// the top-level `dataStore` namespace list, and the managed layer sources key.
+const setupEngine = ({
+    namespaces = [],
+    visibility,
+    visibilityRejects,
+} = {}) => {
+    mockEngine = {
+        query: jest.fn((q) => {
+            if ('dataStore' in q) {
+                return Promise.resolve({ dataStore: namespaces })
+            }
+            if ('layerSourcesVisibility' in q) {
+                return visibilityRejects
+                    ? Promise.reject(new Error('404'))
+                    : Promise.resolve({ layerSourcesVisibility: visibility })
+            }
+            return Promise.resolve({})
+        }),
+        mutate: jest.fn().mockResolvedValue({}),
+    }
+}
+
 describe('useLoadDataStore', () => {
     beforeEach(() => {
         mockDispatch.mockClear()
-        mockEngine = {
-            // Namespace missing -> hook should create the key once
-            query: jest.fn().mockResolvedValue({ dataStore: [] }),
-            mutate: jest.fn().mockResolvedValue({}),
-        }
     })
 
     it('queries the datastore once on mount, not on every render', async () => {
+        setupEngine({ namespaces: [] })
         const { rerender } = renderHook(() => useLoadDataStore())
 
         // Force several re-renders, as App does on any redux state change
@@ -37,15 +65,89 @@ describe('useLoadDataStore', () => {
         })
     })
 
-    it('creates the namespace key exactly once and dispatches the result', async () => {
+    it('creates the namespace key once with defaults when the namespace is missing', async () => {
+        setupEngine({ namespaces: ['SOME_OTHER_APP'] })
         renderHook(() => useLoadDataStore())
 
-        await waitFor(() => expect(mockDispatch).toHaveBeenCalledTimes(1))
-
-        // Only one create mutation, no flood of racing creates
+        await waitFor(() =>
+            expect(mockDispatch).toHaveBeenCalledWith(
+                initLayerSources(defaultIds)
+            )
+        )
         expect(mockEngine.mutate).toHaveBeenCalledTimes(1)
         expect(mockEngine.mutate).toHaveBeenCalledWith(
-            expect.objectContaining({ type: 'create' })
+            expect.objectContaining({ type: 'create', data: defaultIds })
+        )
+    })
+
+    it('dispatches stored ids without mutating when there are no updates', async () => {
+        const stored = earthEngineLayersDefaultIds()
+        const expectedValidIds = earthEngineLayersIds().filter((id) =>
+            stored.includes(id)
+        )
+        setupEngine({ namespaces: [MAPS_APP_NAMESPACE], visibility: stored })
+        renderHook(() => useLoadDataStore())
+
+        await waitFor(() =>
+            expect(mockDispatch).toHaveBeenCalledWith(
+                initLayerSources(expectedValidIds)
+            )
+        )
+        expect(mockEngine.mutate).not.toHaveBeenCalled()
+    })
+
+    it('migrates and persists ids when stored ids are outdated', async () => {
+        const stored = Object.keys(earthEngineLayersUpdates)
+        const updatedIds = stored.map(
+            (id) => earthEngineLayersUpdates[id] || id
+        )
+        const expectedValidIds = earthEngineLayersIds().filter((id) =>
+            updatedIds.includes(id)
+        )
+        setupEngine({ namespaces: [MAPS_APP_NAMESPACE], visibility: stored })
+        renderHook(() => useLoadDataStore())
+
+        await waitFor(() =>
+            expect(mockDispatch).toHaveBeenCalledWith(
+                initLayerSources(expectedValidIds)
+            )
+        )
+        expect(mockEngine.mutate).toHaveBeenCalledTimes(1)
+        expect(mockEngine.mutate).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'update', data: expectedValidIds })
+        )
+    })
+
+    it('resets the key to defaults when stored value is not an array', async () => {
+        setupEngine({ namespaces: [MAPS_APP_NAMESPACE], visibility: {} })
+        renderHook(() => useLoadDataStore())
+
+        await waitFor(() =>
+            expect(mockDispatch).toHaveBeenCalledWith(
+                initLayerSources(defaultIds)
+            )
+        )
+        expect(mockEngine.mutate).toHaveBeenCalledTimes(1)
+        expect(mockEngine.mutate).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'update', data: defaultIds })
+        )
+    })
+
+    it('creates the key with defaults when the key query rejects', async () => {
+        setupEngine({
+            namespaces: [MAPS_APP_NAMESPACE],
+            visibilityRejects: true,
+        })
+        renderHook(() => useLoadDataStore())
+
+        await waitFor(() =>
+            expect(mockDispatch).toHaveBeenCalledWith(
+                initLayerSources(defaultIds)
+            )
+        )
+        expect(mockEngine.mutate).toHaveBeenCalledTimes(1)
+        expect(mockEngine.mutate).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'create', data: defaultIds })
         )
     })
 })

--- a/src/components/app/__tests__/useLoadDataStore.spec.js
+++ b/src/components/app/__tests__/useLoadDataStore.spec.js
@@ -1,0 +1,51 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { useLoadDataStore } from '../useLoadDataStore.js'
+
+const mockDispatch = jest.fn()
+let mockEngine
+
+jest.mock('react-redux', () => ({
+    useDispatch: () => mockDispatch,
+}))
+
+jest.mock('@dhis2/app-runtime', () => ({
+    useDataEngine: () => mockEngine,
+}))
+
+describe('useLoadDataStore', () => {
+    beforeEach(() => {
+        mockDispatch.mockClear()
+        mockEngine = {
+            // Namespace missing -> hook should create the key once
+            query: jest.fn().mockResolvedValue({ dataStore: [] }),
+            mutate: jest.fn().mockResolvedValue({}),
+        }
+    })
+
+    it('queries the datastore once on mount, not on every render', async () => {
+        const { rerender } = renderHook(() => useLoadDataStore())
+
+        // Force several re-renders, as App does on any redux state change
+        rerender()
+        rerender()
+        rerender()
+
+        // The regression: before the fix this fired on every render.
+        expect(mockEngine.query).toHaveBeenCalledTimes(1)
+        expect(mockEngine.query).toHaveBeenCalledWith({
+            dataStore: { resource: 'dataStore' },
+        })
+    })
+
+    it('creates the namespace key exactly once and dispatches the result', async () => {
+        renderHook(() => useLoadDataStore())
+
+        await waitFor(() => expect(mockDispatch).toHaveBeenCalledTimes(1))
+
+        // Only one create mutation, no flood of racing creates
+        expect(mockEngine.mutate).toHaveBeenCalledTimes(1)
+        expect(mockEngine.mutate).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'create' })
+        )
+    })
+})

--- a/src/components/app/useLoadDataStore.js
+++ b/src/components/app/useLoadDataStore.js
@@ -1,4 +1,5 @@
 import { useDataEngine } from '@dhis2/app-runtime'
+import { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import { initLayerSources } from '../../actions/layerSources.js'
 import {
@@ -28,34 +29,75 @@ export const useLoadDataStore = () => {
     const layerSourceDefaultIds = [...earthEngineLayersDefaultIds()]
     const dispatch = useDispatch()
     const engine = useDataEngine()
-    engine
-        .query({ dataStore: { resource: 'dataStore' } })
-        .then(({ dataStore }) => {
-            if (!dataStore.includes(MAPS_APP_NAMESPACE)) {
-                // Create namespace/key if missing in datastore
-                engine
-                    .mutate({
-                        resource: resourceLayerSourcesVisibility,
-                        type: 'create',
-                        data: layerSourceDefaultIds,
-                    })
-                    .then(() => {
-                        dispatch(initLayerSources(layerSourceDefaultIds))
-                    })
-            } else {
-                engine
-                    .query({
-                        layerSourcesVisibility: {
+
+    useEffect(() => {
+        engine
+            .query({ dataStore: { resource: 'dataStore' } })
+            .then(({ dataStore }) => {
+                if (!dataStore.includes(MAPS_APP_NAMESPACE)) {
+                    // Create namespace/key if missing in datastore
+                    engine
+                        .mutate({
                             resource: resourceLayerSourcesVisibility,
-                        },
-                    })
-                    .then(({ layerSourcesVisibility }) => {
-                        if (!Array.isArray(layerSourcesVisibility)) {
-                            // Reset namespace/key if integrity has been broken
+                            type: 'create',
+                            data: layerSourceDefaultIds,
+                        })
+                        .then(() => {
+                            dispatch(initLayerSources(layerSourceDefaultIds))
+                        })
+                } else {
+                    engine
+                        .query({
+                            layerSourcesVisibility: {
+                                resource: resourceLayerSourcesVisibility,
+                            },
+                        })
+                        .then(({ layerSourcesVisibility }) => {
+                            if (!Array.isArray(layerSourcesVisibility)) {
+                                // Reset namespace/key if integrity has been broken
+                                engine
+                                    .mutate({
+                                        resource:
+                                            resourceLayerSourcesVisibility,
+                                        type: 'update',
+                                        data: layerSourceDefaultIds,
+                                    })
+                                    .then(() => {
+                                        dispatch(
+                                            initLayerSources(
+                                                layerSourceDefaultIds
+                                            )
+                                        )
+                                    })
+                            } else {
+                                const { ids, changed } = applyUpdates(
+                                    layerSourcesVisibility
+                                )
+                                const validIds = earthEngineLayersIds().filter(
+                                    (id) => ids.includes(id)
+                                )
+                                if (changed) {
+                                    engine
+                                        .mutate({
+                                            resource:
+                                                resourceLayerSourcesVisibility,
+                                            type: 'update',
+                                            data: validIds,
+                                        })
+                                        .then(() => {
+                                            dispatch(initLayerSources(validIds))
+                                        })
+                                } else {
+                                    dispatch(initLayerSources(validIds))
+                                }
+                            }
+                        })
+                        .catch(() => {
+                            // Create key if missing in namespace
                             engine
                                 .mutate({
                                     resource: resourceLayerSourcesVisibility,
-                                    type: 'update',
+                                    type: 'create',
                                     data: layerSourceDefaultIds,
                                 })
                                 .then(() => {
@@ -63,43 +105,9 @@ export const useLoadDataStore = () => {
                                         initLayerSources(layerSourceDefaultIds)
                                     )
                                 })
-                        } else {
-                            const { ids, changed } = applyUpdates(
-                                layerSourcesVisibility
-                            )
-                            const validIds = earthEngineLayersIds().filter(
-                                (id) => ids.includes(id)
-                            )
-                            if (changed) {
-                                engine
-                                    .mutate({
-                                        resource:
-                                            resourceLayerSourcesVisibility,
-                                        type: 'update',
-                                        data: validIds,
-                                    })
-                                    .then(() => {
-                                        dispatch(initLayerSources(validIds))
-                                    })
-                            } else {
-                                dispatch(initLayerSources(validIds))
-                            }
-                        }
-                    })
-                    .catch(() => {
-                        // Create key if missing in namespace
-                        engine
-                            .mutate({
-                                resource: resourceLayerSourcesVisibility,
-                                type: 'create',
-                                data: layerSourceDefaultIds,
-                            })
-                            .then(() => {
-                                dispatch(
-                                    initLayerSources(layerSourceDefaultIds)
-                                )
-                            })
-                    })
-            }
-        })
+                        })
+                }
+            })
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
 }

--- a/src/components/app/useLoadDataStore.js
+++ b/src/components/app/useLoadDataStore.js
@@ -1,4 +1,5 @@
 import { useDataEngine } from '@dhis2/app-runtime'
+import log from 'loglevel'
 import { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
 import { initLayerSources } from '../../actions/layerSources.js'
@@ -31,6 +32,10 @@ export const useLoadDataStore = () => {
     const engine = useDataEngine()
 
     useEffect(() => {
+        // Guard against dispatching/mutating after unmount (and against
+        // React 18 StrictMode running the effect twice in development)
+        let cancelled = false
+
         // Write the default layer sources to the key and load them
         const resetToDefaults = async (type) => {
             await engine.mutate({
@@ -38,13 +43,19 @@ export const useLoadDataStore = () => {
                 type,
                 data: layerSourceDefaultIds,
             })
-            dispatch(initLayerSources(layerSourceDefaultIds))
+            if (!cancelled) {
+                dispatch(initLayerSources(layerSourceDefaultIds))
+            }
         }
 
         const loadDataStore = async () => {
             const { dataStore } = await engine.query({
                 dataStore: { resource: 'dataStore' },
             })
+
+            if (cancelled) {
+                return
+            }
 
             if (!dataStore.includes(MAPS_APP_NAMESPACE)) {
                 // Create namespace/key if missing in datastore
@@ -58,6 +69,10 @@ export const useLoadDataStore = () => {
                         resource: resourceLayerSourcesVisibility,
                     },
                 })
+
+                if (cancelled) {
+                    return
+                }
 
                 if (!Array.isArray(layerSourcesVisibility)) {
                     // Reset namespace/key if integrity has been broken
@@ -76,14 +91,22 @@ export const useLoadDataStore = () => {
                         data: validIds,
                     })
                 }
-                dispatch(initLayerSources(validIds))
+                if (!cancelled) {
+                    dispatch(initLayerSources(validIds))
+                }
             } catch {
                 // Create key if missing in namespace
                 await resetToDefaults('create')
             }
         }
 
-        loadDataStore()
+        loadDataStore().catch((error) =>
+            log.error('Failed to load managed layer sources', error)
+        )
+
+        return () => {
+            cancelled = true
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 }

--- a/src/components/app/useLoadDataStore.js
+++ b/src/components/app/useLoadDataStore.js
@@ -31,83 +31,59 @@ export const useLoadDataStore = () => {
     const engine = useDataEngine()
 
     useEffect(() => {
-        engine
-            .query({ dataStore: { resource: 'dataStore' } })
-            .then(({ dataStore }) => {
-                if (!dataStore.includes(MAPS_APP_NAMESPACE)) {
-                    // Create namespace/key if missing in datastore
-                    engine
-                        .mutate({
-                            resource: resourceLayerSourcesVisibility,
-                            type: 'create',
-                            data: layerSourceDefaultIds,
-                        })
-                        .then(() => {
-                            dispatch(initLayerSources(layerSourceDefaultIds))
-                        })
-                } else {
-                    engine
-                        .query({
-                            layerSourcesVisibility: {
-                                resource: resourceLayerSourcesVisibility,
-                            },
-                        })
-                        .then(({ layerSourcesVisibility }) => {
-                            if (!Array.isArray(layerSourcesVisibility)) {
-                                // Reset namespace/key if integrity has been broken
-                                engine
-                                    .mutate({
-                                        resource:
-                                            resourceLayerSourcesVisibility,
-                                        type: 'update',
-                                        data: layerSourceDefaultIds,
-                                    })
-                                    .then(() => {
-                                        dispatch(
-                                            initLayerSources(
-                                                layerSourceDefaultIds
-                                            )
-                                        )
-                                    })
-                            } else {
-                                const { ids, changed } = applyUpdates(
-                                    layerSourcesVisibility
-                                )
-                                const validIds = earthEngineLayersIds().filter(
-                                    (id) => ids.includes(id)
-                                )
-                                if (changed) {
-                                    engine
-                                        .mutate({
-                                            resource:
-                                                resourceLayerSourcesVisibility,
-                                            type: 'update',
-                                            data: validIds,
-                                        })
-                                        .then(() => {
-                                            dispatch(initLayerSources(validIds))
-                                        })
-                                } else {
-                                    dispatch(initLayerSources(validIds))
-                                }
-                            }
-                        })
-                        .catch(() => {
-                            // Create key if missing in namespace
-                            engine
-                                .mutate({
-                                    resource: resourceLayerSourcesVisibility,
-                                    type: 'create',
-                                    data: layerSourceDefaultIds,
-                                })
-                                .then(() => {
-                                    dispatch(
-                                        initLayerSources(layerSourceDefaultIds)
-                                    )
-                                })
-                        })
-                }
+        // Write the default layer sources to the key and load them
+        const resetToDefaults = async (type) => {
+            await engine.mutate({
+                resource: resourceLayerSourcesVisibility,
+                type,
+                data: layerSourceDefaultIds,
             })
+            dispatch(initLayerSources(layerSourceDefaultIds))
+        }
+
+        const loadDataStore = async () => {
+            const { dataStore } = await engine.query({
+                dataStore: { resource: 'dataStore' },
+            })
+
+            if (!dataStore.includes(MAPS_APP_NAMESPACE)) {
+                // Create namespace/key if missing in datastore
+                await resetToDefaults('create')
+                return
+            }
+
+            try {
+                const { layerSourcesVisibility } = await engine.query({
+                    layerSourcesVisibility: {
+                        resource: resourceLayerSourcesVisibility,
+                    },
+                })
+
+                if (!Array.isArray(layerSourcesVisibility)) {
+                    // Reset namespace/key if integrity has been broken
+                    await resetToDefaults('update')
+                    return
+                }
+
+                const { ids, changed } = applyUpdates(layerSourcesVisibility)
+                const validIds = earthEngineLayersIds().filter((id) =>
+                    ids.includes(id)
+                )
+                if (changed) {
+                    await engine.mutate({
+                        resource: resourceLayerSourcesVisibility,
+                        type: 'update',
+                        data: validIds,
+                    })
+                }
+                dispatch(initLayerSources(validIds))
+            } catch {
+                // Create key if missing in namespace
+                await resetToDefaults('create')
+            }
+        }
+
+        loadDataStore()
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 }

--- a/src/components/app/useLoadDataStore.js
+++ b/src/components/app/useLoadDataStore.js
@@ -95,8 +95,10 @@ export const useLoadDataStore = () => {
                     dispatch(initLayerSources(validIds))
                 }
             } catch {
-                // Create key if missing in namespace
-                await resetToDefaults('create')
+                if (!cancelled) {
+                    // Create key if missing in namespace
+                    await resetToDefaults('create')
+                }
             }
         }
 


### PR DESCRIPTION
_No Jira ticket — found during a repository bug-hunt._

### Description

`useLoadDataStore` issued its `dataStore` query — and the `create`/`update` mutations behind it — directly in the **render body** with no `useEffect`. Since the hook is called unconditionally from `App`, which re-renders on virtually every redux state change (data table toggle, panel open/close, interpretation render count, etc.), the datastore was re-queried on every interaction.

Worse, for a first-time user with an empty namespace, each render also fired an `engine.mutate({ type: 'create' })` before the previous one resolved — repeated racing `create` mutations against the same datastore key, which can produce 409s / race conditions.

**Fix:** wrap the logic in `useEffect(() => { ... }, [])` so it runs once on mount (matching how `useLoadMap` already works). `engine`/`dispatch` are stable references, so an empty dependency array correctly expresses "run once".

### Testing

Added `useLoadDataStore.spec.js`:
- Asserts the datastore is queried **once** across multiple re-renders (this fails against the pre-fix code — verified by reverting).
- Asserts the namespace key is created **exactly once**.

Both pass against the fix.

---

### Quality checklist

- [ ] Dashboard tested _N/A_
- [x] Cypress and/or Jest tests added/updated
- [ ] Docs added _N/A_
- [ ] d2-ci dependencies replaced _N/A_
- [x] Tester approved (BR)

---

AI Assisted