### PR TITLE
fix: stop flooding logs with warnings when opening the Data dimension panel [DHIS2-20499]

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "start-server-and-test": "^2.1.3"
     },
     "dependencies": {
-        "@dhis2/analytics": "^29.5.4",
+        "@dhis2/analytics": "^29.5.5",
         "@dhis2/app-runtime": "^3.14.4",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",
         "@dhis2/maps-gl": "^4.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2144,10 +2144,10 @@
     classnames "^2.3.1"
     prop-types "^15.7.2"
 
-"@dhis2/analytics@^29.5.4":
-  version "29.5.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-29.5.4.tgz#e7dc9a11f634c4ee50d0866aacc801b31b621808"
-  integrity sha512-qQj4rLLdJLJLTp6ByG2P/XAtjeZq/5AquQErZR4CCe474vVcr4UVQ+h2rsRqHBj9EpYUAXr5kkCD5mQbPXqthQ==
+"@dhis2/analytics@^29.5.5":
+  version "29.5.5"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-29.5.5.tgz#7251df2e21996bec222718daf219bc4c9e185226"
+  integrity sha512-WuQe3EgUukLx9ZlO8/67LAAaBM0Lhy3IGtQrAh3Cq1VAZfX/FfmVNydeFJh77CSBvCOVnM7o36ngsQ+fL6aEBA==
   dependencies:
     "@dhis2/multi-calendar-dates" "^1.2.2"
     "@dnd-kit/core" "^6.0.7"


### PR DESCRIPTION
Implements [DHIS2-20499](https://dhis2.atlassian.net/browse/DHIS2-20499)

### Description

https://github.com/dhis2/analytics/pull/1839

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested _N/A_
- [ ] Cypress and/or Jest tests added/updated _N/A_
- [ ] Docs added _N/A_
- [x] d2-ci dependencies replaced (https://github.com/dhis2/analytics/pull/1839)
- [x] Tester approved (BR)

[DHIS2-20499]: https://dhis2.atlassian.net/browse/DHIS2-20499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ