### PR TITLE
fix: fix memory leak in north arrow rotation

### DIFF
--- a/src/components/download/NorthArrow.jsx
+++ b/src/components/download/NorthArrow.jsx
@@ -25,7 +25,7 @@ const NorthArrow = ({
     useEffect(() => {
         map.on('rotate', onMapRotate)
         return () => {
-            map.on('rotate', onMapRotate)
+            map.off('rotate', onMapRotate)
         }
     }, [map, onMapRotate])
 


### PR DESCRIPTION
_No Jira ticket — found during a repository bug-hunt._

### Problem

`NorthArrow`'s `useEffect` cleanup called `map.on('rotate', onMapRotate)` instead of `map.off`, so every unmount/re-run **registered another** listener and removed none.

`NorthArrow` mounts/unmounts each time download mode (or the "Show north arrow" toggle) flips ([MapPosition.jsx:136](https://github.com/dhis2/maps-app/blob/master/src/components/map/MapPosition.jsx#L136)). As a result:

- `rotate` listeners accumulate on the shared map (`getMapGL()` instance) and are never released.
- `setRotation` keeps firing on unmounted components → React "setState on unmounted component" warnings and wasted work on every map rotation.

### Fix

One-line change in [NorthArrow.jsx:28](https://github.com/dhis2/maps-app/blob/master/src/components/download/NorthArrow.jsx#L28): `map.on` → `map.off` in the effect cleanup. This matches the established teardown pattern in sibling components (`OverviewMap.jsx`, `OverviewMapOutline.js`).

### Testing

Enter download mode with the north arrow enabled, exit, and repeat. Before: listener count grows each cycle and setState-on-unmounted warnings appear. After: listener is correctly removed on unmount.

---

AI Assisted