### PR TITLE
chore: fix Cypress flakiness from shared live-instance state

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -4,6 +4,10 @@ const {
     downloadedFileTasks,
 } = require('./cypress/plugins/downloadedFileTasks.js')
 const {
+    createReplicaAccountForRun,
+    deleteReplicaAccount,
+} = require('./cypress/plugins/e2eReplicaAccount.js')
+const {
     excludeByVersionTags,
 } = require('./cypress/plugins/excludeByVersionTags.js')
 
@@ -22,6 +26,29 @@ async function setupNodeEvents(on, config) {
     if (!config.env.dhis2InstanceVersion) {
         throw new Error(
             'dhis2InstanceVersion is missing. Check the README for more information.'
+        )
+    }
+
+    config.env.useReplicaAccount = !!process.env.CI
+
+    if (config.env.useReplicaAccount) {
+        const { username, password, replicaUserId } =
+            await createReplicaAccountForRun({
+                baseUrl: config.env.dhis2BaseUrl,
+                username: config.env.dhis2Username,
+                password: config.env.dhis2Password,
+            })
+
+        config.env.replicaUsername = username
+        config.env.replicaPassword = password
+
+        on('after:run', () =>
+            deleteReplicaAccount({
+                baseUrl: config.env.dhis2BaseUrl,
+                username: config.env.dhis2Username,
+                password: config.env.dhis2Password,
+                replicaUserId,
+            })
         )
     }
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -32,24 +32,31 @@ async function setupNodeEvents(on, config) {
     config.env.useReplicaAccount = !!process.env.CI
 
     if (config.env.useReplicaAccount) {
-        const { username, password, replicaUserId } =
-            await createReplicaAccountForRun({
-                baseUrl: config.env.dhis2BaseUrl,
-                username: config.env.dhis2Username,
-                password: config.env.dhis2Password,
-            })
+        try {
+            const { username, password, replicaUserId } =
+                await createReplicaAccountForRun({
+                    baseUrl: config.env.dhis2BaseUrl,
+                    username: config.env.dhis2Username,
+                    password: config.env.dhis2Password,
+                })
 
-        config.env.replicaUsername = username
-        config.env.replicaPassword = password
+            config.env.replicaUsername = username
+            config.env.replicaPassword = password
 
-        on('after:run', () =>
-            deleteReplicaAccount({
-                baseUrl: config.env.dhis2BaseUrl,
-                username: config.env.dhis2Username,
-                password: config.env.dhis2Password,
-                replicaUserId,
-            })
-        )
+            on('after:run', () =>
+                deleteReplicaAccount({
+                    baseUrl: config.env.dhis2BaseUrl,
+                    username: config.env.dhis2Username,
+                    password: config.env.dhis2Password,
+                    replicaUserId,
+                })
+            )
+        } catch (error) {
+            console.warn(
+                `WARNING: could not create e2e replica account, falling back to the standard account: ${error.message}`
+            )
+            config.env.useReplicaAccount = false
+        }
     }
 
     return config

--- a/cypress/integration/filemenu.cy.js
+++ b/cypress/integration/filemenu.cy.js
@@ -9,9 +9,9 @@ import {
 } from '../elements/file_menu.js'
 import { Layer as OrgUnitLayer } from '../elements/layer.js'
 import { ThematicLayer } from '../elements/thematic_layer.js'
-import { EXTENDED_TIMEOUT } from '../support/util.js'
+import { EXTENDED_TIMEOUT, uniqueId } from '../support/util.js'
 
-const MAP_TITLE = 'test ' + new Date().toUTCString().slice(-24, -4)
+const MAP_TITLE = 'test ' + uniqueId()
 const SAVEAS_MAP_TITLE = `${MAP_TITLE}-2`
 
 describe('File menu', () => {
@@ -70,7 +70,7 @@ describe('File menu', () => {
         cy.visit('/', EXTENDED_TIMEOUT)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
-        const title = 'test ' + new Date().toUTCString().slice(-24, -4)
+        const title = 'test ' + uniqueId()
         const renamedTitle = `renamed ${title}`
 
         createMap(title)
@@ -123,9 +123,8 @@ describe('File menu', () => {
         cy.visit('/', EXTENDED_TIMEOUT)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
-        const title = 'test ' + new Date().toUTCString().slice(-24, -4)
-        const renamedTitle =
-            'renamed ' + new Date().toUTCString().slice(-24, -4)
+        const title = 'test ' + uniqueId()
+        const renamedTitle = 'renamed ' + uniqueId()
 
         createMap(title)
         const description = 'this is the explanation of the map'

--- a/cypress/integration/interpretations.cy.js
+++ b/cypress/integration/interpretations.cy.js
@@ -1,8 +1,8 @@
 import { saveNewMap, deleteMap } from '../elements/file_menu.js'
 import { ThematicLayer } from '../elements/thematic_layer.js'
-import { EXTENDED_TIMEOUT } from '../support/util.js'
+import { EXTENDED_TIMEOUT, uniqueId } from '../support/util.js'
 
-const MAP_TITLE = 'test ' + new Date().toUTCString().slice(-24, -4)
+const MAP_TITLE = 'test ' + uniqueId()
 context('Interpretations', () => {
     it('opens the interpretations panel for a map', () => {
         cy.visit('/#/ZBjCfSaLSqD', EXTENDED_TIMEOUT)

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -12,6 +12,7 @@ import {
     getApiBaseUrl,
     EXTENDED_TIMEOUT,
     POPUP_WAIT,
+    uniqueId,
 } from '../../support/util.js'
 
 const HIV_INDICATOR_GROUP = 'HIV'
@@ -728,8 +729,7 @@ context('Thematic Layers', () => {
 
     // TODO - update demo database with calculations instead of creating on the fly
     it('adds a thematic layer with a calculation', () => {
-        const timestamp = new Date().toUTCString().slice(-24, -4)
-        const calculationName = `map calc ${timestamp}`
+        const calculationName = `map calc ${uniqueId()}`
 
         // add a calculation
         cy.request('POST', `${getApiBaseUrl()}/api/expressionDimensionItems`, {

--- a/cypress/integration/manageLayerSources.cy.js
+++ b/cypress/integration/manageLayerSources.cy.js
@@ -90,17 +90,29 @@ describe('Manage Layer Sources', () => {
                 .should(assertion)
         })
 
-        // Replace dataStore with default layer sources visibility list
-        cy.request({
-            method: 'PUT',
-            url: `${getApiBaseUrl()}/api/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
-            headers: {
-                'Content-Type': 'application/json;charset=UTF-8',
-            },
-            body: LAYER_SOURCES_DEFAULT_MANAGED_LIST,
-        }).then((response) => {
-            expect(response.status).to.eq(200)
-        })
+        let managedList = [...LAYER_SOURCES_DEFAULT_MANAGED_LIST]
+        cy.intercept(
+            'GET',
+            `**/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
+            (req) => req.reply(managedList)
+        ).as('getManagedList')
+
+        cy.intercept(
+            'PUT',
+            `**/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
+            (req) => {
+                managedList = req.body
+                req.reply({
+                    statusCode: 200,
+                    body: {
+                        httpStatus: 'OK',
+                        httpStatusCode: 200,
+                        status: 'OK',
+                        message: "Key updated: 'MANAGED_LAYER_SOURCES'",
+                    },
+                })
+            }
+        ).as('putManagedList')
 
         // Visit page
         cy.visit('/', EXTENDED_TIMEOUT)
@@ -156,18 +168,6 @@ describe('Manage Layer Sources', () => {
         cy.getByDataTest('managelayersources-button').click()
         cy.waitForCheckbox(0, 'be.checked')
         cy.getByDataTest('managelayersourcesmodal-button').click()
-
-        // Restore dataStore with default layer sources visibility list
-        cy.request({
-            method: 'PUT',
-            url: `${getApiBaseUrl()}/api/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
-            headers: {
-                'Content-Type': 'application/json;charset=UTF-8',
-            },
-            body: LAYER_SOURCES_DEFAULT_MANAGED_LIST,
-        }).then((response) => {
-            expect(response.status).to.eq(200)
-        })
     })
 
     it('w/o admin authority: check managelayersources button is hidden', () => {
@@ -187,17 +187,11 @@ describe('Manage Layer Sources', () => {
             }
         ).as('getAuthorization')
 
-        // Replace dataStore with default layer sources visibility list -1
-        cy.request({
-            method: 'PUT',
-            url: `${getApiBaseUrl()}/api/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
-            headers: {
-                'Content-Type': 'application/json;charset=UTF-8',
-            },
-            body: LAYER_SOURCES_DEFAULT_MANAGED_LIST.slice(0, -1),
-        }).then((response) => {
-            expect(response.status).to.eq(200)
-        })
+        cy.intercept(
+            'GET',
+            `**/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
+            (req) => req.reply(LAYER_SOURCES_DEFAULT_MANAGED_LIST.slice(0, -1))
+        ).as('getManagedListTrimmed')
 
         // Visit page
         cy.visit('/', EXTENDED_TIMEOUT)
@@ -217,18 +211,6 @@ describe('Manage Layer Sources', () => {
 
             // Checks that manage layers modal is not accessible
             cy.getByDataTest('managelayers-button').should('not.exist')
-        })
-
-        // Restore dataStore with default layer sources visibility list
-        cy.request({
-            method: 'PUT',
-            url: `${getApiBaseUrl()}/api/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
-            headers: {
-                'Content-Type': 'application/json;charset=UTF-8',
-            },
-            body: LAYER_SOURCES_DEFAULT_MANAGED_LIST,
-        }).then((response) => {
-            expect(response.status).to.eq(200)
         })
     })
 
@@ -315,16 +297,14 @@ describe('Manage Layer Sources', () => {
     })
 
     it('at start, if "invalid_source_id" in namespace, app ignores id', () => {
-        // Mock "invalid_source_id" in namespace
         cy.intercept(
             'GET',
             `**/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
-            (request) => {
-                delete request.headers['if-none-match']
-                request.continue((response) => {
-                    response.send([...response.body, 'invalid_source_id'])
-                })
-            }
+            (req) =>
+                req.reply([
+                    ...LAYER_SOURCES_DEFAULT_MANAGED_LIST,
+                    'invalid_source_id',
+                ])
         ).as('getNamespaceArray')
 
         // Visit page

--- a/cypress/plugins/e2eReplicaAccount.js
+++ b/cypress/plugins/e2eReplicaAccount.js
@@ -1,6 +1,8 @@
+const crypto = require('node:crypto')
+
 const MAX_REPLICA_CREATE_ATTEMPTS = 3
 
-const uniqueId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+const uniqueId = () => `${Date.now()}-${crypto.randomBytes(4).toString('hex')}`
 
 const dhis2Fetch = async (
     baseUrl,
@@ -32,7 +34,7 @@ const dhis2Fetch = async (
 }
 
 const createReplicaUser = async ({ baseUrl, adminId, auth }, attempt = 1) => {
-    const username = `e2e_${uniqueId().replace(/-/g, '_')}`
+    const username = `e2e_${uniqueId().replaceAll('-', '_')}`
     const password = `Aa1!${uniqueId()}`
 
     await dhis2Fetch(baseUrl, `/api/users/${adminId}/replica`, {

--- a/cypress/plugins/e2eReplicaAccount.js
+++ b/cypress/plugins/e2eReplicaAccount.js
@@ -1,0 +1,94 @@
+const MAX_REPLICA_CREATE_ATTEMPTS = 3
+
+const uniqueId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
+const dhis2Fetch = async (
+    baseUrl,
+    path,
+    { method = 'GET', auth, body, qs } = {}
+) => {
+    const url = new URL(`${baseUrl}${path}`)
+    if (qs) {
+        Object.entries(qs).forEach(([key, value]) =>
+            url.searchParams.set(key, value)
+        )
+    }
+
+    const headers = { 'Content-Type': 'application/json' }
+    if (auth) {
+        headers.Authorization = `Basic ${Buffer.from(
+            `${auth.username}:${auth.password}`
+        ).toString('base64')}`
+    }
+
+    const response = await fetch(url, {
+        method,
+        headers,
+        body: body ? JSON.stringify(body) : undefined,
+    })
+    const responseBody = await response.json().catch(() => null)
+
+    return { status: response.status, body: responseBody }
+}
+
+const createReplicaUser = async ({ baseUrl, adminId, auth }, attempt = 1) => {
+    const username = `e2e_${uniqueId().replace(/-/g, '_')}`
+    const password = `Aa1!${uniqueId()}`
+
+    await dhis2Fetch(baseUrl, `/api/users/${adminId}/replica`, {
+        method: 'POST',
+        auth,
+        body: { username, password },
+    })
+
+    const lookup = await dhis2Fetch(baseUrl, '/api/users', {
+        auth,
+        qs: { filter: `username:eq:${username}`, fields: 'id' },
+    })
+    const replicaUserId = lookup.body?.users?.[0]?.id
+
+    if (replicaUserId) {
+        return { username, password, replicaUserId }
+    }
+    if (attempt >= MAX_REPLICA_CREATE_ATTEMPTS) {
+        throw new Error(
+            `Failed to create e2e replica user after ${attempt} attempts (last tried '${username}')`
+        )
+    }
+
+    return createReplicaUser({ baseUrl, adminId, auth }, attempt + 1)
+}
+
+const createReplicaAccountForRun = async ({ baseUrl, username, password }) => {
+    const auth = { username, password }
+    const me = await dhis2Fetch(baseUrl, '/api/me', { auth })
+    const adminId = me.body?.id
+
+    if (!adminId) {
+        throw new Error(
+            'Could not resolve the admin user id for e2e replica account creation'
+        )
+    }
+
+    return createReplicaUser({ baseUrl, adminId, auth })
+}
+
+const deleteReplicaAccount = async ({
+    baseUrl,
+    username,
+    password,
+    replicaUserId,
+}) => {
+    const response = await dhis2Fetch(baseUrl, `/api/users/${replicaUserId}`, {
+        method: 'DELETE',
+        auth: { username, password },
+    })
+
+    if (response.status < 200 || response.status >= 300) {
+        console.warn(
+            `WARNING: failed to delete e2e replica user ${replicaUserId} (status ${response.status}) - it may need manual cleanup`
+        )
+    }
+}
+
+module.exports = { createReplicaAccountForRun, deleteReplicaAccount }

--- a/cypress/plugins/e2eReplicaAccount.js
+++ b/cypress/plugins/e2eReplicaAccount.js
@@ -34,7 +34,7 @@ const dhis2Fetch = async (
 }
 
 const createReplicaUser = async ({ baseUrl, adminId, auth }, attempt = 1) => {
-    const username = `e2e_${uniqueId().replaceAll('-', '_')}`
+    const username = `e2e_mapsapp_${uniqueId().replaceAll('-', '_')}`
     const password = `Aa1!${uniqueId()}`
 
     await dhis2Fetch(baseUrl, `/api/users/${adminId}/replica`, {

--- a/cypress/plugins/e2eReplicaAccount.js
+++ b/cypress/plugins/e2eReplicaAccount.js
@@ -1,8 +1,12 @@
 const crypto = require('node:crypto')
 
 const MAX_REPLICA_CREATE_ATTEMPTS = 3
+const MAX_REPLICA_DELETE_ATTEMPTS = 3
+const REPLICA_DELETE_RETRY_DELAY_MS = 3000
 
 const uniqueId = () => `${Date.now()}-${crypto.randomBytes(4).toString('hex')}`
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 const dhis2Fetch = async (
     baseUrl,
@@ -75,22 +79,31 @@ const createReplicaAccountForRun = async ({ baseUrl, username, password }) => {
     return createReplicaUser({ baseUrl, adminId, auth })
 }
 
-const deleteReplicaAccount = async ({
-    baseUrl,
-    username,
-    password,
-    replicaUserId,
-}) => {
+const deleteReplicaAccount = async (
+    { baseUrl, username, password, replicaUserId },
+    attempt = 1
+) => {
     const response = await dhis2Fetch(baseUrl, `/api/users/${replicaUserId}`, {
         method: 'DELETE',
         auth: { username, password },
     })
 
-    if (response.status < 200 || response.status >= 300) {
-        console.warn(
-            `WARNING: failed to delete e2e replica user ${replicaUserId} (status ${response.status}) - it may need manual cleanup`
+    if (response.status >= 200 && response.status < 300) {
+        return
+    }
+
+    if (attempt < MAX_REPLICA_DELETE_ATTEMPTS) {
+        await wait(REPLICA_DELETE_RETRY_DELAY_MS)
+        return deleteReplicaAccount(
+            { baseUrl, username, password, replicaUserId },
+            attempt + 1
         )
     }
+
+    console.warn(
+        `WARNING: failed to delete e2e replica user ${replicaUserId} after ${attempt} attempts (status ${response.status}) - it may need manual cleanup`,
+        JSON.stringify(response.body)
+    )
 }
 
 module.exports = { createReplicaAccountForRun, deleteReplicaAccount }

--- a/cypress/plugins/e2eReplicaAccount.js
+++ b/cypress/plugins/e2eReplicaAccount.js
@@ -7,12 +7,10 @@
  * (the backend plausibly still starting up); a 4xx is definitive and fails
  * immediately instead of retrying.
  *
- * createReplicaUser is a single attempt once the backend is confirmed ready
- * - it either works or it doesn't.
+ * createReplicaUser is a single request; a failure throws.
  *
- * deleteReplicaAccount retries with backoff: reproduced directly against the
- * live test instance, some deletion failures are transient and resolve given
- * time, which a single attempt can't take advantage of.
+ * deleteReplicaAccount is a single request; a failure is logged as a
+ * warning and left for manual or nightly cleanup.
  *
  * If account creation fails outright, cypress.config.js catches it and falls
  * back to running the job under the standard shared account instead of
@@ -22,8 +20,6 @@ const crypto = require('node:crypto')
 
 const MAX_BACKEND_READY_ATTEMPTS = 5
 const BACKEND_READY_RETRY_DELAY_MS = 3000
-const MAX_REPLICA_DELETE_ATTEMPTS = 3
-const REPLICA_DELETE_RETRY_DELAY_MS = 3000
 
 const uniqueId = () => `${Date.now()}-${crypto.randomBytes(4).toString('hex')}`
 
@@ -125,41 +121,24 @@ const createReplicaAccountForRun = async ({ baseUrl, username, password }) => {
     return createReplicaUser({ baseUrl, adminId, auth })
 }
 
-const deleteReplicaAccount = async (
-    { baseUrl, username, password, replicaUserId },
-    attempt = 1
-) => {
+const deleteReplicaAccount = async ({
+    baseUrl,
+    username,
+    password,
+    replicaUserId,
+}) => {
     const response = await dhis2Fetch(baseUrl, `/api/users/${replicaUserId}`, {
         method: 'DELETE',
         auth: { username, password },
     })
 
     if (response.status >= 200 && response.status < 300) {
-        if (attempt > 1) {
-            console.log(
-                `Deleted e2e replica user ${replicaUserId} on attempt ${attempt} after ${
-                    attempt - 1
-                } prior failure(s)`
-            )
-        }
         return
     }
 
     console.warn(
-        `WARNING: attempt ${attempt}/${MAX_REPLICA_DELETE_ATTEMPTS} to delete e2e replica user ${replicaUserId} failed (status ${response.status})`,
+        `WARNING: failed to delete e2e replica user ${replicaUserId} (status ${response.status}) - it may need manual cleanup`,
         JSON.stringify(response.body)
-    )
-
-    if (attempt < MAX_REPLICA_DELETE_ATTEMPTS) {
-        await wait(REPLICA_DELETE_RETRY_DELAY_MS)
-        return deleteReplicaAccount(
-            { baseUrl, username, password, replicaUserId },
-            attempt + 1
-        )
-    }
-
-    console.warn(
-        `WARNING: e2e replica user ${replicaUserId} could not be deleted after ${attempt} attempts - it may need manual cleanup`
     )
 }
 

--- a/cypress/plugins/e2eReplicaAccount.js
+++ b/cypress/plugins/e2eReplicaAccount.js
@@ -1,6 +1,27 @@
+/*
+ * Creates a per-CI-job replica admin user at run start and deletes it at run
+ * end, so parallel jobs against the same shared DHIS2 instance don't collide
+ * on a single shared account. Username embeds the CI run id for traceability.
+ *
+ * waitForBackendReady retries only network-level failures or 5xx responses
+ * (the backend plausibly still starting up); a 4xx is definitive and fails
+ * immediately instead of retrying.
+ *
+ * createReplicaUser is a single attempt once the backend is confirmed ready
+ * - it either works or it doesn't.
+ *
+ * deleteReplicaAccount retries with backoff: reproduced directly against the
+ * live test instance, some deletion failures are transient and resolve given
+ * time, which a single attempt can't take advantage of.
+ *
+ * If account creation fails outright, cypress.config.js catches it and falls
+ * back to running the job under the standard shared account instead of
+ * failing the whole run.
+ */
 const crypto = require('node:crypto')
 
-const MAX_REPLICA_CREATE_ATTEMPTS = 3
+const MAX_BACKEND_READY_ATTEMPTS = 5
+const BACKEND_READY_RETRY_DELAY_MS = 3000
 const MAX_REPLICA_DELETE_ATTEMPTS = 3
 const REPLICA_DELETE_RETRY_DELAY_MS = 3000
 
@@ -27,18 +48,27 @@ const dhis2Fetch = async (
         ).toString('base64')}`
     }
 
-    const response = await fetch(url, {
-        method,
-        headers,
-        body: body ? JSON.stringify(body) : undefined,
-    })
-    const responseBody = await response.json().catch(() => null)
+    try {
+        const response = await fetch(url, {
+            method,
+            headers,
+            body: body ? JSON.stringify(body) : undefined,
+        })
+        const responseBody = await response.json().catch(() => null)
 
-    return { status: response.status, body: responseBody }
+        return { status: response.status, body: responseBody }
+    } catch (error) {
+        return { status: 0, body: { message: error.message } }
+    }
 }
 
-const createReplicaUser = async ({ baseUrl, adminId, auth }, attempt = 1) => {
-    const username = `e2e_mapsapp_${uniqueId().replaceAll('-', '_')}`
+const buildReplicaUsername = () =>
+    `e2e_mapsapp_run${
+        process.env.GITHUB_RUN_ID ?? 'local'
+    }_${uniqueId().replaceAll('-', '_')}`
+
+const createReplicaUser = async ({ baseUrl, adminId, auth }) => {
+    const username = buildReplicaUsername()
     const password = `Aa1!${uniqueId()}`
 
     await dhis2Fetch(baseUrl, `/api/users/${adminId}/replica`, {
@@ -53,20 +83,36 @@ const createReplicaUser = async ({ baseUrl, adminId, auth }, attempt = 1) => {
     })
     const replicaUserId = lookup.body?.users?.[0]?.id
 
-    if (replicaUserId) {
-        return { username, password, replicaUserId }
-    }
-    if (attempt >= MAX_REPLICA_CREATE_ATTEMPTS) {
+    if (!replicaUserId) {
         throw new Error(
-            `Failed to create e2e replica user after ${attempt} attempts (last tried '${username}')`
+            `Failed to create e2e replica user '${username}' - lookup did not find it after creation`
         )
     }
 
-    return createReplicaUser({ baseUrl, adminId, auth }, attempt + 1)
+    return { username, password, replicaUserId }
+}
+
+const waitForBackendReady = async ({ baseUrl, auth }, attempt = 1) => {
+    const response = await dhis2Fetch(baseUrl, '/api/system/info', { auth })
+
+    if (response.status >= 200 && response.status < 300) {
+        return
+    }
+
+    const isRetryable = response.status === 0 || response.status >= 500
+    if (!isRetryable || attempt >= MAX_BACKEND_READY_ATTEMPTS) {
+        throw new Error(
+            `Backend at ${baseUrl} is not ready (status ${response.status}, attempt ${attempt})`
+        )
+    }
+
+    await wait(BACKEND_READY_RETRY_DELAY_MS)
+    return waitForBackendReady({ baseUrl, auth }, attempt + 1)
 }
 
 const createReplicaAccountForRun = async ({ baseUrl, username, password }) => {
     const auth = { username, password }
+    await waitForBackendReady({ baseUrl, auth })
     const me = await dhis2Fetch(baseUrl, '/api/me', { auth })
     const adminId = me.body?.id
 
@@ -89,8 +135,20 @@ const deleteReplicaAccount = async (
     })
 
     if (response.status >= 200 && response.status < 300) {
+        if (attempt > 1) {
+            console.log(
+                `Deleted e2e replica user ${replicaUserId} on attempt ${attempt} after ${
+                    attempt - 1
+                } prior failure(s)`
+            )
+        }
         return
     }
+
+    console.warn(
+        `WARNING: attempt ${attempt}/${MAX_REPLICA_DELETE_ATTEMPTS} to delete e2e replica user ${replicaUserId} failed (status ${response.status})`,
+        JSON.stringify(response.body)
+    )
 
     if (attempt < MAX_REPLICA_DELETE_ATTEMPTS) {
         await wait(REPLICA_DELETE_RETRY_DELAY_MS)
@@ -101,8 +159,7 @@ const deleteReplicaAccount = async (
     }
 
     console.warn(
-        `WARNING: failed to delete e2e replica user ${replicaUserId} after ${attempt} attempts (status ${response.status}) - it may need manual cleanup`,
-        JSON.stringify(response.body)
+        `WARNING: e2e replica user ${replicaUserId} could not be deleted after ${attempt} attempts - it may need manual cleanup`
     )
 }
 

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -36,8 +36,6 @@ const findSessionCookieForBaseUrl = (baseUrl, cookies) =>
     )
 
 before(() => {
-    const username = Cypress.env('dhis2Username')
-    const password = Cypress.env('dhis2Password')
     const baseUrl = Cypress.env('dhis2BaseUrl')
     const instanceVersion = Cypress.env('dhis2InstanceVersion')
     const hideRequestsFromLog = Cypress.env('hideRequestsFromLog')
@@ -46,6 +44,13 @@ before(() => {
         // disable Cypress's default behavior of logging all XMLHttpRequests and fetches
         cy.intercept({ resourceType: /xhr|fetch/ }, { log: false })
     }
+
+    const username = Cypress.env('useReplicaAccount')
+        ? Cypress.env('replicaUsername')
+        : Cypress.env('dhis2Username')
+    const password = Cypress.env('useReplicaAccount')
+        ? Cypress.env('replicaPassword')
+        : Cypress.env('dhis2Password')
 
     cy.loginByApi({ username, password, baseUrl })
         .its('status')
@@ -68,7 +73,7 @@ before(() => {
 
     cy.request({
         method: 'GET',
-        url: `${Cypress.env('dhis2BaseUrl')}/api/system/info?fields=version`,
+        url: `${baseUrl}/api/system/info?fields=version`,
     }).then(({ body: { version } }) => {
         const match = version.match(
             /^(\d+)\.(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([\w.]+))?$/

--- a/cypress/support/util.js
+++ b/cypress/support/util.js
@@ -3,8 +3,12 @@ export const POPUP_WAIT = 2500
 
 export const CURRENT_YEAR = new Date().getFullYear()
 
-export const uniqueId = () =>
-    `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+const randomHex = (byteLength) =>
+    Array.from(crypto.getRandomValues(new Uint8Array(byteLength)))
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('')
+
+export const uniqueId = () => `${Date.now()}-${randomHex(4)}`
 
 export const getApiBaseUrl = () => {
     const baseUrl = Cypress.env('dhis2BaseUrl') || ''

--- a/cypress/support/util.js
+++ b/cypress/support/util.js
@@ -3,6 +3,9 @@ export const POPUP_WAIT = 2500
 
 export const CURRENT_YEAR = new Date().getFullYear()
 
+export const uniqueId = () =>
+    `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
 export const getApiBaseUrl = () => {
     const baseUrl = Cypress.env('dhis2BaseUrl') || ''
 


### PR DESCRIPTION
Two sources of flakiness from parallel E2E runs sharing one live DHIS2 instance: (1) all shards authenticating as the same admin user, now replaced with a dedicated replica user created per CI run; (2) tests mutating a real shared dataStore key for setup/teardown, now mocked via `cy.intercept()` so parallel runs can't race on it. Plus a small SonarQube cleanup on the new replica-account plugin.