### PR TITLE
fix: prevent crash when loading map with external layer

### DIFF
--- a/src/util/__tests__/getMigratedMapConfig.spec.js
+++ b/src/util/__tests__/getMigratedMapConfig.spec.js
@@ -48,6 +48,46 @@ test('getMigratedMapConfig when basemap in mapViews', () => {
     )
 })
 
+test.each([
+    ['empty string config', ''],
+    ['missing config', undefined],
+    ['null config', null],
+    ['malformed config string', '{not valid json'],
+])(
+    'getMigratedMapConfig does not throw for external layer with %s',
+    (_label, externalConfig) => {
+        const config = {
+            id: 'mapId',
+            name: 'map name',
+            mapViews: [
+                { layer: 'external', config: externalConfig },
+                { layer: 'thematic', name: 'All the pretty colors' },
+            ],
+        }
+
+        let result
+        expect(() => {
+            result = getMigratedMapConfig(config, defaultBasemapId)
+        }).not.toThrow()
+
+        // The external view is not treated as a basemap, so it is retained
+        // and the default basemap is applied.
+        expect(result.basemap).toEqual({
+            id: defaultBasemapId,
+            opacity: 1,
+            isVisible: true,
+        })
+        expect(result.mapViews).toEqual([
+            { layer: 'external', config: externalConfig, isVisible: true },
+            {
+                layer: 'thematic',
+                name: 'All the pretty colors',
+                isVisible: true,
+            },
+        ])
+    }
+)
+
 test('getMigratedMapConfig when basemap is a string but not "none"', () => {
     const config = {
         id: 'mapId',

--- a/src/util/getMigratedMapConfig.js
+++ b/src/util/getMigratedMapConfig.js
@@ -9,7 +9,7 @@ export const getMigratedMapConfig = (config, defaultBasemapId) =>
 // Safely parse a mapView config, which may be empty, missing or malformed
 const safeParseConfig = (config) => {
     try {
-        // JSON.parse(null) yields null, JSON.parse('1') yields a number, etc.
+        // Guard against JSON.parse returning non-objects (null, numbers)
         const parsed = JSON.parse(config)
         return isObject(parsed) ? parsed : {}
     } catch {
@@ -41,6 +41,8 @@ const extractBasemap = (config, defaultBasemapId) => {
             basemap = { isVisible: false }
         } else {
             try {
+                // Not safeParseConfig: this branch recovers a malformed value
+                // as a plain basemap ID rather than falling back to {}
                 const { id, opacity, hidden } = JSON.parse(config.basemap)
                 basemap = { id, opacity, isVisible: !hidden }
             } catch {

--- a/src/util/getMigratedMapConfig.js
+++ b/src/util/getMigratedMapConfig.js
@@ -6,18 +6,29 @@ export const getMigratedMapConfig = (config, defaultBasemapId) =>
         upgradeGisAppLayers(extractBasemap(config, defaultBasemapId))
     )
 
+// Safely parse a mapView config, which may be empty, missing or malformed
+const safeParseConfig = (config) => {
+    try {
+        // JSON.parse(null) yields null, JSON.parse('1') yields a number, etc.
+        const parsed = JSON.parse(config)
+        return isObject(parsed) ? parsed : {}
+    } catch {
+        return {}
+    }
+}
+
 // Different ways of specifying a basemap
 const extractBasemap = (config, defaultBasemapId) => {
     const externalBasemap = config.mapViews.find(
         (view) =>
             view.layer === EXTERNAL_LAYER &&
-            JSON.parse(view.config || {}).mapLayerPosition === 'BASEMAP'
+            safeParseConfig(view.config).mapLayerPosition === 'BASEMAP'
     )
     let basemap
     let mapViews = config.mapViews
 
     if (externalBasemap) {
-        basemap = JSON.parse(externalBasemap.config)
+        basemap = safeParseConfig(externalBasemap.config)
         mapViews = config.mapViews.filter(
             (view) => view.id !== externalBasemap.id
         )


### PR DESCRIPTION
_No Jira ticket — found during a repository bug-hunt._

### Problem

Opening a saved map fails with a generic `Could not load map with id "…"` error when the map contains an **external-layer view whose `config` is empty, missing, or `null`**.

`getMigratedMapConfig` parsed the external layer config as:

```js
JSON.parse(view.config || {})
```

When `view.config` is falsy, the fallback is the **object** `{}` (not the string `'{}'`). `JSON.parse` coerces its argument to a string, so this becomes `JSON.parse("[object Object]")` → `SyntaxError`. The throw propagates through `fetchMap` and fails the entire map load — in both the app and the map plugin (`MapContainer.jsx`).

Unlike the basemap-string parse further down, this parse was unguarded.

### Fix

Introduce a `safeParseConfig` helper that returns `{}` on any parse failure, and route both external-layer parses through it.

The helper also coalesces non-object results to `{}`. This catches a second latent edge: `JSON.parse(null)` does **not** throw — it returns `null` — which would otherwise still crash on the downstream `.mapLayerPosition` access. A try/catch alone would not have been enough.

### Tests

Added a parameterized regression test covering external-layer views with empty-string, missing, `null`, and malformed-string configs — asserting the map migrates without throwing and the external view is retained (not mistaken for a basemap) with the default basemap applied.

All `getMigratedMapConfig` tests pass (19 total) and ESLint is clean.

---

AI Assisted
