### PR TITLE
chore: remove arbitrary cy.wait calls from Cypress tests

### DIFF
--- a/.github/workflows/dhis2-preview-pr.yml
+++ b/.github/workflows/dhis2-preview-pr.yml
@@ -34,7 +34,7 @@ jobs:
 
             - name: Deploy
               id: netlify-deploy
-              uses: nwtgck/actions-netlify@v3
+              uses: nwtgck/actions-netlify@v4
               timeout-minutes: 1
               with:
                   github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/dhis2-preview-pr.yml
+++ b/.github/workflows/dhis2-preview-pr.yml
@@ -24,6 +24,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: 20.x
+                  cache: 'yarn'
 
             - name: Install
               run: yarn install --frozen-lockfile

--- a/.github/workflows/dhis2-preview-pr.yml
+++ b/.github/workflows/dhis2-preview-pr.yml
@@ -20,8 +20,8 @@ jobs:
         runs-on: ubuntu-latest
         if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v7
               with:
                   node-version: 20.x
                   cache: 'yarn'

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -43,6 +43,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: 20.x
+                  cache: 'yarn'
             - name: Install
               run: yarn install --frozen-lockfile
 
@@ -65,6 +66,7 @@ jobs:
                   CI: true
                   BROWSER: none
                   CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+                  CYPRESS_VIDEO: ${{ env.SHOULD_RECORD }}
                   CYPRESS_dhis2BaseUrl: ${{ env.DEV_URL }}
                   CYPRESS_dhis2InstanceVersion: ${{ env.API_VERSION }}
                   CYPRESS_dhis2Username: ${{ secrets.CYPRESS_DHIS2_USERNAME }}

--- a/.github/workflows/e2e-dev.yml
+++ b/.github/workflows/e2e-dev.yml
@@ -25,7 +25,7 @@ jobs:
         outputs:
             matrix: ${{ steps.set-matrix.outputs.specs }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Generate Test matrix
               id: set-matrix
               run: echo "::set-output name=specs::$(node cypress/support/generateTestMatrix.js)"
@@ -39,8 +39,8 @@ jobs:
             matrix:
                 spec-group: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v7
               with:
                   node-version: 20.x
                   cache: 'yarn'
@@ -51,7 +51,7 @@ jobs:
               run: yarn d2-app-scripts i18n generate
 
             - name: Run e2e tests
-              uses: cypress-io/github-action@v5
+              uses: cypress-io/github-action@v7
               with:
                   start: yarn d2-app-scripts start
                   wait-on: 'http://localhost:3000'

--- a/.github/workflows/publish-d2-ci.yml
+++ b/.github/workflows/publish-d2-ci.yml
@@ -31,9 +31,9 @@ jobs:
             - name: Print GitHub ref
               run: echo "GITHUB_REF is $GITHUB_REF"
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v7
               with:
                   node-version: 20.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         outputs:
             build_exists: ${{ steps.check_build.outputs.build_exists }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                   token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
 
@@ -32,7 +32,7 @@ jobs:
                   ssh-signing-key: ${{ secrets.DHIS2_BOT_SSH_SIGNING_KEY }}
                   ssh-signing-key-passphrase: ${{ secrets.DHIS2_BOT_SSH_SIGNING_PASSPHRASE }}
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v7
               with:
                   node-version: 20.x
 
@@ -65,7 +65,7 @@ jobs:
         steps:
             - name: Checkout code
               if: ${{ needs.release.outputs.build_exists == 'yes' && success() }}
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: master
                   fetch-depth: 0

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -18,7 +18,7 @@ jobs:
         outputs:
             matrix: ${{ steps.set-matrix.outputs.specs }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Generate Test matrix
               id: set-matrix
               run: echo "::set-output name=specs::$(node cypress/support/generateTestMatrix.js)"
@@ -26,8 +26,8 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v7
               with:
                   node-version: 20.x
                   cache: 'yarn'
@@ -38,7 +38,7 @@ jobs:
             - name: Build
               run: yarn d2-app-scripts build
 
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v7
               with:
                   name: app-build
                   path: |
@@ -49,8 +49,8 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v7
               with:
                   node-version: 20.x
                   cache: 'yarn'
@@ -67,8 +67,8 @@ jobs:
     test:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v7
               with:
                   node-version: 20.x
                   cache: 'yarn'

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -30,6 +30,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: 20.x
+                  cache: 'yarn'
 
             - name: Install
               run: yarn install --frozen-lockfile
@@ -52,6 +53,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: 20.x
+                  cache: 'yarn'
 
             - name: Install
               run: yarn install --frozen-lockfile
@@ -69,6 +71,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: 20.x
+                  cache: 'yarn'
 
             - name: Install
               run: yarn install --frozen-lockfile
@@ -82,7 +85,7 @@ jobs:
     call-workflow-e2e-prod:
         if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
         needs: [build, lint, test, setup-matrix]
-        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests-prod.yml@feat/hardcoded-dev-version-minor
+        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests-prod.yml@maps-app
         with:
             should_record: ${{ contains(github.event.head_commit.message, '[e2e record]') || contains(join(github.event.pull_request.labels.*.name), 'e2e record')}}
             spec-group: ${{ needs.setup-matrix.outputs.matrix }}

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -4,6 +4,10 @@ const {
     downloadedFileTasks,
 } = require('./cypress/plugins/downloadedFileTasks.js')
 const {
+    createReplicaAccountForRun,
+    deleteReplicaAccount,
+} = require('./cypress/plugins/e2eReplicaAccount.js')
+const {
     excludeByVersionTags,
 } = require('./cypress/plugins/excludeByVersionTags.js')
 
@@ -22,6 +26,29 @@ async function setupNodeEvents(on, config) {
     if (!config.env.dhis2InstanceVersion) {
         throw new Error(
             'dhis2InstanceVersion is missing. Check the README for more information.'
+        )
+    }
+
+    config.env.useReplicaAccount = !!process.env.CI
+
+    if (config.env.useReplicaAccount) {
+        const { username, password, replicaUserId } =
+            await createReplicaAccountForRun({
+                baseUrl: config.env.dhis2BaseUrl,
+                username: config.env.dhis2Username,
+                password: config.env.dhis2Password,
+            })
+
+        config.env.replicaUsername = username
+        config.env.replicaPassword = password
+
+        on('after:run', () =>
+            deleteReplicaAccount({
+                baseUrl: config.env.dhis2BaseUrl,
+                username: config.env.dhis2Username,
+                password: config.env.dhis2Password,
+                replicaUserId,
+            })
         )
     }
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -66,10 +66,6 @@ module.exports = defineConfig({
         defaultCommandTimeout: 15000,
         // Record video
         video: true,
-        /* Only compress and upload videos for failures.
-         * This will save execution time and reduce the risk
-         * out-of-memory issues on the CI machine */
-        videoUploadOnPasses: false,
         // Enabled to reduce the risk of out-of-memory issues
         experimentalMemoryManagement: true,
         // Set to a low number to reduce the risk of out-of-memory issues

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -32,24 +32,31 @@ async function setupNodeEvents(on, config) {
     config.env.useReplicaAccount = !!process.env.CI
 
     if (config.env.useReplicaAccount) {
-        const { username, password, replicaUserId } =
-            await createReplicaAccountForRun({
-                baseUrl: config.env.dhis2BaseUrl,
-                username: config.env.dhis2Username,
-                password: config.env.dhis2Password,
-            })
+        try {
+            const { username, password, replicaUserId } =
+                await createReplicaAccountForRun({
+                    baseUrl: config.env.dhis2BaseUrl,
+                    username: config.env.dhis2Username,
+                    password: config.env.dhis2Password,
+                })
 
-        config.env.replicaUsername = username
-        config.env.replicaPassword = password
+            config.env.replicaUsername = username
+            config.env.replicaPassword = password
 
-        on('after:run', () =>
-            deleteReplicaAccount({
-                baseUrl: config.env.dhis2BaseUrl,
-                username: config.env.dhis2Username,
-                password: config.env.dhis2Password,
-                replicaUserId,
-            })
-        )
+            on('after:run', () =>
+                deleteReplicaAccount({
+                    baseUrl: config.env.dhis2BaseUrl,
+                    username: config.env.dhis2Username,
+                    password: config.env.dhis2Password,
+                    replicaUserId,
+                })
+            )
+        } catch (error) {
+            console.warn(
+                `WARNING: could not create e2e replica account, falling back to the standard account: ${error.message}`
+            )
+            config.env.useReplicaAccount = false
+        }
     }
 
     return config

--- a/cypress/elements/event_layer.js
+++ b/cypress/elements/event_layer.js
@@ -1,3 +1,4 @@
+import { EXTENDED_TIMEOUT } from '../support/util.js'
 import { Layer } from './layer.js'
 
 export class EventLayer extends Layer {
@@ -17,7 +18,9 @@ export class EventLayer extends Layer {
     }
 
     selectCoordinate(coordinate) {
-        cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.getByDataTest('coordinatefield-content', EXTENDED_TIMEOUT).should(
+            ($el) => expect($el.text().trim().length).to.be.greaterThan(0)
+        )
 
         cy.getByDataTest('coordinatefield-content').then(($element) => {
             // Check if the coordinate is already selected by looking at the text content

--- a/cypress/elements/event_layer.js
+++ b/cypress/elements/event_layer.js
@@ -3,16 +3,16 @@ import { Layer } from './layer.js'
 
 export class EventLayer extends Layer {
     selectProgram(program) {
-        cy.get('[data-test="programselect"]').click()
-        cy.contains(program).scrollIntoView()
-        cy.contains(program).click()
+        cy.get('[data-test="programselect"]', EXTENDED_TIMEOUT).click()
+        cy.contains(program, EXTENDED_TIMEOUT).scrollIntoView()
+        cy.contains(program, EXTENDED_TIMEOUT).click()
 
         return this
     }
 
     selectStage(stage) {
-        cy.get('[data-test="programstageselect"]').click()
-        cy.contains(stage).click()
+        cy.get('[data-test="programstageselect"]', EXTENDED_TIMEOUT).click()
+        cy.contains(stage, EXTENDED_TIMEOUT).click()
 
         return this
     }
@@ -39,7 +39,7 @@ export class EventLayer extends Layer {
     }
 
     validateStage(stage) {
-        cy.get('[data-test="programstageselect"]')
+        cy.get('[data-test="programstageselect"]', EXTENDED_TIMEOUT)
             .contains(stage)
             .should('be.visible')
 

--- a/cypress/elements/file_menu.js
+++ b/cypress/elements/file_menu.js
@@ -26,10 +26,12 @@ export const openMap = (mapName) => {
     cy.getByDataTest('dhis2-uicore-datatable')
         .contains(mapName)
         .should('be.visible')
+
+    cy.intercept('GET', /\/maps\/[a-zA-Z0-9]{11}/).as('getMapOnOpen')
+
     cy.getByDataTest('dhis2-uicore-datatable').contains(mapName).click()
 
-    // cy.get('[data-test="dhis2-uicore-layer"]').click('topLeft');
-    // cy.wait(1000);
+    cy.wait('@getMapOnOpen')
 
     cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
@@ -137,7 +139,11 @@ export const deleteMap = () => {
 
     cy.getByDataTest('file-menu-delete-modal').should('be.visible')
 
+    cy.intercept('DELETE', /\/maps/).as('deleteMapMutation')
+
     cy.getByDataTest('file-menu-delete-modal-delete', EXTENDED_TIMEOUT).click()
+
+    cy.wait('@deleteMapMutation')
 
     cy.getByDataTest('file-menu-delete-modal', EXTENDED_TIMEOUT).should(
         'not.exist'

--- a/cypress/elements/file_menu.js
+++ b/cypress/elements/file_menu.js
@@ -31,8 +31,7 @@ export const openMap = (mapName) => {
 
     cy.getByDataTest('dhis2-uicore-datatable').contains(mapName).click()
 
-    cy.wait('@getMapOnOpen')
-
+    cy.wait('@getMapOnOpen', EXTENDED_TIMEOUT)
     cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
     cy.getByDataTest('open-file-dialog-modal').should('not.be.visible')
@@ -143,8 +142,7 @@ export const deleteMap = () => {
 
     cy.getByDataTest('file-menu-delete-modal-delete', EXTENDED_TIMEOUT).click()
 
-    cy.wait('@deleteMapMutation')
-
+    cy.wait('@deleteMapMutation', EXTENDED_TIMEOUT)
     cy.getByDataTest('file-menu-delete-modal', EXTENDED_TIMEOUT).should(
         'not.exist'
     )

--- a/cypress/elements/layer.js
+++ b/cypress/elements/layer.js
@@ -33,6 +33,12 @@ export class Layer {
     openOu(ouName) {
         cy.getByDataTest('org-unit-tree').contains(ouName).scrollIntoView()
 
+        // Expanding a tree node fetches its children fresh, on demand
+        cy.intercept(
+            'GET',
+            /\/organisationUnits\/[a-zA-Z0-9]{11}\?fields=children/
+        ).as('fetchOuChildren')
+
         cy.getByDataTest('org-unit-tree')
             .contains(ouName)
             .parents('[data-test="org-unit-tree-node"]')
@@ -40,6 +46,8 @@ export class Layer {
             .within(() => {
                 cy.getByDataTest('org-unit-tree-node-toggle').click()
             })
+
+        cy.wait('@fetchOuChildren', EXTENDED_TIMEOUT)
 
         return this
     }

--- a/cypress/elements/layer.js
+++ b/cypress/elements/layer.js
@@ -8,7 +8,7 @@ export class Layer {
 
         cy.getByDataTest('add-layer-button', EXTENDED_TIMEOUT).click()
 
-        cy.get(`[data-test="${dataTest}"]`).click()
+        cy.get(`[data-test="${dataTest}"]`, EXTENDED_TIMEOUT).click()
 
         return this
     }
@@ -164,7 +164,9 @@ export class Layer {
 
     validatePopupContents(contents) {
         contents.forEach((content) => {
-            cy.get('.maplibregl-popup').contains(content).should('be.visible')
+            cy.get('.maplibregl-popup', EXTENDED_TIMEOUT)
+                .contains(content)
+                .should('be.visible')
         })
 
         return this

--- a/cypress/elements/map_canvas.js
+++ b/cypress/elements/map_canvas.js
@@ -13,7 +13,7 @@ export const assertMapPosition = (
     expectedHeights,
     tolerance = 0
 ) => {
-    getMaps().then(($canvas) => {
+    getMaps().should(($canvas) => {
         const boundingRect = $canvas[0].getBoundingClientRect()
         expect(
             expectedBottoms.some(

--- a/cypress/elements/map_context_menu.js
+++ b/cypress/elements/map_context_menu.js
@@ -1,3 +1,4 @@
+import { EXTENDED_TIMEOUT } from '../support/util.js'
 import { getMaps } from './map_canvas.js'
 
 export const DRILL_UP = 'context-menu-drill-up'
@@ -18,7 +19,7 @@ export const expectContextMenuOptions = (availableOptions) => {
             getMaps().first().rightclick(xpos, ypos)
 
             // menu has correct number of items
-            cy.getByDataTest('context-menu')
+            cy.getByDataTest('context-menu', EXTENDED_TIMEOUT)
                 .find('li')
                 .should('have.length', availableOptions.length)
 

--- a/cypress/elements/thematic_layer.js
+++ b/cypress/elements/thematic_layer.js
@@ -2,6 +2,11 @@ import { Layer } from './layer.js'
 
 export class ThematicLayer extends Layer {
     selectItemType(itemType) {
+        cy.intercept(
+            'GET',
+            /\/(indicatorGroups|dataElementGroups|dataSets|programs)\b/
+        ).as('fetchGroups')
+
         cy.getByDataTest(
             'data-dimension-left-header-data-types-select-field-content'
         ).click()
@@ -9,12 +14,23 @@ export class ThematicLayer extends Layer {
         return this
     }
     selectGroup(group) {
+        cy.wait('@fetchGroups')
+
         cy.getByDataTest(
             'data-dimension-left-header-groups-select-field-content'
         ).click()
+
+        cy.intercept(
+            'GET',
+            /\/(indicators|dataElements|dataElementOperands|dataSets|dataItems)\b/
+        ).as('fetchItems')
+
         cy.getByDataTest('dhis2-uicore-select-menu-menuwrapper')
             .contains(group)
             .click()
+
+        cy.wait('@fetchItems')
+
         return this
     }
     selectSubGroup(subGroup) {

--- a/cypress/elements/thematic_layer.js
+++ b/cypress/elements/thematic_layer.js
@@ -9,6 +9,14 @@ export class ThematicLayer extends Layer {
         ).as('fetchGroups')
         this._groupsFetchPending = true
 
+        // Calculations bypasses GroupSelector/ItemSelector entirely (see
+        // @dhis2/analytics's DataDimension.js) - its item list is fetched
+        // directly once this type is chosen, consumed in selectDataItem().
+        if (itemType === 'Calculations') {
+            cy.intercept('GET', /\/dataItems\b/).as('fetchDataItems')
+            this._dataItemsFetchPending = true
+        }
+
         cy.getByDataTest(
             'data-dimension-left-header-data-types-select-field-content'
         ).click()
@@ -48,6 +56,11 @@ export class ThematicLayer extends Layer {
         return this
     }
     selectDataItem(dataItem) {
+        if (this._dataItemsFetchPending) {
+            cy.wait('@fetchDataItems', EXTENDED_TIMEOUT)
+            this._dataItemsFetchPending = false
+        }
+
         cy.getByDataTest('data-dimension-transfer-sourceoptions')
             .contains(dataItem)
             .click()

--- a/cypress/elements/thematic_layer.js
+++ b/cypress/elements/thematic_layer.js
@@ -1,3 +1,4 @@
+import { EXTENDED_TIMEOUT } from '../support/util.js'
 import { Layer } from './layer.js'
 
 export class ThematicLayer extends Layer {
@@ -6,6 +7,7 @@ export class ThematicLayer extends Layer {
             'GET',
             /\/(indicatorGroups|dataElementGroups|dataSets|programs)\b/
         ).as('fetchGroups')
+        this._groupsFetchPending = true
 
         cy.getByDataTest(
             'data-dimension-left-header-data-types-select-field-content'
@@ -14,7 +16,10 @@ export class ThematicLayer extends Layer {
         return this
     }
     selectGroup(group) {
-        cy.wait('@fetchGroups')
+        if (this._groupsFetchPending) {
+            cy.wait('@fetchGroups', EXTENDED_TIMEOUT)
+            this._groupsFetchPending = false
+        }
 
         cy.getByDataTest(
             'data-dimension-left-header-groups-select-field-content'
@@ -29,7 +34,7 @@ export class ThematicLayer extends Layer {
             .contains(group)
             .click()
 
-        cy.wait('@fetchItems')
+        cy.wait('@fetchItems', EXTENDED_TIMEOUT)
 
         return this
     }

--- a/cypress/integration/basemaps.cy.js
+++ b/cypress/integration/basemaps.cy.js
@@ -20,7 +20,7 @@ describe('Basemap checks', () => {
             })
         }).as('openMap')
 
-        cy.visit('/?id=ytkZY3ChM6J', EXTENDED_TIMEOUT)
+        cy.visit('/?id=ytkZY3ChM6J')
         cy.wait('@openMap', EXTENDED_TIMEOUT)
 
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
@@ -38,7 +38,7 @@ describe('Basemap checks', () => {
             })
         }).as('openMap')
 
-        cy.visit('/?id=zDP78aJU8nX', EXTENDED_TIMEOUT)
+        cy.visit('/?id=zDP78aJU8nX')
         cy.wait('@openMap', EXTENDED_TIMEOUT)
 
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
@@ -57,7 +57,7 @@ describe('Basemap checks', () => {
             })
         }).as('openMap')
 
-        cy.visit('/?id=qTfO4YkQ9xW', EXTENDED_TIMEOUT)
+        cy.visit('/?id=qTfO4YkQ9xW')
         cy.wait('@openMap', EXTENDED_TIMEOUT)
 
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
@@ -86,7 +86,7 @@ describe('Basemap checks', () => {
             })
         }).as('openMap')
 
-        cy.visit('/?id=ZugJzZ7xxRW', EXTENDED_TIMEOUT)
+        cy.visit('/?id=ZugJzZ7xxRW')
         cy.wait('@openMap', EXTENDED_TIMEOUT)
 
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
@@ -115,7 +115,7 @@ describe('Basemap checks', () => {
             })
         }).as('openMap')
 
-        cy.visit('/?id=wIIoj44X77r', EXTENDED_TIMEOUT)
+        cy.visit('/?id=wIIoj44X77r')
         cy.wait('@systemSettings', EXTENDED_TIMEOUT)
         cy.wait('@openMap', EXTENDED_TIMEOUT)
 
@@ -145,7 +145,7 @@ describe('Basemap checks', () => {
             })
         }).as('openMap')
 
-        cy.visit('/?id=wIIoj44X77r', EXTENDED_TIMEOUT)
+        cy.visit('/?id=wIIoj44X77r')
         cy.wait('@systemSettings', EXTENDED_TIMEOUT)
         cy.wait('@openMap', EXTENDED_TIMEOUT)
 

--- a/cypress/integration/dataDownload.cy.js
+++ b/cypress/integration/dataDownload.cy.js
@@ -53,8 +53,6 @@ describe('Data Download', () => {
             .contains('Download')
             .click()
 
-        cy.wait(3000) // eslint-disable-line cypress/no-unnecessary-waiting
-
         cy.waitUntil(
             () => cy.task('getLastDownloadFilePath').then((result) => result),
             { timeout: 3000, interval: 100 }
@@ -84,8 +82,6 @@ describe('Data Download', () => {
             .find('button')
             .contains('Download')
             .click()
-
-        cy.wait(3000) // eslint-disable-line cypress/no-unnecessary-waiting
 
         cy.waitUntil(
             () => cy.task('getLastDownloadFilePath').then((result) => result),

--- a/cypress/integration/dataDownload.cy.js
+++ b/cypress/integration/dataDownload.cy.js
@@ -55,7 +55,7 @@ describe('Data Download', () => {
 
         cy.waitUntil(
             () => cy.task('getLastDownloadFilePath').then((result) => result),
-            { timeout: 3000, interval: 100 }
+            { timeout: 8000, interval: 100 }
         ).then((filePath) => {
             expect(filePath).to.include('geojson')
             expect(filePath).to.include(
@@ -85,7 +85,7 @@ describe('Data Download', () => {
 
         cy.waitUntil(
             () => cy.task('getLastDownloadFilePath').then((result) => result),
-            { timeout: 3000, interval: 100 }
+            { timeout: 8000, interval: 100 }
         ).then((filePath) => {
             expect(filePath).to.include('geojson')
             expect(filePath).to.include(

--- a/cypress/integration/dataDownload.cy.js
+++ b/cypress/integration/dataDownload.cy.js
@@ -39,13 +39,12 @@ describe('Data Download', () => {
     })
 
     it('downloads data from a thematic layer', () => {
-        cy.intercept('GET', '**/analytics.json**').as('getThematicData')
+        cy.intercept('GET', /\/analytics\?/).as('getThematicData')
 
         cy.visit(`/?id=${mapWithThematicLayer.id}`)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
-        cy.wait('@getThematicData')
-
+        cy.wait('@getThematicData', EXTENDED_TIMEOUT)
         cy.get('[data-test="layercard"]')
             .find('h2')
             .contains(mapWithThematicLayer.cardTitle, EXTENDED_TIMEOUT)
@@ -78,8 +77,7 @@ describe('Data Download', () => {
         cy.visit(`/?id=${mapWithEventLayer.id}`)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
-        cy.wait('@getEventData')
-
+        cy.wait('@getEventData', EXTENDED_TIMEOUT)
         cy.get('[data-test="layercard"]')
             .find('h2')
             .contains(mapWithEventLayer.cardTitle, EXTENDED_TIMEOUT)

--- a/cypress/integration/dataDownload.cy.js
+++ b/cypress/integration/dataDownload.cy.js
@@ -39,8 +39,12 @@ describe('Data Download', () => {
     })
 
     it('downloads data from a thematic layer', () => {
-        cy.visit(`/?id=${mapWithThematicLayer.id}`, EXTENDED_TIMEOUT)
+        cy.intercept('GET', '**/analytics.json**').as('getThematicData')
+
+        cy.visit(`/?id=${mapWithThematicLayer.id}`)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
+
+        cy.wait('@getThematicData')
 
         cy.get('[data-test="layercard"]')
             .find('h2')
@@ -69,8 +73,12 @@ describe('Data Download', () => {
     })
 
     it('downloads data from an event layer', () => {
-        cy.visit(`/?id=${mapWithEventLayer.id}`, EXTENDED_TIMEOUT)
+        cy.intercept('GET', '**/analytics/events/**').as('getEventData')
+
+        cy.visit(`/?id=${mapWithEventLayer.id}`)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
+
+        cy.wait('@getEventData')
 
         cy.get('[data-test="layercard"]')
             .find('h2')
@@ -99,7 +107,7 @@ describe('Data Download', () => {
     })
 
     it('fails to download event layer', () => {
-        cy.visit(`/?id=${mapWithEventLayer.id}`, EXTENDED_TIMEOUT)
+        cy.visit(`/?id=${mapWithEventLayer.id}`)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
         cy.get('[data-test="layercard"]')
             .find('h2')

--- a/cypress/integration/dataTable.cy.js
+++ b/cypress/integration/dataTable.cy.js
@@ -44,7 +44,7 @@ describe('data table', () => {
             IFRAME_HEADER_HEIGHT,
         ].map((h) => viewportHeight - h - MENU_HEIGHT)
 
-        cy.visit(`/#/${map.id}`, EXTENDED_TIMEOUT)
+        cy.visit(`/#/${map.id}`)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         //check that the map resizes properly
@@ -147,7 +147,7 @@ describe('data table', () => {
     })
 
     it('opens the data table for an Event layer', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
 
         const EvenLayer = new EventLayer()
 

--- a/cypress/integration/fetcherrors.cy.js
+++ b/cypress/integration/fetcherrors.cy.js
@@ -7,8 +7,7 @@ describe('Fetch errors', () => {
 
         cy.visit('/?id=nonexisting')
 
-        cy.wait('@getMap')
-
+        cy.wait('@getMap', EXTENDED_TIMEOUT)
         cy.getByDataTest('layercard', EXTENDED_TIMEOUT).should('not.exist')
         cy.getByDataTest('basemapcard', EXTENDED_TIMEOUT).should('be.visible')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')

--- a/cypress/integration/fetcherrors.cy.js
+++ b/cypress/integration/fetcherrors.cy.js
@@ -3,7 +3,11 @@ import { EXTENDED_TIMEOUT } from '../support/util.js'
 
 describe('Fetch errors', () => {
     it('non-existing map id does not crash app', () => {
-        cy.visit('/?id=nonexisting', EXTENDED_TIMEOUT)
+        cy.intercept('GET', '**/maps/nonexisting*').as('getMap')
+
+        cy.visit('/?id=nonexisting')
+
+        cy.wait('@getMap')
 
         cy.getByDataTest('layercard', EXTENDED_TIMEOUT).should('not.exist')
         cy.getByDataTest('basemapcard', EXTENDED_TIMEOUT).should('be.visible')
@@ -19,7 +23,7 @@ describe('Fetch errors', () => {
             }
         )
 
-        cy.visit('/?currentAnalyticalObject=true', EXTENDED_TIMEOUT)
+        cy.visit('/?currentAnalyticalObject=true')
 
         cy.getByDataTest('layercard', EXTENDED_TIMEOUT).should('not.exist')
         cy.getByDataTest('basemapcard', EXTENDED_TIMEOUT).should('be.visible')
@@ -32,7 +36,7 @@ describe('Fetch errors', () => {
             statusCode: 409,
         })
 
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
 
         cy.getByDataTest('layercard', EXTENDED_TIMEOUT).should('not.exist')
         cy.getByDataTest('basemapcard', EXTENDED_TIMEOUT).should('be.visible')
@@ -42,7 +46,7 @@ describe('Fetch errors', () => {
     it('failed timeline thematic layer does not crash app', () => {
         cy.intercept('GET', '**/api/**/analytics*', { statusCode: 500 })
 
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
 
         const Layer = new ThematicLayer()
         Layer.openDialog('Thematic')
@@ -76,7 +80,7 @@ describe('Fetch errors', () => {
             statusCode: 409,
         })
 
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
 
         cy.getByDataTest('layercard', EXTENDED_TIMEOUT).should('not.exist')
         cy.getByDataTest('basemapcard', EXTENDED_TIMEOUT).should('be.visible')

--- a/cypress/integration/filemenu.cy.js
+++ b/cypress/integration/filemenu.cy.js
@@ -9,9 +9,9 @@ import {
 } from '../elements/file_menu.js'
 import { Layer as OrgUnitLayer } from '../elements/layer.js'
 import { ThematicLayer } from '../elements/thematic_layer.js'
-import { EXTENDED_TIMEOUT } from '../support/util.js'
+import { EXTENDED_TIMEOUT, uniqueId } from '../support/util.js'
 
-const MAP_TITLE = 'test ' + new Date().toUTCString().slice(-24, -4)
+const MAP_TITLE = 'test ' + uniqueId()
 const SAVEAS_MAP_TITLE = `${MAP_TITLE}-2`
 
 describe('File menu', () => {
@@ -70,7 +70,7 @@ describe('File menu', () => {
         cy.visit('/', EXTENDED_TIMEOUT)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
-        const title = 'test ' + new Date().toUTCString().slice(-24, -4)
+        const title = 'test ' + uniqueId()
         const renamedTitle = `renamed ${title}`
 
         createMap(title)
@@ -123,9 +123,8 @@ describe('File menu', () => {
         cy.visit('/', EXTENDED_TIMEOUT)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
-        const title = 'test ' + new Date().toUTCString().slice(-24, -4)
-        const renamedTitle =
-            'renamed ' + new Date().toUTCString().slice(-24, -4)
+        const title = 'test ' + uniqueId()
+        const renamedTitle = 'renamed ' + uniqueId()
 
         createMap(title)
         const description = 'this is the explanation of the map'

--- a/cypress/integration/filemenu.cy.js
+++ b/cypress/integration/filemenu.cy.js
@@ -52,7 +52,7 @@ describe('File menu', () => {
     }
 
     it('saves a new map', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         cy.intercept({ method: 'GET', url: /\/maps\// }, (req) => {
@@ -67,7 +67,7 @@ describe('File menu', () => {
     })
 
     it('renames a map', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         const title = 'test ' + uniqueId()
@@ -120,7 +120,7 @@ describe('File menu', () => {
     })
 
     it('handles a failure when renaming the map', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         const title = 'test ' + uniqueId()
@@ -159,7 +159,7 @@ describe('File menu', () => {
 
     // Skipped: flaky in CI (#2006)
     it.skip('save existing as new map', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         openMap(MAP_TITLE)
@@ -195,7 +195,7 @@ describe('File menu', () => {
 
     // Skipped: flaky in CI (#2006)
     it.skip('save changes to existing map', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         openMap(SAVEAS_MAP_TITLE)
@@ -255,7 +255,7 @@ describe('File menu', () => {
 
     // Skipped: flaky in CI (#2006)
     it.skip('save changes to existing map fails', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         openMap(MAP_TITLE)
@@ -279,7 +279,7 @@ describe('File menu', () => {
 
     // Skipped: flaky in CI (#2006)
     it.skip('save as new map fails', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         openMap(MAP_TITLE)
@@ -300,7 +300,7 @@ describe('File menu', () => {
     })
 
     it('deletes MAP_TITLE map', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         openMap(MAP_TITLE)
@@ -321,7 +321,7 @@ describe('File menu', () => {
 
     // Skipped: flaky in CI (#2006)
     it.skip('deletes SAVEAS_MAP_TITLE map', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         openMap(SAVEAS_MAP_TITLE)

--- a/cypress/integration/interpretations.cy.js
+++ b/cypress/integration/interpretations.cy.js
@@ -1,8 +1,8 @@
 import { saveNewMap, deleteMap } from '../elements/file_menu.js'
 import { ThematicLayer } from '../elements/thematic_layer.js'
-import { EXTENDED_TIMEOUT } from '../support/util.js'
+import { EXTENDED_TIMEOUT, uniqueId } from '../support/util.js'
 
-const MAP_TITLE = 'test ' + new Date().toUTCString().slice(-24, -4)
+const MAP_TITLE = 'test ' + uniqueId()
 context('Interpretations', () => {
     it('opens the interpretations panel for a map', () => {
         cy.visit('/#/ZBjCfSaLSqD', EXTENDED_TIMEOUT)

--- a/cypress/integration/interpretations.cy.js
+++ b/cypress/integration/interpretations.cy.js
@@ -55,11 +55,9 @@ context('Interpretations', () => {
             .its('response.statusCode')
             .should('eq', 201)
 
-        // Force wait because the See interpretations component
-        // isn't loaded yet
-        cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
-
-        cy.get('button').contains('See interpretation').click()
+        cy.contains('button', 'See interpretation', EXTENDED_TIMEOUT)
+            .should('be.visible')
+            .click()
 
         cy.getByDataTest('dhis2-uicore-modalcontent')
             .find('canvas.maplibregl-canvas')

--- a/cypress/integration/interpretations.cy.js
+++ b/cypress/integration/interpretations.cy.js
@@ -5,7 +5,7 @@ import { EXTENDED_TIMEOUT, uniqueId } from '../support/util.js'
 const MAP_TITLE = 'test ' + uniqueId()
 context('Interpretations', () => {
     it('opens the interpretations panel for a map', () => {
-        cy.visit('/#/ZBjCfSaLSqD', EXTENDED_TIMEOUT)
+        cy.visit('/#/ZBjCfSaLSqD')
         const ThemLayer = new ThematicLayer()
         ThemLayer.validateCardTitle('ANC LLITN coverage')
         cy.get('canvas.maplibregl-canvas').should('be.visible')
@@ -76,10 +76,7 @@ context('Interpretations', () => {
         cy.intercept({ method: 'POST', url: /dataStatistics/ }).as(
             'postDataStatistics'
         )
-        cy.visit(
-            '/#/ZBjCfSaLSqD?interpretationId=yKqhXZdeJ6a',
-            EXTENDED_TIMEOUT
-        ) //ANC: LLITN coverage district and facility
+        cy.visit('/#/ZBjCfSaLSqD?interpretationId=yKqhXZdeJ6a') //ANC: LLITN coverage district and facility
 
         cy.wait('@postDataStatistics', EXTENDED_TIMEOUT)
             .its('response.statusCode')

--- a/cypress/integration/keyboard.cy.js
+++ b/cypress/integration/keyboard.cy.js
@@ -13,7 +13,7 @@ const alt = {
 
 describe('keyboard navigation', () => {
     it('tab', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
 
         // StartEndDate
         cy.getByDataTest('add-layer-button', EXTENDED_TIMEOUT).click()
@@ -43,7 +43,7 @@ describe('keyboard navigation', () => {
     })
 
     it('esc', () => {
-        cy.visit(`/#/${map.id}`, EXTENDED_TIMEOUT)
+        cy.visit(`/#/${map.id}`)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         // Layer popover

--- a/cypress/integration/layers/eventlayer.cy.js
+++ b/cypress/integration/layers/eventlayer.cy.js
@@ -1,11 +1,6 @@
 import { EventLayer } from '../../elements/event_layer.js'
 import { getMaps } from '../../elements/map_canvas.js'
-import {
-    CURRENT_YEAR,
-    EXTENDED_TIMEOUT,
-    POPUP_WAIT,
-    getDhis2Version,
-} from '../../support/util.js'
+import { CURRENT_YEAR, getDhis2Version } from '../../support/util.js'
 
 const programE2E = {
     name: 'E2E program',
@@ -97,10 +92,7 @@ const testCoordinate = (Layer, coordinates, reOpenDialog = true) => {
     Layer.validateDialogClosed(true)
 
     // Wait for map to load
-    cy.wait(POPUP_WAIT)
-    cy.get('#dhis2-map-container')
-        .findByDataTest('dhis2-uicore-componentcover', EXTENDED_TIMEOUT)
-        .should('not.exist')
+    cy.waitForMap()
 
     // Check popup
     getMaps().click('center') // Click in the middle of the map
@@ -246,10 +238,7 @@ context('Event Layers', () => {
         Layer.validateCardPeriod(`March ${CURRENT_YEAR - 1}`)
         Layer.validateCardPeriod(`September ${CURRENT_YEAR - 1}`)
 
-        cy.wait(POPUP_WAIT)
-        cy.get('#dhis2-map-container')
-            .findByDataTest('dhis2-uicore-componentcover', EXTENDED_TIMEOUT)
-            .should('not.exist')
+        cy.waitForMap()
 
         getMaps().click('center')
         Layer.validatePopupContents(['Event location'])
@@ -298,10 +287,7 @@ context('Event Layers', () => {
             .selectOu(programIP.ousAlt[2])
             .addToMap()
 
-        cy.wait(POPUP_WAIT)
-        cy.get('#dhis2-map-container')
-            .findByDataTest('dhis2-uicore-componentcover', EXTENDED_TIMEOUT)
-            .should('not.exist')
+        cy.waitForMap()
 
         getMaps().click('center')
         Layer.validatePopupContents([

--- a/cypress/integration/layers/eventlayer.cy.js
+++ b/cypress/integration/layers/eventlayer.cy.js
@@ -107,13 +107,33 @@ const testCoordinate = (Layer, coordinates, reOpenDialog = true) => {
     Layer.validateCardContents(['Coordinate field', `${coordinates.name}`])
 }
 
-const selectProgramAndStage = (Layer, programName, stageName) => {
+const selectProgramAndStage = (
+    Layer,
+    programName,
+    { stageName, validateOnly = false } = {}
+) => {
+    cy.intercept('GET', /\/programs\?/).as('getPrograms')
+    cy.intercept('GET', /\/programs\/[a-zA-Z0-9]{11}\?fields=programStages/).as(
+        'getProgramStages'
+    )
     cy.intercept(
         'GET',
         /\/programStages\/[a-zA-Z0-9]{11}\?fields=programStageDataElements/
     ).as('getProgramStageDataElements')
 
-    Layer.openDialog('Events').selectProgram(programName).selectStage(stageName)
+    Layer.openDialog('Events')
+
+    cy.wait('@getPrograms')
+
+    Layer.selectProgram(programName)
+
+    cy.wait('@getProgramStages')
+
+    if (validateOnly) {
+        Layer.validateStage(stageName)
+    } else {
+        Layer.selectStage(stageName)
+    }
 
     cy.wait('@getProgramStageDataElements')
 }
@@ -127,10 +147,12 @@ context('Event Layers', () => {
     const Layer = new EventLayer()
 
     it('adds an event layer and applies style for boolean data element', () => {
-        Layer.openDialog('Events')
-            .selectProgram(programE2E.name)
-            .validateStage(programE2E.stage)
-            .selectTab('Style')
+        selectProgramAndStage(Layer, programE2E.name, {
+            stageName: programE2E.stage,
+            validateOnly: true,
+        })
+
+        Layer.selectTab('Style')
 
         cy.getByDataTest('style-by-data-item-select').click()
 
@@ -158,13 +180,12 @@ context('Event Layers', () => {
     })
 
     it('shows error if no endDate is specified', () => {
-        Layer.openDialog('Events')
-            .selectProgram(programIP.name)
-            .validateStage(programIP.stage)
-            .selectTab('Period')
-            .selectStartEndDates()
-            .typeEndDate()
-            .addToMap()
+        selectProgramAndStage(Layer, programIP.name, {
+            stageName: programIP.stage,
+            validateOnly: true,
+        })
+
+        Layer.selectTab('Period').selectStartEndDates().typeEndDate().addToMap()
 
         Layer.validateDialogClosed(false)
         cy.contains('End date is invalid').should('be.visible')
@@ -177,10 +198,12 @@ context('Event Layers', () => {
     })
 
     it('adds an event layer - relative period', () => {
-        Layer.openDialog('Events')
-            .selectProgram(programIP.name)
-            .validateStage(programIP.stage)
-            .selectTab('Org Units')
+        selectProgramAndStage(Layer, programIP.name, {
+            stageName: programIP.stage,
+            validateOnly: true,
+        })
+
+        Layer.selectTab('Org Units')
             .selectOu(programIP.ous[0])
             .selectOu(programIP.ous[1])
             .addToMap()
@@ -192,10 +215,12 @@ context('Event Layers', () => {
     })
 
     it('adds an event layer - start-end dates', () => {
-        Layer.openDialog('Events')
-            .selectProgram(programIP.name)
-            .validateStage(programIP.stage)
-            .selectTab('Period')
+        selectProgramAndStage(Layer, programIP.name, {
+            stageName: programIP.stage,
+            validateOnly: true,
+        })
+
+        Layer.selectTab('Period')
             .selectStartEndDates()
             .typeStartDate(programIP.startDate)
             .typeEndDate(programIP.endDate)
@@ -215,10 +240,12 @@ context('Event Layers', () => {
     })
 
     it('adds an event layer with multiple periods', () => {
-        Layer.openDialog('Events')
-            .selectProgram(programIP.name)
-            .validateStage(programIP.stage)
-            .selectTab('Period')
+        selectProgramAndStage(Layer, programIP.name, {
+            stageName: programIP.stage,
+            validateOnly: true,
+        })
+
+        Layer.selectTab('Period')
             .selectPeriodType({
                 periodType: 'MONTHLY',
                 periodDimension: 'fixed',
@@ -252,10 +279,12 @@ context('Event Layers', () => {
     })
 
     it('preserves start/end dates when editing a saved event layer', () => {
-        Layer.openDialog('Events')
-            .selectProgram(programIP.name)
-            .validateStage(programIP.stage)
-            .selectTab('Period')
+        selectProgramAndStage(Layer, programIP.name, {
+            stageName: programIP.stage,
+            validateOnly: true,
+        })
+
+        Layer.selectTab('Period')
             .selectStartEndDates()
             .typeStartDate(programIP.startDate)
             .typeEndDate(programIP.endDate)
@@ -278,10 +307,12 @@ context('Event Layers', () => {
     })
 
     it('opens an event popup', () => {
-        Layer.openDialog('Events')
-            .selectProgram(programIP.name)
-            .validateStage(programIP.stage)
-            .selectTab('Period')
+        selectProgramAndStage(Layer, programIP.name, {
+            stageName: programIP.stage,
+            validateOnly: true,
+        })
+
+        Layer.selectTab('Period')
             .selectStartEndDates()
             .typeStartDate(programIP.startDate)
             .typeEndDate(programIP.endDate)
@@ -314,21 +345,17 @@ context('Event Layers', () => {
 
     it('sends multiple filters on the same dimension with colon separator [DHIS2-19696]', () => {
         cy.intercept('GET', /analytics\/events\/query\//).as('analyticsQuery')
-        cy.intercept(
-            'GET',
-            /\/programStages\/[a-zA-Z0-9]{11}\?fields=programStageDataElements/
-        ).as('getProgramStageDataElements')
 
-        Layer.openDialog('Events')
-            .selectProgram(programIP.name)
-            .validateStage(programIP.stage)
-            .selectTab('Style')
+        selectProgramAndStage(Layer, programIP.name, {
+            stageName: programIP.stage,
+            validateOnly: true,
+        })
+
+        Layer.selectTab('Style')
             .selectViewAllEvents()
             .selectTab('Org Units')
             .selectOu(programIP.ous[0])
             .selectOu(programIP.ous[1])
-
-        cy.wait('@getProgramStageDataElements')
 
         Layer.selectTab('Filter')
 
@@ -376,7 +403,9 @@ context('Event Layers', () => {
         // TODO: E2E DB fix
         // Event layer config
 
-        selectProgramAndStage(Layer, programGeowR.name, programGeowR.stage)
+        selectProgramAndStage(Layer, programGeowR.name, {
+            stageName: programGeowR.stage,
+        })
 
         Layer.selectCoordinate(programGeowR.scenarios[0].coordinates[0].name)
         Layer.selectTab('Period')
@@ -408,7 +437,9 @@ context('Event Layers', () => {
     it.skip('change coordinate field - event orgunit', () => {
         // TODO: E2E DB fix
         // Event layer config
-        selectProgramAndStage(Layer, programGeowR.name, programGeowR.stage)
+        selectProgramAndStage(Layer, programGeowR.name, {
+            stageName: programGeowR.stage,
+        })
         Layer.selectCoordinate(programGeowR.scenarios[0].coordinates[0].name)
         Layer.selectTab('Period')
             .selectStartEndDates()
@@ -448,7 +479,9 @@ context('Event Layers', () => {
             serverVersion.minor >= 42
         ) {
             // Event layer config
-            selectProgramAndStage(Layer, programGeowR.name, programGeowR.stage)
+            selectProgramAndStage(Layer, programGeowR.name, {
+                stageName: programGeowR.stage,
+            })
             Layer.selectCoordinate(
                 programGeowR.scenarios[0].coordinates[0].name
             )

--- a/cypress/integration/layers/eventlayer.cy.js
+++ b/cypress/integration/layers/eventlayer.cy.js
@@ -245,7 +245,9 @@ context('Event Layers', () => {
 
         cy.waitForMap()
 
+        cy.intercept('GET', '**/tracker/events/*').as('getEventPopupData')
         getMaps().click('center')
+        cy.wait('@getEventPopupData', EXTENDED_TIMEOUT)
         Layer.validatePopupContents(['Event location'])
     })
 
@@ -294,7 +296,9 @@ context('Event Layers', () => {
 
         cy.waitForMap()
 
+        cy.intercept('GET', '**/tracker/events/*').as('getEventPopupData')
         getMaps().click('center')
+        cy.wait('@getEventPopupData', EXTENDED_TIMEOUT)
         Layer.validatePopupContents([
             'Event location',
             '-13.188339, 8.405215',

--- a/cypress/integration/layers/eventlayer.cy.js
+++ b/cypress/integration/layers/eventlayer.cy.js
@@ -1,6 +1,10 @@
 import { EventLayer } from '../../elements/event_layer.js'
 import { getMaps } from '../../elements/map_canvas.js'
-import { CURRENT_YEAR, getDhis2Version } from '../../support/util.js'
+import {
+    CURRENT_YEAR,
+    EXTENDED_TIMEOUT,
+    getDhis2Version,
+} from '../../support/util.js'
 
 const programE2E = {
     name: 'E2E program',
@@ -117,6 +121,7 @@ const selectProgramAndStage = (Layer, programName, stageName) => {
 context('Event Layers', () => {
     beforeEach(() => {
         cy.visit('/')
+        cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
     })
 
     const Layer = new EventLayer()

--- a/cypress/integration/layers/eventlayer.cy.js
+++ b/cypress/integration/layers/eventlayer.cy.js
@@ -116,12 +116,9 @@ const selectProgramAndStage = (
     cy.intercept('GET', /\/programs\/[a-zA-Z0-9]{11}\?fields=programStages/).as(
         'getProgramStages'
     )
-    // Fired in parallel with getProgramStages the instant a program is
-    // selected - StyleByDataItem (EventDataItemsProvider) stays empty
-    // until both this and getProgramStageDataElements resolve.
     cy.intercept(
         'GET',
-        /\/programs\/[a-zA-Z0-9]{11}\?fields=trackedEntityType,programTrackedEntityAttributes/
+        /\/programs\/[a-zA-Z0-9]{11}\?fields=trackedEntityType/
     ).as('getProgramTrackedEntityAttributes')
     cy.intercept(
         'GET',

--- a/cypress/integration/layers/eventlayer.cy.js
+++ b/cypress/integration/layers/eventlayer.cy.js
@@ -116,6 +116,13 @@ const selectProgramAndStage = (
     cy.intercept('GET', /\/programs\/[a-zA-Z0-9]{11}\?fields=programStages/).as(
         'getProgramStages'
     )
+    // Fired in parallel with getProgramStages the instant a program is
+    // selected - StyleByDataItem (EventDataItemsProvider) stays empty
+    // until both this and getProgramStageDataElements resolve.
+    cy.intercept(
+        'GET',
+        /\/programs\/[a-zA-Z0-9]{11}\?fields=trackedEntityType,programTrackedEntityAttributes/
+    ).as('getProgramTrackedEntityAttributes')
     cy.intercept(
         'GET',
         /\/programStages\/[a-zA-Z0-9]{11}\?fields=programStageDataElements/
@@ -124,7 +131,10 @@ const selectProgramAndStage = (
     Layer.openDialog('Events')
     cy.wait('@getPrograms', EXTENDED_TIMEOUT)
     Layer.selectProgram(programName)
-    cy.wait('@getProgramStages', EXTENDED_TIMEOUT)
+    cy.wait(
+        ['@getProgramStages', '@getProgramTrackedEntityAttributes'],
+        EXTENDED_TIMEOUT
+    )
     if (validateOnly) {
         Layer.validateStage(stageName)
     } else {

--- a/cypress/integration/layers/eventlayer.cy.js
+++ b/cypress/integration/layers/eventlayer.cy.js
@@ -122,20 +122,15 @@ const selectProgramAndStage = (
     ).as('getProgramStageDataElements')
 
     Layer.openDialog('Events')
-
-    cy.wait('@getPrograms')
-
+    cy.wait('@getPrograms', EXTENDED_TIMEOUT)
     Layer.selectProgram(programName)
-
-    cy.wait('@getProgramStages')
-
+    cy.wait('@getProgramStages', EXTENDED_TIMEOUT)
     if (validateOnly) {
         Layer.validateStage(stageName)
     } else {
         Layer.selectStage(stageName)
     }
-
-    cy.wait('@getProgramStageDataElements')
+    cy.wait('@getProgramStageDataElements', EXTENDED_TIMEOUT)
 }
 
 context('Event Layers', () => {

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -15,6 +15,8 @@ import {
 } from '../../support/util.js'
 
 const MAP_TIMEOUT = { timeout: 40000 }
+// Extra buffer on top of waitForMap()
+const POPUP_WAIT_BUFFER = 1000
 
 const HIV_INDICATOR_GROUP = 'HIV'
 const HIV_INDICATOR_NAME = 'VCCT post-test counselling rate'
@@ -241,6 +243,8 @@ context('Thematic Layers', () => {
         Layer.validateDialogClosed(true)
 
         cy.waitForMap(MAP_TIMEOUT)
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(POPUP_WAIT_BUFFER)
         getMaps().click('center') //Click in the middle of the map
         Layer.validatePopupContents(['Value: 0'])
 
@@ -254,6 +258,8 @@ context('Thematic Layers', () => {
         Layer.validateDialogClosed(true)
 
         cy.waitForMap(MAP_TIMEOUT)
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(POPUP_WAIT_BUFFER)
         getMaps().click('center') //Click in the middle of the map
         Layer.validatePopupContents(['Value: No data'])
     })
@@ -291,6 +297,8 @@ context('Thematic Layers', () => {
         ])
 
         cy.waitForMap(MAP_TIMEOUT)
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(POPUP_WAIT_BUFFER)
         getMaps().click('center')
 
         Layer.validatePopupContents(['Tonkolili'])
@@ -314,6 +322,8 @@ context('Thematic Layers', () => {
         Layer.validateCardTitle(`March ${CURRENT_YEAR - 1}`)
 
         cy.waitForMap(MAP_TIMEOUT)
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(POPUP_WAIT_BUFFER)
         getMaps().click('center')
 
         Layer.validatePopupContents(['Tonkolili'])
@@ -337,6 +347,8 @@ context('Thematic Layers', () => {
         Layer.validateCardTitle(`September ${CURRENT_YEAR - 1}`)
 
         cy.waitForMap(MAP_TIMEOUT)
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(POPUP_WAIT_BUFFER)
         getMaps().click('center')
 
         Layer.validatePopupContents(['Tonkolili'])
@@ -564,6 +576,9 @@ context('Thematic Layers', () => {
         cy.getByDataTest(DRILL_DOWN, EXTENDED_TIMEOUT).click()
 
         cy.waitForMap(MAP_TIMEOUT)
+        // fitBounds animation after drilling down
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(1000)
         getMaps().click('center')
         cy.get('.maplibregl-popup', EXTENDED_TIMEOUT).should('be.visible')
         cy.get('.maplibregl-popup').invoke('text').as('popupTextBeforePlay')

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -806,6 +806,8 @@ context('Thematic Layers', () => {
             .selectOuLevel('Chiefdom')
             .updateMap()
 
+        cy.waitForMap(MAP_TIMEOUT)
+
         // confirm that the map is valid now
         cy.getByDataTest('layerlegend-item').should('have.length', 5)
     })

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -11,7 +11,6 @@ import {
     CURRENT_YEAR,
     getApiBaseUrl,
     EXTENDED_TIMEOUT,
-    POPUP_WAIT,
     uniqueId,
 } from '../../support/util.js'
 
@@ -186,10 +185,7 @@ context('Thematic Layers', () => {
 
         getMaps().click('center')
 
-        cy.wait(POPUP_WAIT)
-        cy.get('#dhis2-map-container')
-            .findByDataTest('dhis2-uicore-componentcover', EXTENDED_TIMEOUT)
-            .should('not.exist')
+        cy.waitForMap()
 
         getMaps().click('center')
         Layer.validatePopupContents(['Gbonkonlenken'])
@@ -242,10 +238,7 @@ context('Thematic Layers', () => {
 
         Layer.validateDialogClosed(true)
 
-        cy.wait(POPUP_WAIT)
-        cy.get('#dhis2-map-container')
-            .findByDataTest('dhis2-uicore-componentcover', EXTENDED_TIMEOUT)
-            .should('not.exist')
+        cy.waitForMap()
         getMaps().click('center') //Click in the middle of the map
         Layer.validatePopupContents(['Value: 0'])
 
@@ -258,10 +251,7 @@ context('Thematic Layers', () => {
 
         Layer.validateDialogClosed(true)
 
-        cy.wait(POPUP_WAIT)
-        cy.get('#dhis2-map-container')
-            .findByDataTest('dhis2-uicore-componentcover', EXTENDED_TIMEOUT)
-            .should('not.exist')
+        cy.waitForMap()
         getMaps().click('center') //Click in the middle of the map
         Layer.validatePopupContents(['Value: No data'])
     })
@@ -298,7 +288,7 @@ context('Thematic Layers', () => {
             `${CURRENT_YEAR - 1} March, ${CURRENT_YEAR - 1} September`,
         ])
 
-        cy.wait(POPUP_WAIT)
+        cy.waitForMap()
         getMaps().click('center')
 
         Layer.validatePopupContents(['Tonkolili'])
@@ -321,7 +311,7 @@ context('Thematic Layers', () => {
 
         Layer.validateCardTitle(`March ${CURRENT_YEAR - 1}`)
 
-        cy.wait(POPUP_WAIT)
+        cy.waitForMap()
         getMaps().click('center')
 
         Layer.validatePopupContents(['Tonkolili'])
@@ -344,7 +334,7 @@ context('Thematic Layers', () => {
 
         Layer.validateCardTitle(`September ${CURRENT_YEAR - 1}`)
 
-        cy.wait(POPUP_WAIT)
+        cy.waitForMap()
         getMaps().click('center')
 
         Layer.validatePopupContents(['Tonkolili'])
@@ -496,8 +486,7 @@ context('Thematic Layers', () => {
             .children()
             .should('have.length', 2)
 
-        // wait to make sure the maps are loaded
-        cy.wait(2000) // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.waitForMap()
 
         // check that the first timeline period is shown in blue
         cy.get('.dhis2-map-period').should('be.visible')
@@ -516,16 +505,16 @@ context('Thematic Layers', () => {
 
         cy.get('.play-icon').click()
         cy.get('.pause-icon').should('be.visible')
-        cy.wait((5 - 1) * 1500)
 
         // check that the last timeline period is shown in blue
-        cy.get('svg.dhis2-map-timeline')
+        // (EXTENDED_TIMEOUT lets this retry until the animation reaches its final period)
+        cy.get('svg.dhis2-map-timeline', EXTENDED_TIMEOUT)
             .find('rect')
             .first()
             .should('have.css', 'fill', 'rgb(255, 255, 255)')
             .and('have.css', 'fill-opacity', '0.8')
 
-        cy.get('svg.dhis2-map-timeline')
+        cy.get('svg.dhis2-map-timeline', EXTENDED_TIMEOUT)
             .find('rect')
             .last()
             .should('have.css', 'fill', 'rgb(20, 124, 215)')
@@ -560,7 +549,7 @@ context('Thematic Layers', () => {
         Layer.validateDialogClosed(true)
 
         cy.get('svg.dhis2-map-timeline', EXTENDED_TIMEOUT).should('be.visible')
-        cy.wait(2000) // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.waitForMap()
 
         // Drill down
         getMaps()
@@ -572,21 +561,15 @@ context('Thematic Layers', () => {
             })
         cy.getByDataTest(DRILL_DOWN).click()
 
-        cy.wait(2000) // eslint-disable-line cypress/no-unnecessary-waiting
-
-        cy.wait(POPUP_WAIT)
-        cy.get('#dhis2-map-container')
-            .findByDataTest('dhis2-uicore-componentcover', EXTENDED_TIMEOUT)
-            .should('not.exist')
+        cy.waitForMap()
         getMaps().click('center')
         cy.get('.maplibregl-popup').should('be.visible')
         cy.get('.maplibregl-popup').invoke('text').as('popupTextBeforePlay')
 
         cy.get('.play-icon').click()
-        cy.wait(1500 + 500)
 
         cy.get('@popupTextBeforePlay').then((textBefore) => {
-            cy.get('.maplibregl-popup')
+            cy.get('.maplibregl-popup', EXTENDED_TIMEOUT)
                 .invoke('text')
                 .should('not.eq', textBefore)
         })
@@ -717,8 +700,7 @@ context('Thematic Layers', () => {
             .children()
             .should('have.length', 2)
 
-        // wait to make sure the maps are loaded
-        cy.wait(2000) // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.waitForMap()
 
         expectContextMenuOptions([
             { name: DRILL_UP, disabled: true },

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -294,7 +294,7 @@ context('Thematic Layers', () => {
         getMaps().click('center')
 
         Layer.validatePopupContents(['Tonkolili'])
-        cy.get('.maplibregl-popup')
+        cy.get('.maplibregl-popup', EXTENDED_TIMEOUT)
             .contains('Value:')
             .invoke('text')
             .then((step1Text) => {
@@ -317,7 +317,7 @@ context('Thematic Layers', () => {
         getMaps().click('center')
 
         Layer.validatePopupContents(['Tonkolili'])
-        cy.get('.maplibregl-popup')
+        cy.get('.maplibregl-popup', EXTENDED_TIMEOUT)
             .contains('Value:')
             .invoke('text')
             .then((step2Text) => {
@@ -340,7 +340,7 @@ context('Thematic Layers', () => {
         getMaps().click('center')
 
         Layer.validatePopupContents(['Tonkolili'])
-        cy.get('.maplibregl-popup')
+        cy.get('.maplibregl-popup', EXTENDED_TIMEOUT)
             .contains('Value:')
             .invoke('text')
             .then((step3Text) => {
@@ -565,7 +565,7 @@ context('Thematic Layers', () => {
 
         cy.waitForMap(MAP_TIMEOUT)
         getMaps().click('center')
-        cy.get('.maplibregl-popup').should('be.visible')
+        cy.get('.maplibregl-popup', EXTENDED_TIMEOUT).should('be.visible')
         cy.get('.maplibregl-popup').invoke('text').as('popupTextBeforePlay')
 
         cy.get('.play-icon').click()

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -14,6 +14,8 @@ import {
     uniqueId,
 } from '../../support/util.js'
 
+const MAP_TIMEOUT = { timeout: 40000 }
+
 const HIV_INDICATOR_GROUP = 'HIV'
 const HIV_INDICATOR_NAME = 'VCCT post-test counselling rate'
 
@@ -185,7 +187,7 @@ context('Thematic Layers', () => {
 
         getMaps().click('center')
 
-        cy.waitForMap()
+        cy.waitForMap(MAP_TIMEOUT)
 
         getMaps().click('center')
         Layer.validatePopupContents(['Gbonkonlenken'])
@@ -238,7 +240,7 @@ context('Thematic Layers', () => {
 
         Layer.validateDialogClosed(true)
 
-        cy.waitForMap()
+        cy.waitForMap(MAP_TIMEOUT)
         getMaps().click('center') //Click in the middle of the map
         Layer.validatePopupContents(['Value: 0'])
 
@@ -251,7 +253,7 @@ context('Thematic Layers', () => {
 
         Layer.validateDialogClosed(true)
 
-        cy.waitForMap()
+        cy.waitForMap(MAP_TIMEOUT)
         getMaps().click('center') //Click in the middle of the map
         Layer.validatePopupContents(['Value: No data'])
     })
@@ -288,7 +290,7 @@ context('Thematic Layers', () => {
             `${CURRENT_YEAR - 1} March, ${CURRENT_YEAR - 1} September`,
         ])
 
-        cy.waitForMap()
+        cy.waitForMap(MAP_TIMEOUT)
         getMaps().click('center')
 
         Layer.validatePopupContents(['Tonkolili'])
@@ -311,7 +313,7 @@ context('Thematic Layers', () => {
 
         Layer.validateCardTitle(`March ${CURRENT_YEAR - 1}`)
 
-        cy.waitForMap()
+        cy.waitForMap(MAP_TIMEOUT)
         getMaps().click('center')
 
         Layer.validatePopupContents(['Tonkolili'])
@@ -334,7 +336,7 @@ context('Thematic Layers', () => {
 
         Layer.validateCardTitle(`September ${CURRENT_YEAR - 1}`)
 
-        cy.waitForMap()
+        cy.waitForMap(MAP_TIMEOUT)
         getMaps().click('center')
 
         Layer.validatePopupContents(['Tonkolili'])
@@ -486,7 +488,7 @@ context('Thematic Layers', () => {
             .children()
             .should('have.length', 2)
 
-        cy.waitForMap()
+        cy.waitForMap(MAP_TIMEOUT)
 
         // check that the first timeline period is shown in blue
         cy.get('.dhis2-map-period').should('be.visible')
@@ -549,7 +551,7 @@ context('Thematic Layers', () => {
         Layer.validateDialogClosed(true)
 
         cy.get('svg.dhis2-map-timeline', EXTENDED_TIMEOUT).should('be.visible')
-        cy.waitForMap()
+        cy.waitForMap(MAP_TIMEOUT)
 
         // Drill down
         getMaps()
@@ -561,7 +563,7 @@ context('Thematic Layers', () => {
             })
         cy.getByDataTest(DRILL_DOWN).click()
 
-        cy.waitForMap()
+        cy.waitForMap(MAP_TIMEOUT)
         getMaps().click('center')
         cy.get('.maplibregl-popup').should('be.visible')
         cy.get('.maplibregl-popup').invoke('text').as('popupTextBeforePlay')
@@ -700,7 +702,7 @@ context('Thematic Layers', () => {
             .children()
             .should('have.length', 2)
 
-        cy.waitForMap()
+        cy.waitForMap(MAP_TIMEOUT)
 
         expectContextMenuOptions([
             { name: DRILL_UP, disabled: true },

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -12,6 +12,7 @@ import {
     getApiBaseUrl,
     EXTENDED_TIMEOUT,
     POPUP_WAIT,
+    uniqueId,
 } from '../../support/util.js'
 
 const HIV_INDICATOR_GROUP = 'HIV'
@@ -728,8 +729,7 @@ context('Thematic Layers', () => {
 
     // TODO - update demo database with calculations instead of creating on the fly
     it('adds a thematic layer with a calculation', () => {
-        const timestamp = new Date().toUTCString().slice(-24, -4)
-        const calculationName = `map calc ${timestamp}`
+        const calculationName = `map calc ${uniqueId()}`
 
         // add a calculation
         cy.request('POST', `${getApiBaseUrl()}/api/expressionDimensionItems`, {

--- a/cypress/integration/layers/thematiclayer.cy.js
+++ b/cypress/integration/layers/thematiclayer.cy.js
@@ -561,7 +561,7 @@ context('Thematic Layers', () => {
                     .first()
                     .rightclick($el.width() / 2, $el.height() / 2)
             })
-        cy.getByDataTest(DRILL_DOWN).click()
+        cy.getByDataTest(DRILL_DOWN, EXTENDED_TIMEOUT).click()
 
         cy.waitForMap(MAP_TIMEOUT)
         getMaps().click('center')

--- a/cypress/integration/layers/trackedentitylayer.cy.js
+++ b/cypress/integration/layers/trackedentitylayer.cy.js
@@ -1,5 +1,6 @@
 import { getMaps } from '../../elements/map_canvas.js'
 import { TeLayer } from '../../elements/trackedentity_layer.js'
+import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
 describe('Tracked Entity Layers', () => {
     beforeEach(() => {
@@ -44,7 +45,12 @@ describe('Tracked Entity Layers', () => {
         Layer.validateDialogClosed(true)
 
         cy.waitForMap()
+
+        cy.intercept('GET', '**/tracker/trackedEntities/*').as(
+            'getTrackedEntityPopupData'
+        )
         getMaps().click('center') // Click somewhere on the map
+        cy.wait('@getTrackedEntityPopupData', EXTENDED_TIMEOUT)
 
         Layer.validatePopupContents([
             'Organisation unit',

--- a/cypress/integration/layers/trackedentitylayer.cy.js
+++ b/cypress/integration/layers/trackedentitylayer.cy.js
@@ -2,6 +2,16 @@ import { getMaps } from '../../elements/map_canvas.js'
 import { TeLayer } from '../../elements/trackedentity_layer.js'
 import { EXTENDED_TIMEOUT } from '../../support/util.js'
 
+const selectTeTypeAndProgram = (Layer, teType, program) => {
+    cy.intercept('GET', /\/trackedEntityTypes\?/).as('getTrackedEntityTypes')
+    Layer.openDialog('Tracked entities').selectTab('Data')
+    cy.wait('@getTrackedEntityTypes', EXTENDED_TIMEOUT)
+    cy.intercept('GET', /\/programs\?/).as('getPrograms')
+    Layer.selectTeType(teType)
+    cy.wait('@getPrograms', EXTENDED_TIMEOUT)
+    Layer.selectTeProgram(program)
+}
+
 describe('Tracked Entity Layers', () => {
     beforeEach(() => {
         cy.visit('/')
@@ -10,13 +20,13 @@ describe('Tracked Entity Layers', () => {
     const Layer = new TeLayer()
 
     it('adds a tracked entity layer', () => {
-        Layer.openDialog('Tracked entities')
-            .selectTab('Data')
-            .selectTeType('Malaria Entity')
-            .selectTeProgram(
-                'Malaria case diagnosis, treatment and investigation'
-            )
-            .selectTab('Org Units')
+        selectTeTypeAndProgram(
+            Layer,
+            'Malaria Entity',
+            'Malaria case diagnosis, treatment and investigation'
+        )
+
+        Layer.selectTab('Org Units')
             .selectOu('Bombali')
             .selectOu('Bo')
             .addToMap()
@@ -30,11 +40,13 @@ describe('Tracked Entity Layers', () => {
     })
 
     it('opens a tracked entity layer popup', () => {
-        Layer.openDialog('Tracked entities')
-            .selectTab('Data')
-            .selectTeType('Focus area')
-            .selectTeProgram('Malaria focus investigation')
-            .selectTab('Period')
+        selectTeTypeAndProgram(
+            Layer,
+            'Focus area',
+            'Malaria focus investigation'
+        )
+
+        Layer.selectTab('Period')
             .typeStartDate('2018-00-00')
             .selectTab('Org Units')
             .openOu('Bo')
@@ -72,11 +84,13 @@ describe('Tracked Entity Layers', () => {
     })
 
     it('shows error if no endDate is specified', () => {
-        Layer.openDialog('Tracked entities')
-            .selectTab('Data')
-            .selectTeType('Focus area')
-            .selectTeProgram('Malaria focus investigation')
-            .selectTab('Period')
+        selectTeTypeAndProgram(
+            Layer,
+            'Focus area',
+            'Malaria focus investigation'
+        )
+
+        Layer.selectTab('Period')
             .typeStartDate('2018-01-01')
             .typeEndDate('2')
             .addToMap()

--- a/cypress/integration/layers/trackedentitylayer.cy.js
+++ b/cypress/integration/layers/trackedentitylayer.cy.js
@@ -52,9 +52,27 @@ describe('Tracked Entity Layers', () => {
             .openOu('Bo')
             .openOu('Badjia')
             .selectOu('Njandama MCHP')
-            .addToMap()
+
+        cy.intercept(
+            'GET',
+            /\/trackedEntityTypes\/[a-zA-Z0-9]{11}\?fields=trackedEntityTypeAttributes/
+        ).as('getTrackedEntityTypeAttributes')
+        cy.intercept(
+            'GET',
+            /\/programs\/[a-zA-Z0-9]{11}\?fields=programTrackedEntityAttributes/
+        ).as('getProgramTrackedEntityAttributesForPopup')
+
+        Layer.addToMap()
 
         Layer.validateDialogClosed(true)
+
+        cy.wait(
+            [
+                '@getTrackedEntityTypeAttributes',
+                '@getProgramTrackedEntityAttributesForPopup',
+            ],
+            EXTENDED_TIMEOUT
+        )
 
         cy.waitForMap()
 

--- a/cypress/integration/layers/trackedentitylayer.cy.js
+++ b/cypress/integration/layers/trackedentitylayer.cy.js
@@ -1,6 +1,5 @@
 import { getMaps } from '../../elements/map_canvas.js'
 import { TeLayer } from '../../elements/trackedentity_layer.js'
-import { EXTENDED_TIMEOUT, POPUP_WAIT } from '../../support/util.js'
 
 describe('Tracked Entity Layers', () => {
     beforeEach(() => {
@@ -44,10 +43,7 @@ describe('Tracked Entity Layers', () => {
 
         Layer.validateDialogClosed(true)
 
-        cy.wait(POPUP_WAIT)
-        cy.get('#dhis2-map-container')
-            .findByDataTest('dhis2-uicore-componentcover', EXTENDED_TIMEOUT)
-            .should('not.exist')
+        cy.waitForMap()
         getMaps().click('center') // Click somewhere on the map
 
         Layer.validatePopupContents([

--- a/cypress/integration/manageLayerSources.cy.js
+++ b/cypress/integration/manageLayerSources.cy.js
@@ -90,17 +90,29 @@ describe('Manage Layer Sources', () => {
                 .should(assertion)
         })
 
-        // Replace dataStore with default layer sources visibility list
-        cy.request({
-            method: 'PUT',
-            url: `${getApiBaseUrl()}/api/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
-            headers: {
-                'Content-Type': 'application/json;charset=UTF-8',
-            },
-            body: LAYER_SOURCES_DEFAULT_MANAGED_LIST,
-        }).then((response) => {
-            expect(response.status).to.eq(200)
-        })
+        let managedList = [...LAYER_SOURCES_DEFAULT_MANAGED_LIST]
+        cy.intercept(
+            'GET',
+            `**/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
+            (req) => req.reply(managedList)
+        ).as('getManagedList')
+
+        cy.intercept(
+            'PUT',
+            `**/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
+            (req) => {
+                managedList = req.body
+                req.reply({
+                    statusCode: 200,
+                    body: {
+                        httpStatus: 'OK',
+                        httpStatusCode: 200,
+                        status: 'OK',
+                        message: "Key updated: 'MANAGED_LAYER_SOURCES'",
+                    },
+                })
+            }
+        ).as('putManagedList')
 
         // Visit page
         cy.visit('/', EXTENDED_TIMEOUT)
@@ -156,18 +168,6 @@ describe('Manage Layer Sources', () => {
         cy.getByDataTest('managelayersources-button').click()
         cy.waitForCheckbox(0, 'be.checked')
         cy.getByDataTest('managelayersourcesmodal-button').click()
-
-        // Restore dataStore with default layer sources visibility list
-        cy.request({
-            method: 'PUT',
-            url: `${getApiBaseUrl()}/api/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
-            headers: {
-                'Content-Type': 'application/json;charset=UTF-8',
-            },
-            body: LAYER_SOURCES_DEFAULT_MANAGED_LIST,
-        }).then((response) => {
-            expect(response.status).to.eq(200)
-        })
     })
 
     it('w/o admin authority: check managelayersources button is hidden', () => {
@@ -187,17 +187,11 @@ describe('Manage Layer Sources', () => {
             }
         ).as('getAuthorization')
 
-        // Replace dataStore with default layer sources visibility list -1
-        cy.request({
-            method: 'PUT',
-            url: `${getApiBaseUrl()}/api/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
-            headers: {
-                'Content-Type': 'application/json;charset=UTF-8',
-            },
-            body: LAYER_SOURCES_DEFAULT_MANAGED_LIST.slice(0, -1),
-        }).then((response) => {
-            expect(response.status).to.eq(200)
-        })
+        cy.intercept(
+            'GET',
+            `**/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
+            (req) => req.reply(LAYER_SOURCES_DEFAULT_MANAGED_LIST.slice(0, -1))
+        ).as('getManagedListTrimmed')
 
         // Visit page
         cy.visit('/', EXTENDED_TIMEOUT)
@@ -217,18 +211,6 @@ describe('Manage Layer Sources', () => {
 
             // Checks that manage layers modal is not accessible
             cy.getByDataTest('managelayers-button').should('not.exist')
-        })
-
-        // Restore dataStore with default layer sources visibility list
-        cy.request({
-            method: 'PUT',
-            url: `${getApiBaseUrl()}/api/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
-            headers: {
-                'Content-Type': 'application/json;charset=UTF-8',
-            },
-            body: LAYER_SOURCES_DEFAULT_MANAGED_LIST,
-        }).then((response) => {
-            expect(response.status).to.eq(200)
         })
     })
 
@@ -315,16 +297,14 @@ describe('Manage Layer Sources', () => {
     })
 
     it('at start, if "invalid_source_id" in namespace, app ignores id', () => {
-        // Mock "invalid_source_id" in namespace
         cy.intercept(
             'GET',
             `**/dataStore/${MAPS_APP_NAMESPACE}/${MAPS_APP_KEY_MANAGED_LAYER_SOURCES}`,
-            (request) => {
-                delete request.headers['if-none-match']
-                request.continue((response) => {
-                    response.send([...response.body, 'invalid_source_id'])
-                })
-            }
+            (req) =>
+                req.reply([
+                    ...LAYER_SOURCES_DEFAULT_MANAGED_LIST,
+                    'invalid_source_id',
+                ])
         ).as('getNamespaceArray')
 
         // Visit page

--- a/cypress/integration/manageLayerSources.cy.js
+++ b/cypress/integration/manageLayerSources.cy.js
@@ -53,7 +53,7 @@ describe('Manage Layer Sources', () => {
         ).as('getAuthorization')
 
         // Visit page
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
 
         // Opening add layer popover and checking content
         cy.getByDataTest('add-layer-button').click()
@@ -115,7 +115,9 @@ describe('Manage Layer Sources', () => {
         ).as('putManagedList')
 
         // Visit page
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
+
+        cy.wait('@getManagedList')
 
         cy.getByDataTest('add-layer-button').click()
 
@@ -124,6 +126,8 @@ describe('Manage Layer Sources', () => {
         cy.waitForCheckbox(0, 'be.checked')
         cy.getByDataTest('layersource-checkbox').eq(0).click()
         cy.getByDataTest('managelayersourcesmodal-button').click()
+
+        cy.wait('@putManagedList')
 
         cy.log('check there is n-1 layers available')
         cy.getByDataTest('add-layer-button').click()
@@ -141,6 +145,8 @@ describe('Manage Layer Sources', () => {
         cy.getByDataTest('layersource-checkbox').eq(1).click()
         cy.getByDataTest('managelayersourcesmodal-button').click()
 
+        cy.wait('@putManagedList')
+
         cy.log('check there is n-2 layers available')
         cy.getByDataTest('add-layer-button').click()
         const n2 = LAYER_SOURCES_DEFAULT_ALL - 2
@@ -156,6 +162,8 @@ describe('Manage Layer Sources', () => {
         cy.waitForCheckbox(0, 'not.be.checked')
         cy.getByDataTest('layersource-checkbox').eq(0).click()
         cy.getByDataTest('managelayersourcesmodal-button').click()
+
+        cy.wait('@putManagedList')
 
         cy.log('check there is n-1 layers available')
         cy.getByDataTest('add-layer-button').click()
@@ -194,7 +202,7 @@ describe('Manage Layer Sources', () => {
         ).as('getManagedListTrimmed')
 
         // Visit page
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
 
         cy.wait('@getAuthorization', EXTENDED_TIMEOUT).then((interception) => {
             cy.log(interception.response.body.authorities)
@@ -239,7 +247,7 @@ describe('Manage Layer Sources', () => {
         ).as('postNamespaceDefault')
 
         // Visit page
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
 
         cy.wait('@getDataStoreEmpty', EXTENDED_TIMEOUT).then(() => {
             cy.wait('@postNamespaceDefault', EXTENDED_TIMEOUT).then(() => {
@@ -282,7 +290,7 @@ describe('Manage Layer Sources', () => {
         ).as('putNamespaceDefault')
 
         // Visit page
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
 
         cy.wait('@getNamespaceObject', EXTENDED_TIMEOUT).then(() => {
             cy.wait('@putNamespaceDefault', EXTENDED_TIMEOUT).then(() => {
@@ -308,7 +316,7 @@ describe('Manage Layer Sources', () => {
         ).as('getNamespaceArray')
 
         // Visit page
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
 
         cy.wait('@getNamespaceArray', EXTENDED_TIMEOUT).then(() => {
             // Verify default layer sources are available

--- a/cypress/integration/manageLayerSources.cy.js
+++ b/cypress/integration/manageLayerSources.cy.js
@@ -117,8 +117,7 @@ describe('Manage Layer Sources', () => {
         // Visit page
         cy.visit('/')
 
-        cy.wait('@getManagedList')
-
+        cy.wait('@getManagedList', EXTENDED_TIMEOUT)
         cy.getByDataTest('add-layer-button').click()
 
         cy.log('remove one layer')
@@ -127,8 +126,7 @@ describe('Manage Layer Sources', () => {
         cy.getByDataTest('layersource-checkbox').eq(0).click()
         cy.getByDataTest('managelayersourcesmodal-button').click()
 
-        cy.wait('@putManagedList')
-
+        cy.wait('@putManagedList', EXTENDED_TIMEOUT)
         cy.log('check there is n-1 layers available')
         cy.getByDataTest('add-layer-button').click()
         const n1 = LAYER_SOURCES_DEFAULT_ALL - 1
@@ -145,8 +143,7 @@ describe('Manage Layer Sources', () => {
         cy.getByDataTest('layersource-checkbox').eq(1).click()
         cy.getByDataTest('managelayersourcesmodal-button').click()
 
-        cy.wait('@putManagedList')
-
+        cy.wait('@putManagedList', EXTENDED_TIMEOUT)
         cy.log('check there is n-2 layers available')
         cy.getByDataTest('add-layer-button').click()
         const n2 = LAYER_SOURCES_DEFAULT_ALL - 2
@@ -163,8 +160,7 @@ describe('Manage Layer Sources', () => {
         cy.getByDataTest('layersource-checkbox').eq(0).click()
         cy.getByDataTest('managelayersourcesmodal-button').click()
 
-        cy.wait('@putManagedList')
-
+        cy.wait('@putManagedList', EXTENDED_TIMEOUT)
         cy.log('check there is n-1 layers available')
         cy.getByDataTest('add-layer-button').click()
         const n3 = LAYER_SOURCES_DEFAULT_ALL - 1

--- a/cypress/integration/mapDownload.cy.js
+++ b/cypress/integration/mapDownload.cy.js
@@ -48,7 +48,7 @@ describe('Map Download', () => {
             viewportHeight - DOWNLOAD_HEADER_HEIGHT - 2 * DOWNLOAD_BORDER,
         ]
 
-        cy.visit(`/#/${mapWithThematicLayer.id}`, EXTENDED_TIMEOUT)
+        cy.visit(`/#/${mapWithThematicLayer.id}`)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         assertMapPosition(expectedBottoms1, expectedHeights1)

--- a/cypress/integration/mapDownload.cy.js
+++ b/cypress/integration/mapDownload.cy.js
@@ -115,7 +115,7 @@ describe('Map Download', () => {
         // check for downloaded file
         cy.waitUntil(
             () => cy.task('getLastDownloadFilePath').then((result) => result),
-            { timeout: 3000, interval: 100 }
+            { timeout: 8000, interval: 100 }
         ).then((filePath) => {
             expect(filePath).to.include(mapWithThematicLayer.downloadFileName)
 

--- a/cypress/integration/mapDownload.cy.js
+++ b/cypress/integration/mapDownload.cy.js
@@ -113,7 +113,6 @@ describe('Map Download', () => {
             .click()
 
         // check for downloaded file
-        cy.wait(3000) // eslint-disable-line cypress/no-unnecessary-waiting
         cy.waitUntil(
             () => cy.task('getLastDownloadFilePath').then((result) => result),
             { timeout: 3000, interval: 100 }
@@ -130,8 +129,6 @@ describe('Map Download', () => {
         cy.url().should('contain', `/#/${mapWithThematicLayer.id}`)
         cy.url().should('not.contain', '/download')
         cy.getByDataTest('headerbar-title').should('be.visible')
-
-        cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
 
         assertMapPosition(expectedBottoms1, expectedHeights1)
 

--- a/cypress/integration/orgUnitInfo.cy.js
+++ b/cypress/integration/orgUnitInfo.cy.js
@@ -3,7 +3,7 @@ import { CURRENT_YEAR, EXTENDED_TIMEOUT } from '../support/util.js'
 
 describe('OrgUnitInfo', () => {
     it('opens the panel for an OrgUnit', () => {
-        cy.visit('/#/eDlFx0jTtV9', EXTENDED_TIMEOUT)
+        cy.visit('/#/eDlFx0jTtV9')
         cy.get('canvas').should('be.visible')
 
         cy.waitForMap()

--- a/cypress/integration/orgUnitInfo.cy.js
+++ b/cypress/integration/orgUnitInfo.cy.js
@@ -6,10 +6,7 @@ describe('OrgUnitInfo', () => {
         cy.visit('/#/eDlFx0jTtV9', EXTENDED_TIMEOUT)
         cy.get('canvas').should('be.visible')
 
-        cy.wait(3000) // eslint-disable-line cypress/no-unnecessary-waiting
-        cy.get('#dhis2-map-container')
-            .findByDataTest('dhis2-uicore-componentcover', EXTENDED_TIMEOUT)
-            .should('not.exist')
+        cy.waitForMap()
         getMaps().click(350, 350) //Click somewhere on the map
 
         cy.get('.maplibregl-popup').contains('View profile').click()

--- a/cypress/integration/orgUnitInfo.cy.js
+++ b/cypress/integration/orgUnitInfo.cy.js
@@ -9,7 +9,9 @@ describe('OrgUnitInfo', () => {
         cy.waitForMap()
         getMaps().click(350, 350) //Click somewhere on the map
 
-        cy.get('.maplibregl-popup').contains('View profile').click()
+        cy.get('.maplibregl-popup', EXTENDED_TIMEOUT)
+            .contains('View profile')
+            .click()
 
         // check the Org Unit Profile panel
         cy.getByDataTest('org-unit-profile').contains(

--- a/cypress/integration/orgUnitInfo.cy.js
+++ b/cypress/integration/orgUnitInfo.cy.js
@@ -9,7 +9,7 @@ describe('OrgUnitInfo', () => {
         cy.waitForMap()
         getMaps().click(350, 350) //Click somewhere on the map
 
-        cy.intercept('GET', '**/organisationUnitProfile/eDlFx0jTtV9/data**').as(
+        cy.intercept('GET', '**/organisationUnitProfile/*/data**').as(
             'orgUnitProfile'
         )
 
@@ -27,7 +27,9 @@ describe('OrgUnitInfo', () => {
         // // TODO - find a way to ensure that "Bombali" is the orgunit that was clicked on
         // // cy.getByDataTest('org-unit-info').find('h3').contains('Bombali')
 
-        cy.intercept('GET', '**/organisationUnitProfile/eDlFx0jTtV9/data**').as(
+        // Wildcarded id: this is whichever org unit's feature is under
+        // the clicked pixel, not the visited map's own id.
+        cy.intercept('GET', '**/organisationUnitProfile/*/data**').as(
             'orgUnitProfilePreviousYear'
         )
 

--- a/cypress/integration/orgUnitInfo.cy.js
+++ b/cypress/integration/orgUnitInfo.cy.js
@@ -9,9 +9,15 @@ describe('OrgUnitInfo', () => {
         cy.waitForMap()
         getMaps().click(350, 350) //Click somewhere on the map
 
+        cy.intercept('GET', '**/organisationUnitProfile/eDlFx0jTtV9/data**').as(
+            'orgUnitProfile'
+        )
+
         cy.get('.maplibregl-popup', EXTENDED_TIMEOUT)
             .contains('View profile')
             .click()
+
+        cy.wait('@orgUnitProfile', EXTENDED_TIMEOUT)
 
         // check the Org Unit Profile panel
         cy.getByDataTest('org-unit-profile').contains(
@@ -21,9 +27,15 @@ describe('OrgUnitInfo', () => {
         // // TODO - find a way to ensure that "Bombali" is the orgunit that was clicked on
         // // cy.getByDataTest('org-unit-info').find('h3').contains('Bombali')
 
+        cy.intercept('GET', '**/organisationUnitProfile/eDlFx0jTtV9/data**').as(
+            'orgUnitProfilePreviousYear'
+        )
+
         cy.getByDataTest('org-unit-data')
             .findByDataTest('button-previous-year')
             .click()
+
+        cy.wait('@orgUnitProfilePreviousYear', EXTENDED_TIMEOUT)
 
         cy.getByDataTest('org-unit-data')
             .findByDataTest('dhis2-uicore-circularloader')

--- a/cypress/integration/pushAnalytics.cy.js
+++ b/cypress/integration/pushAnalytics.cy.js
@@ -32,7 +32,7 @@ describe('push-analytics', () => {
             }
             cy.task('emptyDownloadsFolder')
 
-            cy.visit(`/#/${mapWithThematicLayer.id}`, EXTENDED_TIMEOUT)
+            cy.visit(`/#/${mapWithThematicLayer.id}`)
 
             cy.getByDataTest('dhis2-analytics-hovermenubar')
                 .find('button')

--- a/cypress/integration/pushAnalytics.cy.js
+++ b/cypress/integration/pushAnalytics.cy.js
@@ -45,7 +45,6 @@ describe('push-analytics', () => {
                 .contains('Download')
                 .click()
 
-            cy.wait(3000) // eslint-disable-line cypress/no-unnecessary-waiting
             cy.waitUntil(
                 () =>
                     cy.task('getLastDownloadFilePath').then((result) => result),

--- a/cypress/integration/pushAnalytics.cy.js
+++ b/cypress/integration/pushAnalytics.cy.js
@@ -48,7 +48,7 @@ describe('push-analytics', () => {
             cy.waitUntil(
                 () =>
                     cy.task('getLastDownloadFilePath').then((result) => result),
-                { timeout: 3000, interval: 100 }
+                { timeout: 8000, interval: 100 }
             ).then((filePath) => {
                 expect(filePath).to.include(
                     mapWithThematicLayer.downloadFileName

--- a/cypress/integration/requests.cy.js
+++ b/cypress/integration/requests.cy.js
@@ -171,7 +171,7 @@ describe('API requests check for all layer types', () => {
                 },
             ],
             commonTriggerFn: () => {
-                cy.visit(`#/${id}`, EXTENDED_TIMEOUT)
+                cy.visit(`#/${id}`)
                 cy.getByDataTest('layercard')
                     .find('[data-test="layerlegend"]', EXTENDED_TIMEOUT)
                     .should('exist')

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -254,7 +254,12 @@ describe('Error handling check for all layer types', () => {
                     ...getRequest('getEventsStandard_Analytics2'),
                     triggerFn: () => {
                         clearAndLogin()
+                        cy.intercept(
+                            'GET',
+                            getRequest('getEventsStandard_Analytics1').url
+                        ).as('getEventsAnalytics1')
                         cy.visit(`#/${id}`)
+                        cy.wait('@getEventsAnalytics1')
                         cy.getByDataTest('layercard')
                             .find('[data-test="layerlegend"]', EXTENDED_TIMEOUT)
                             .should('exist')

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -259,7 +259,7 @@ describe('Error handling check for all layer types', () => {
                             getRequest('getEventsStandard_Analytics1').url
                         ).as('getEventsAnalytics1')
                         cy.visit(`#/${id}`)
-                        cy.wait('@getEventsAnalytics1')
+                        cy.wait('@getEventsAnalytics1', EXTENDED_TIMEOUT)
                         cy.getByDataTest('layercard')
                             .find('[data-test="layerlegend"]', EXTENDED_TIMEOUT)
                             .should('exist')

--- a/cypress/integration/requestsErrors.cy.js
+++ b/cypress/integration/requestsErrors.cy.js
@@ -16,8 +16,6 @@ const clearAndLogin = () => {
     cy.loginByApi({ username, password, baseUrl })
         .its('status')
         .should('equal', 200)
-
-    cy.wait(100) // eslint-disable-line cypress/no-unnecessary-waiting
 }
 
 const commonTriggerFn = () => {
@@ -235,7 +233,10 @@ describe('Error handling check for all layer types', () => {
                     triggerFn: () => {
                         clearAndLogin()
                         cy.visit(`#/${id}`)
-                        cy.wait(10000) // eslint-disable-line cypress/no-unnecessary-waiting
+                        cy.getByDataTest(
+                            'headerbar-title',
+                            EXTENDED_TIMEOUT
+                        ).should('be.visible')
                     },
                     errors: ['network', 409], // !TODO: Improve messages
                 },

--- a/cypress/integration/routes.cy.js
+++ b/cypress/integration/routes.cy.js
@@ -232,8 +232,7 @@ describe('Routes', () => {
 
             cy.visit('/#/ZBjCfSaLSqD?interpretationId=yKqhXZdeJ6a') //ANC: LLITN coverage district and facility
 
-            cy.wait(['@getMap', '@getInterpretation'])
-
+            cy.wait(['@getMap', '@getInterpretation'], EXTENDED_TIMEOUT)
             cy.getByDataTest('interpretation-modal', EXTENDED_TIMEOUT)
                 .find('h1')
                 .contains(

--- a/cypress/integration/routes.cy.js
+++ b/cypress/integration/routes.cy.js
@@ -18,7 +18,7 @@ const assertViewMode = () => {
 
 describe('Routes', () => {
     it('loads root route', () => {
-        cy.visit('/', { timeout: 50000 })
+        cy.visit('/')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
         cy.title().should('equal', 'Maps | DHIS2')
     })
@@ -27,7 +27,7 @@ describe('Routes', () => {
         cy.intercept({ method: 'POST', url: /dataStatistics/ }).as(
             'postDataStatistics'
         )
-        cy.visit('/?id=ytkZY3ChM6J', EXTENDED_TIMEOUT) //ANC: 3rd visit coverage last year by district
+        cy.visit('/?id=ytkZY3ChM6J') //ANC: 3rd visit coverage last year by district
 
         cy.wait('@postDataStatistics', EXTENDED_TIMEOUT)
             .its('response.statusCode')
@@ -40,7 +40,7 @@ describe('Routes', () => {
     })
 
     it('loads with map id (hash)', () => {
-        cy.visit('/#/zDP78aJU8nX', EXTENDED_TIMEOUT) //ANC: 1st visit coverage (%) by district last year
+        cy.visit('/#/zDP78aJU8nX') //ANC: 1st visit coverage (%) by district last year
 
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
@@ -53,7 +53,7 @@ describe('Routes', () => {
             fixture: 'analyticalObject_thematicLayer.json',
         })
 
-        cy.visit('/?currentAnalyticalObject=true', EXTENDED_TIMEOUT)
+        cy.visit('/?currentAnalyticalObject=true')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         cy.contains('button', 'Proceed').click()
@@ -68,7 +68,7 @@ describe('Routes', () => {
             fixture: 'analyticalObject_thematicLayer.json',
         })
 
-        cy.visit('/#/currentAnalyticalObject', EXTENDED_TIMEOUT)
+        cy.visit('/#/currentAnalyticalObject')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         cy.contains('button', 'Proceed').click()
@@ -94,7 +94,7 @@ describe('Routes', () => {
             fixture: 'analyticalObject_earthEngineLayer.json',
         })
 
-        cy.visit('/#/currentAnalyticalObject', EXTENDED_TIMEOUT)
+        cy.visit('/#/currentAnalyticalObject')
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         cy.getByDataTest('layercard')
@@ -116,10 +116,7 @@ describe('Routes', () => {
         cy.intercept({ method: 'POST', url: /dataStatistics/ }).as(
             'postDataStatistics'
         )
-        cy.visit(
-            '/?id=ZBjCfSaLSqD&interpretationid=yKqhXZdeJ6a',
-            EXTENDED_TIMEOUT
-        ) //ANC: LLITN coverage district and facility
+        cy.visit('/?id=ZBjCfSaLSqD&interpretationid=yKqhXZdeJ6a') //ANC: LLITN coverage district and facility
 
         cy.wait('@postDataStatistics', EXTENDED_TIMEOUT)
             .its('response.statusCode')
@@ -147,10 +144,7 @@ describe('Routes', () => {
         cy.intercept({ method: 'POST', url: /dataStatistics/ }).as(
             'postDataStatistics'
         )
-        cy.visit(
-            '/?id=ZBjCfSaLSqD&interpretationId=yKqhXZdeJ6a',
-            EXTENDED_TIMEOUT
-        ) //ANC: LLITN coverage district and facility
+        cy.visit('/?id=ZBjCfSaLSqD&interpretationId=yKqhXZdeJ6a') //ANC: LLITN coverage district and facility
 
         cy.wait('@postDataStatistics', EXTENDED_TIMEOUT)
             .its('response.statusCode')
@@ -168,10 +162,7 @@ describe('Routes', () => {
         cy.intercept({ method: 'POST', url: /dataStatistics/ }).as(
             'postDataStatistics'
         )
-        cy.visit(
-            '/#/ZBjCfSaLSqD?interpretationId=yKqhXZdeJ6a',
-            EXTENDED_TIMEOUT
-        ) //ANC: LLITN coverage district and facility
+        cy.visit('/#/ZBjCfSaLSqD?interpretationId=yKqhXZdeJ6a') //ANC: LLITN coverage district and facility
 
         cy.wait('@postDataStatistics', EXTENDED_TIMEOUT)
             .its('response.statusCode')
@@ -189,7 +180,7 @@ describe('Routes', () => {
         cy.intercept({ method: 'POST', url: /dataStatistics/ }).as(
             'postDataStatistics'
         )
-        cy.visit('/#/ZBjCfSaLSqD/download', EXTENDED_TIMEOUT) //ANC: LLITN coverage district and facility
+        cy.visit('/#/ZBjCfSaLSqD/download') //ANC: LLITN coverage district and facility
 
         cy.wait('@postDataStatistics', EXTENDED_TIMEOUT)
             .its('response.statusCode')
@@ -203,7 +194,7 @@ describe('Routes', () => {
             fixture: 'analyticalObject_thematicLayer.json',
         })
 
-        cy.visit('/#/currentAnalyticalObject/download', EXTENDED_TIMEOUT)
+        cy.visit('/#/currentAnalyticalObject/download')
 
         cy.contains('button', 'Proceed').click()
 
@@ -211,7 +202,7 @@ describe('Routes', () => {
     })
 
     it('loads download page for new map', () => {
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
 
         cy.get('canvas.maplibregl-canvas').should('be.visible')
         cy.get('button').contains('Download').click()
@@ -225,21 +216,23 @@ describe('Routes', () => {
 
     describe('navigation by url changes', () => {
         it('navigates to and away from download page', () => {
-            cy.visit('/', EXTENDED_TIMEOUT)
+            cy.visit('/')
             assertViewMode()
 
-            cy.visit('/#/ZBjCfSaLSqD/download', EXTENDED_TIMEOUT) //ANC: LLITN coverage district and facility
+            cy.visit('/#/ZBjCfSaLSqD/download') //ANC: LLITN coverage district and facility
             assertDownloadMode()
 
-            cy.visit('/', EXTENDED_TIMEOUT)
+            cy.visit('/')
             assertViewMode()
         })
 
         it('navigates away from interpretation modal', () => {
-            cy.visit(
-                '/#/ZBjCfSaLSqD?interpretationId=yKqhXZdeJ6a',
-                EXTENDED_TIMEOUT
-            ) //ANC: LLITN coverage district and facility
+            cy.intercept('GET', '**/maps/ZBjCfSaLSqD*').as('getMap')
+            cy.intercept('GET', '**/interpretations/**').as('getInterpretation')
+
+            cy.visit('/#/ZBjCfSaLSqD?interpretationId=yKqhXZdeJ6a') //ANC: LLITN coverage district and facility
+
+            cy.wait(['@getMap', '@getInterpretation'])
 
             cy.getByDataTest('interpretation-modal', EXTENDED_TIMEOUT)
                 .find('h1')
@@ -250,7 +243,7 @@ describe('Routes', () => {
 
             cy.visit('/#/ZBjCfSaLSqD')
 
-            assertViewMode
+            assertViewMode()
         })
 
         it('navigates from currentAnalyticalObject to saved map in download mode', () => {
@@ -258,7 +251,7 @@ describe('Routes', () => {
                 fixture: 'analyticalObject_thematicLayer.json',
             })
 
-            cy.visit('/#/currentAnalyticalObject', EXTENDED_TIMEOUT)
+            cy.visit('/#/currentAnalyticalObject')
             cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
             cy.contains('button', 'Proceed').click()
@@ -268,7 +261,7 @@ describe('Routes', () => {
             cy.get('canvas.maplibregl-canvas').should('be.visible')
 
             // now go to a saved map in download mode
-            cy.visit('/#/eDlFx0jTtV9/download', EXTENDED_TIMEOUT) //ANC: LLITN Cov chiefdom this year
+            cy.visit('/#/eDlFx0jTtV9/download') //ANC: LLITN Cov chiefdom this year
             assertDownloadMode()
 
             cy.getByDataTest('download-map-info')

--- a/cypress/integration/systemsettings.cy.js
+++ b/cypress/integration/systemsettings.cy.js
@@ -77,7 +77,7 @@ describe('systemSettings', () => {
             })
         }).as('getSystemSettings6months')
 
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
         cy.wait('@getSystemSettings6months', EXTENDED_TIMEOUT)
 
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
@@ -111,7 +111,7 @@ describe('systemSettings', () => {
             })
         }).as('getSystemSettings12months')
 
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
 
         cy.wait('@getSystemSettings12months', EXTENDED_TIMEOUT)
 
@@ -142,9 +142,11 @@ describe('systemSettings', () => {
                     body: res.body,
                 })
             })
-        })
+        }).as('getSystemSettingsDarkBasemap')
 
-        cy.visit('/', EXTENDED_TIMEOUT)
+        cy.visit('/')
+        cy.wait('@getSystemSettingsDarkBasemap', EXTENDED_TIMEOUT)
+
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         checkBasemap.activeBasemap('Dark basemap')

--- a/cypress/integration/systemsettings.cy.js
+++ b/cypress/integration/systemsettings.cy.js
@@ -67,6 +67,8 @@ describe('systemSettings', () => {
         // set relative period to 6 months
         cy.intercept(SYSTEM_SETTINGS_ENDPOINT, (req) => {
             delete req.headers['if-none-match']
+            delete req.headers['if-modified-since']
+            req.headers['cache-control'] = 'no-cache'
             req.continue((res) => {
                 res.body.keyAnalysisRelativePeriod = 'LAST_6_MONTHS'
                 res.send({
@@ -76,8 +78,7 @@ describe('systemSettings', () => {
         }).as('getSystemSettings6months')
 
         cy.visit('/', EXTENDED_TIMEOUT)
-        // cy.wait('@getSystemSettings6months')
-        cy.wait(3000) // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.wait('@getSystemSettings6months', EXTENDED_TIMEOUT)
 
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
@@ -99,6 +100,8 @@ describe('systemSettings', () => {
     it('uses Last 12 months as default relative period', () => {
         cy.intercept(SYSTEM_SETTINGS_ENDPOINT, (req) => {
             delete req.headers['if-none-match']
+            delete req.headers['if-modified-since']
+            req.headers['cache-control'] = 'no-cache'
             req.continue((res) => {
                 res.body.keyAnalysisRelativePeriod = 'LAST_12_MONTHS'
 
@@ -110,8 +113,7 @@ describe('systemSettings', () => {
 
         cy.visit('/', EXTENDED_TIMEOUT)
 
-        // cy.wait('@getSystemSettings12months')
-        cy.wait(3000) // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.wait('@getSystemSettings12months', EXTENDED_TIMEOUT)
 
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 

--- a/cypress/integration/ui.cy.js
+++ b/cypress/integration/ui.cy.js
@@ -47,7 +47,7 @@ const getOverlayLayerTitles = () =>
 
 describe('ui', () => {
     it('collapses and expands the Layers Panel', () => {
-        cy.visit(`/#/${map.id}`, EXTENDED_TIMEOUT)
+        cy.visit(`/#/${map.id}`)
         cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
 
         // check that Layers Panel is visible

--- a/cypress/integration/ui.cy.js
+++ b/cypress/integration/ui.cy.js
@@ -35,7 +35,7 @@ const addThematicAndFacilityLayers = () => {
         .selectOuLevel('Facility')
         .addToMap()
 
-    cy.wait(1000) // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.waitForMap()
 }
 
 // Reads the ordered list of overlay layer card titles in the Layers panel.

--- a/cypress/integration/usersettings.cy.js
+++ b/cypress/integration/usersettings.cy.js
@@ -7,8 +7,8 @@ const testMap = {
     cardTitle: 'ANC LLITN coverage',
 }
 
-const interceptRequest = (matcher, param, where = 'body') => {
-    cy.intercept(matcher, (req) => {
+const interceptRequest = (matcher, param, { where = 'body', alias } = {}) => {
+    const handler = (req) => {
         delete req.headers['if-none-match']
         req.reply((res) => {
             if (where === 'body') {
@@ -31,18 +31,27 @@ const interceptRequest = (matcher, param, where = 'body') => {
                 })
             }
         })
-    })
+    }
+
+    if (alias) {
+        cy.intercept(matcher, handler).as(alias)
+    } else {
+        cy.intercept(matcher, handler)
+    }
 }
 
 const interceptRequests = (param) => {
-    interceptRequest({ method: 'GET', url: '**/userSettings' }, param, 'body')
+    interceptRequest({ method: 'GET', url: '**/userSettings' }, param, {
+        where: 'body',
+        alias: 'getUserSettings',
+    })
     interceptRequest(
         {
             method: 'GET',
             url: '**/me?fields=authorities,avatar,email,name,settings',
         },
         param,
-        'settings'
+        { where: 'settings' }
     )
     interceptRequest(
         {
@@ -50,7 +59,7 @@ const interceptRequests = (param) => {
             url: '**/me?fields=:all,organisationUnits[id],userGroups[id],userCredentials[:all,!user,userRoles[id]',
         },
         param,
-        'settings'
+        { where: 'settings' }
     )
     interceptRequest(
         {
@@ -60,7 +69,7 @@ const interceptRequests = (param) => {
             )}`,
         },
         param,
-        'settings'
+        { where: 'settings' }
     )
 }
 
@@ -81,7 +90,7 @@ const interceptNameProperty = (keyAnalysisDisplayProperty) => {
             url: '**/systemSettings?key=keyAnalysisRelativePeriod,keyBingMapsApiKey,keyHideDailyPeriods,keyHideWeeklyPeriods,keyHideBiWeeklyPeriods,keyHideMonthlyPeriods,keyHideBiMonthlyPeriods,keyDefaultBaseMap',
         },
         param,
-        'body'
+        { where: 'body' }
     )
 }
 
@@ -90,6 +99,7 @@ describe('uses the correct locale', () => {
         interceptLanguage('nb')
 
         cy.visit(`/?id=${testMap.id}`)
+        cy.wait('@getUserSettings')
         cy.get('[data-test=layercard]')
             .find('h2')
             .contains(`${testMap.cardTitle}`)
@@ -111,6 +121,7 @@ describe('uses the correct locale', () => {
         interceptLanguage('en')
 
         cy.visit(`/?id=${testMap.id}`)
+        cy.wait('@getUserSettings')
         cy.get('[data-test=layercard]')
             .find('h2')
             .contains(`${testMap.cardTitle}`)

--- a/cypress/integration/usersettings.cy.js
+++ b/cypress/integration/usersettings.cy.js
@@ -99,7 +99,7 @@ describe('uses the correct locale', () => {
         interceptLanguage('nb')
 
         cy.visit(`/?id=${testMap.id}`)
-        cy.wait('@getUserSettings')
+        cy.wait('@getUserSettings', EXTENDED_TIMEOUT)
         cy.get('[data-test=layercard]')
             .find('h2')
             .contains(`${testMap.cardTitle}`)
@@ -121,7 +121,7 @@ describe('uses the correct locale', () => {
         interceptLanguage('en')
 
         cy.visit(`/?id=${testMap.id}`)
-        cy.wait('@getUserSettings')
+        cy.wait('@getUserSettings', EXTENDED_TIMEOUT)
         cy.get('[data-test=layercard]')
             .find('h2')
             .contains(`${testMap.cardTitle}`)

--- a/cypress/plugins/e2eReplicaAccount.js
+++ b/cypress/plugins/e2eReplicaAccount.js
@@ -1,6 +1,8 @@
+const crypto = require('node:crypto')
+
 const MAX_REPLICA_CREATE_ATTEMPTS = 3
 
-const uniqueId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+const uniqueId = () => `${Date.now()}-${crypto.randomBytes(4).toString('hex')}`
 
 const dhis2Fetch = async (
     baseUrl,
@@ -32,7 +34,7 @@ const dhis2Fetch = async (
 }
 
 const createReplicaUser = async ({ baseUrl, adminId, auth }, attempt = 1) => {
-    const username = `e2e_${uniqueId().replace(/-/g, '_')}`
+    const username = `e2e_${uniqueId().replaceAll('-', '_')}`
     const password = `Aa1!${uniqueId()}`
 
     await dhis2Fetch(baseUrl, `/api/users/${adminId}/replica`, {

--- a/cypress/plugins/e2eReplicaAccount.js
+++ b/cypress/plugins/e2eReplicaAccount.js
@@ -1,0 +1,94 @@
+const MAX_REPLICA_CREATE_ATTEMPTS = 3
+
+const uniqueId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
+const dhis2Fetch = async (
+    baseUrl,
+    path,
+    { method = 'GET', auth, body, qs } = {}
+) => {
+    const url = new URL(`${baseUrl}${path}`)
+    if (qs) {
+        Object.entries(qs).forEach(([key, value]) =>
+            url.searchParams.set(key, value)
+        )
+    }
+
+    const headers = { 'Content-Type': 'application/json' }
+    if (auth) {
+        headers.Authorization = `Basic ${Buffer.from(
+            `${auth.username}:${auth.password}`
+        ).toString('base64')}`
+    }
+
+    const response = await fetch(url, {
+        method,
+        headers,
+        body: body ? JSON.stringify(body) : undefined,
+    })
+    const responseBody = await response.json().catch(() => null)
+
+    return { status: response.status, body: responseBody }
+}
+
+const createReplicaUser = async ({ baseUrl, adminId, auth }, attempt = 1) => {
+    const username = `e2e_${uniqueId().replace(/-/g, '_')}`
+    const password = `Aa1!${uniqueId()}`
+
+    await dhis2Fetch(baseUrl, `/api/users/${adminId}/replica`, {
+        method: 'POST',
+        auth,
+        body: { username, password },
+    })
+
+    const lookup = await dhis2Fetch(baseUrl, '/api/users', {
+        auth,
+        qs: { filter: `username:eq:${username}`, fields: 'id' },
+    })
+    const replicaUserId = lookup.body?.users?.[0]?.id
+
+    if (replicaUserId) {
+        return { username, password, replicaUserId }
+    }
+    if (attempt >= MAX_REPLICA_CREATE_ATTEMPTS) {
+        throw new Error(
+            `Failed to create e2e replica user after ${attempt} attempts (last tried '${username}')`
+        )
+    }
+
+    return createReplicaUser({ baseUrl, adminId, auth }, attempt + 1)
+}
+
+const createReplicaAccountForRun = async ({ baseUrl, username, password }) => {
+    const auth = { username, password }
+    const me = await dhis2Fetch(baseUrl, '/api/me', { auth })
+    const adminId = me.body?.id
+
+    if (!adminId) {
+        throw new Error(
+            'Could not resolve the admin user id for e2e replica account creation'
+        )
+    }
+
+    return createReplicaUser({ baseUrl, adminId, auth })
+}
+
+const deleteReplicaAccount = async ({
+    baseUrl,
+    username,
+    password,
+    replicaUserId,
+}) => {
+    const response = await dhis2Fetch(baseUrl, `/api/users/${replicaUserId}`, {
+        method: 'DELETE',
+        auth: { username, password },
+    })
+
+    if (response.status < 200 || response.status >= 300) {
+        console.warn(
+            `WARNING: failed to delete e2e replica user ${replicaUserId} (status ${response.status}) - it may need manual cleanup`
+        )
+    }
+}
+
+module.exports = { createReplicaAccountForRun, deleteReplicaAccount }

--- a/cypress/plugins/e2eReplicaAccount.js
+++ b/cypress/plugins/e2eReplicaAccount.js
@@ -34,7 +34,7 @@ const dhis2Fetch = async (
 }
 
 const createReplicaUser = async ({ baseUrl, adminId, auth }, attempt = 1) => {
-    const username = `e2e_${uniqueId().replaceAll('-', '_')}`
+    const username = `e2e_mapsapp_${uniqueId().replaceAll('-', '_')}`
     const password = `Aa1!${uniqueId()}`
 
     await dhis2Fetch(baseUrl, `/api/users/${adminId}/replica`, {

--- a/cypress/plugins/e2eReplicaAccount.js
+++ b/cypress/plugins/e2eReplicaAccount.js
@@ -1,8 +1,12 @@
 const crypto = require('node:crypto')
 
 const MAX_REPLICA_CREATE_ATTEMPTS = 3
+const MAX_REPLICA_DELETE_ATTEMPTS = 3
+const REPLICA_DELETE_RETRY_DELAY_MS = 3000
 
 const uniqueId = () => `${Date.now()}-${crypto.randomBytes(4).toString('hex')}`
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
 
 const dhis2Fetch = async (
     baseUrl,
@@ -75,22 +79,31 @@ const createReplicaAccountForRun = async ({ baseUrl, username, password }) => {
     return createReplicaUser({ baseUrl, adminId, auth })
 }
 
-const deleteReplicaAccount = async ({
-    baseUrl,
-    username,
-    password,
-    replicaUserId,
-}) => {
+const deleteReplicaAccount = async (
+    { baseUrl, username, password, replicaUserId },
+    attempt = 1
+) => {
     const response = await dhis2Fetch(baseUrl, `/api/users/${replicaUserId}`, {
         method: 'DELETE',
         auth: { username, password },
     })
 
-    if (response.status < 200 || response.status >= 300) {
-        console.warn(
-            `WARNING: failed to delete e2e replica user ${replicaUserId} (status ${response.status}) - it may need manual cleanup`
+    if (response.status >= 200 && response.status < 300) {
+        return
+    }
+
+    if (attempt < MAX_REPLICA_DELETE_ATTEMPTS) {
+        await wait(REPLICA_DELETE_RETRY_DELAY_MS)
+        return deleteReplicaAccount(
+            { baseUrl, username, password, replicaUserId },
+            attempt + 1
         )
     }
+
+    console.warn(
+        `WARNING: failed to delete e2e replica user ${replicaUserId} after ${attempt} attempts (status ${response.status}) - it may need manual cleanup`,
+        JSON.stringify(response.body)
+    )
 }
 
 module.exports = { createReplicaAccountForRun, deleteReplicaAccount }

--- a/cypress/plugins/e2eReplicaAccount.js
+++ b/cypress/plugins/e2eReplicaAccount.js
@@ -7,12 +7,10 @@
  * (the backend plausibly still starting up); a 4xx is definitive and fails
  * immediately instead of retrying.
  *
- * createReplicaUser is a single attempt once the backend is confirmed ready
- * - it either works or it doesn't.
+ * createReplicaUser is a single request; a failure throws.
  *
- * deleteReplicaAccount retries with backoff: reproduced directly against the
- * live test instance, some deletion failures are transient and resolve given
- * time, which a single attempt can't take advantage of.
+ * deleteReplicaAccount is a single request; a failure is logged as a
+ * warning and left for manual or nightly cleanup.
  *
  * If account creation fails outright, cypress.config.js catches it and falls
  * back to running the job under the standard shared account instead of
@@ -22,8 +20,6 @@ const crypto = require('node:crypto')
 
 const MAX_BACKEND_READY_ATTEMPTS = 5
 const BACKEND_READY_RETRY_DELAY_MS = 3000
-const MAX_REPLICA_DELETE_ATTEMPTS = 3
-const REPLICA_DELETE_RETRY_DELAY_MS = 3000
 
 const uniqueId = () => `${Date.now()}-${crypto.randomBytes(4).toString('hex')}`
 
@@ -125,41 +121,24 @@ const createReplicaAccountForRun = async ({ baseUrl, username, password }) => {
     return createReplicaUser({ baseUrl, adminId, auth })
 }
 
-const deleteReplicaAccount = async (
-    { baseUrl, username, password, replicaUserId },
-    attempt = 1
-) => {
+const deleteReplicaAccount = async ({
+    baseUrl,
+    username,
+    password,
+    replicaUserId,
+}) => {
     const response = await dhis2Fetch(baseUrl, `/api/users/${replicaUserId}`, {
         method: 'DELETE',
         auth: { username, password },
     })
 
     if (response.status >= 200 && response.status < 300) {
-        if (attempt > 1) {
-            console.log(
-                `Deleted e2e replica user ${replicaUserId} on attempt ${attempt} after ${
-                    attempt - 1
-                } prior failure(s)`
-            )
-        }
         return
     }
 
     console.warn(
-        `WARNING: attempt ${attempt}/${MAX_REPLICA_DELETE_ATTEMPTS} to delete e2e replica user ${replicaUserId} failed (status ${response.status})`,
+        `WARNING: failed to delete e2e replica user ${replicaUserId} (status ${response.status}) - it may need manual cleanup`,
         JSON.stringify(response.body)
-    )
-
-    if (attempt < MAX_REPLICA_DELETE_ATTEMPTS) {
-        await wait(REPLICA_DELETE_RETRY_DELAY_MS)
-        return deleteReplicaAccount(
-            { baseUrl, username, password, replicaUserId },
-            attempt + 1
-        )
-    }
-
-    console.warn(
-        `WARNING: e2e replica user ${replicaUserId} could not be deleted after ${attempt} attempts - it may need manual cleanup`
     )
 }
 

--- a/cypress/plugins/e2eReplicaAccount.js
+++ b/cypress/plugins/e2eReplicaAccount.js
@@ -1,6 +1,27 @@
+/*
+ * Creates a per-CI-job replica admin user at run start and deletes it at run
+ * end, so parallel jobs against the same shared DHIS2 instance don't collide
+ * on a single shared account. Username embeds the CI run id for traceability.
+ *
+ * waitForBackendReady retries only network-level failures or 5xx responses
+ * (the backend plausibly still starting up); a 4xx is definitive and fails
+ * immediately instead of retrying.
+ *
+ * createReplicaUser is a single attempt once the backend is confirmed ready
+ * - it either works or it doesn't.
+ *
+ * deleteReplicaAccount retries with backoff: reproduced directly against the
+ * live test instance, some deletion failures are transient and resolve given
+ * time, which a single attempt can't take advantage of.
+ *
+ * If account creation fails outright, cypress.config.js catches it and falls
+ * back to running the job under the standard shared account instead of
+ * failing the whole run.
+ */
 const crypto = require('node:crypto')
 
-const MAX_REPLICA_CREATE_ATTEMPTS = 3
+const MAX_BACKEND_READY_ATTEMPTS = 5
+const BACKEND_READY_RETRY_DELAY_MS = 3000
 const MAX_REPLICA_DELETE_ATTEMPTS = 3
 const REPLICA_DELETE_RETRY_DELAY_MS = 3000
 
@@ -27,18 +48,27 @@ const dhis2Fetch = async (
         ).toString('base64')}`
     }
 
-    const response = await fetch(url, {
-        method,
-        headers,
-        body: body ? JSON.stringify(body) : undefined,
-    })
-    const responseBody = await response.json().catch(() => null)
+    try {
+        const response = await fetch(url, {
+            method,
+            headers,
+            body: body ? JSON.stringify(body) : undefined,
+        })
+        const responseBody = await response.json().catch(() => null)
 
-    return { status: response.status, body: responseBody }
+        return { status: response.status, body: responseBody }
+    } catch (error) {
+        return { status: 0, body: { message: error.message } }
+    }
 }
 
-const createReplicaUser = async ({ baseUrl, adminId, auth }, attempt = 1) => {
-    const username = `e2e_mapsapp_${uniqueId().replaceAll('-', '_')}`
+const buildReplicaUsername = () =>
+    `e2e_mapsapp_run${
+        process.env.GITHUB_RUN_ID ?? 'local'
+    }_${uniqueId().replaceAll('-', '_')}`
+
+const createReplicaUser = async ({ baseUrl, adminId, auth }) => {
+    const username = buildReplicaUsername()
     const password = `Aa1!${uniqueId()}`
 
     await dhis2Fetch(baseUrl, `/api/users/${adminId}/replica`, {
@@ -53,20 +83,36 @@ const createReplicaUser = async ({ baseUrl, adminId, auth }, attempt = 1) => {
     })
     const replicaUserId = lookup.body?.users?.[0]?.id
 
-    if (replicaUserId) {
-        return { username, password, replicaUserId }
-    }
-    if (attempt >= MAX_REPLICA_CREATE_ATTEMPTS) {
+    if (!replicaUserId) {
         throw new Error(
-            `Failed to create e2e replica user after ${attempt} attempts (last tried '${username}')`
+            `Failed to create e2e replica user '${username}' - lookup did not find it after creation`
         )
     }
 
-    return createReplicaUser({ baseUrl, adminId, auth }, attempt + 1)
+    return { username, password, replicaUserId }
+}
+
+const waitForBackendReady = async ({ baseUrl, auth }, attempt = 1) => {
+    const response = await dhis2Fetch(baseUrl, '/api/system/info', { auth })
+
+    if (response.status >= 200 && response.status < 300) {
+        return
+    }
+
+    const isRetryable = response.status === 0 || response.status >= 500
+    if (!isRetryable || attempt >= MAX_BACKEND_READY_ATTEMPTS) {
+        throw new Error(
+            `Backend at ${baseUrl} is not ready (status ${response.status}, attempt ${attempt})`
+        )
+    }
+
+    await wait(BACKEND_READY_RETRY_DELAY_MS)
+    return waitForBackendReady({ baseUrl, auth }, attempt + 1)
 }
 
 const createReplicaAccountForRun = async ({ baseUrl, username, password }) => {
     const auth = { username, password }
+    await waitForBackendReady({ baseUrl, auth })
     const me = await dhis2Fetch(baseUrl, '/api/me', { auth })
     const adminId = me.body?.id
 
@@ -89,8 +135,20 @@ const deleteReplicaAccount = async (
     })
 
     if (response.status >= 200 && response.status < 300) {
+        if (attempt > 1) {
+            console.log(
+                `Deleted e2e replica user ${replicaUserId} on attempt ${attempt} after ${
+                    attempt - 1
+                } prior failure(s)`
+            )
+        }
         return
     }
+
+    console.warn(
+        `WARNING: attempt ${attempt}/${MAX_REPLICA_DELETE_ATTEMPTS} to delete e2e replica user ${replicaUserId} failed (status ${response.status})`,
+        JSON.stringify(response.body)
+    )
 
     if (attempt < MAX_REPLICA_DELETE_ATTEMPTS) {
         await wait(REPLICA_DELETE_RETRY_DELAY_MS)
@@ -101,8 +159,7 @@ const deleteReplicaAccount = async (
     }
 
     console.warn(
-        `WARNING: failed to delete e2e replica user ${replicaUserId} after ${attempt} attempts (status ${response.status}) - it may need manual cleanup`,
-        JSON.stringify(response.body)
+        `WARNING: e2e replica user ${replicaUserId} could not be deleted after ${attempt} attempts - it may need manual cleanup`
     )
 }
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -9,13 +9,13 @@ Cypress.Commands.add('getByDataTest', (selector, ...args) =>
 Cypress.Commands.add('waitForMap', (options = {}) => {
     const timeout = options.timeout ?? EXTENDED_TIMEOUT.timeout
 
-    cy.get('body', { timeout }).should(() => {
-        const mask = document.querySelector(
-            '#dhis2-map-container .dhis2-map-loading-mask'
-        )
+    cy.get('#dhis2-map-container', { timeout }).should(($container) => {
+        const container = $container[0]
+
+        const mask = container.querySelector('.dhis2-map-loading-mask')
         expect(mask, 'map loading mask should not be present').to.be.null
 
-        const maps = document.querySelectorAll('.dhis2-map')
+        const maps = container.querySelectorAll('.dhis2-map')
         expect(
             maps.length,
             'at least one .dhis2-map element should exist'

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,9 +1,33 @@
 import '@dhis2/cypress-commands'
 import 'cypress-wait-until'
+import { EXTENDED_TIMEOUT } from './util.js'
 
 Cypress.Commands.add('getByDataTest', (selector, ...args) =>
     cy.get(`[data-test="${selector}"]`, ...args)
 )
+
+Cypress.Commands.add('waitForMap', (options = {}) => {
+    const timeout = options.timeout ?? EXTENDED_TIMEOUT.timeout
+
+    cy.get('body', { timeout }).should(() => {
+        const mask = document.querySelector(
+            '#dhis2-map-container .dhis2-map-loading-mask'
+        )
+        expect(mask, 'map loading mask should not be present').to.be.null
+
+        const maps = document.querySelectorAll('.dhis2-map')
+        expect(
+            maps.length,
+            'at least one .dhis2-map element should exist'
+        ).to.be.greaterThan(0)
+        maps.forEach((el) => {
+            expect(
+                el.classList.contains('dhis2-map-rendered'),
+                'every .dhis2-map element should be rendered'
+            ).to.equal(true)
+        })
+    })
+})
 Cypress.Commands.add(
     'findByDataTest',
     {

--- a/cypress/support/cypressFiles.json
+++ b/cypress/support/cypressFiles.json
@@ -1,36 +1,51 @@
 {
-    "cypress/integration/basemaps.cy.js": { "include": true, "duration": 60 },
+    "cypress/integration/basemaps.cy.js": {
+        "include": true,
+        "duration": 105
+    },
     "cypress/integration/dataDownload.cy.js": {
         "include": true,
-        "duration": 45
+        "duration": 55
     },
-    "cypress/integration/dataTable.cy.js": { "include": true, "duration": 60 },
+    "cypress/integration/dataTable.cy.js": {
+        "include": true,
+        "duration": 54
+    },
     "cypress/integration/fetcherrors.cy.js": {
         "include": true,
-        "duration": 15
+        "duration": 39
     },
-    "cypress/integration/filemenu.cy.js": { "include": true, "duration": 90 },
+    "cypress/integration/filemenu.cy.js": {
+        "include": true,
+        "duration": 86
+    },
     "cypress/integration/interpretations.cy.js": {
         "include": true,
-        "duration": 45
+        "duration": 46
     },
-    "cypress/integration/keyboard.cy.js": { "include": true, "duration": 30 },
+    "cypress/integration/keyboard.cy.js": {
+        "include": true,
+        "duration": 23
+    },
     "cypress/integration/manageLayerSources.cy.js": {
         "include": true,
-        "duration": 45
+        "duration": 48
     },
     "cypress/integration/mapDownload.cy.js": {
         "include": true,
-        "duration": 15
+        "duration": 14
     },
     "cypress/integration/orgUnitInfo.cy.js": {
         "include": true,
+        "duration": 13
+    },
+    "cypress/integration/plugin.cy.js": {
+        "include": false,
         "duration": 15
     },
-    "cypress/integration/plugin.cy.js": { "include": false, "duration": 15 },
     "cypress/integration/pushAnalytics.cy.js": {
         "include": true,
-        "duration": 15
+        "duration": 17
     },
     "cypress/integration/requests.cy.js": {
         "include": false,
@@ -43,20 +58,23 @@
     },
     "cypress/integration/routes.cy.js": {
         "include": true,
-        "duration": 150
+        "duration": 187
     },
     "cypress/integration/systemsettings.cy.js": {
         "include": true,
-        "duration": 45
+        "duration": 48
     },
-    "cypress/integration/ui.cy.js": { "include": true, "duration": 30 },
+    "cypress/integration/ui.cy.js": {
+        "include": true,
+        "duration": 47
+    },
     "cypress/integration/usersettings.cy.js": {
         "include": true,
-        "duration": 45
+        "duration": 63
     },
     "cypress/integration/layers/eventlayer.cy.js": {
         "include": true,
-        "duration": 120
+        "duration": 159
     },
     "cypress/integration/layers/multilayers.cy.js": {
         "include": true,
@@ -64,30 +82,30 @@
     },
     "cypress/integration/layers/externallayer.cy.js": {
         "include": true,
-        "duration": 15
+        "duration": 7
     },
     "cypress/integration/layers/duplicatelayer.cy.js": {
         "include": true,
-        "duration": 30
+        "duration": 11
     },
     "cypress/integration/layers/orgunitlayer.cy.js": {
         "include": true,
-        "duration": 30
+        "duration": 29
     },
     "cypress/integration/layers/facilitylayer.cy.js": {
         "include": true,
-        "duration": 30
+        "duration": 31
     },
     "cypress/integration/layers/thematiclayer.cy.js": {
         "include": true,
-        "duration": 270
+        "duration": 294
     },
     "cypress/integration/layers/geojsonlayer.cy.js": {
         "include": true,
-        "duration": 30
+        "duration": 27
     },
     "cypress/integration/layers/trackedentitylayer.cy.js": {
         "include": true,
-        "duration": 45
+        "duration": 47
     }
 }

--- a/cypress/support/cypressFiles.json
+++ b/cypress/support/cypressFiles.json
@@ -1,15 +1,15 @@
 {
     "cypress/integration/basemaps.cy.js": {
         "include": true,
-        "duration": 105
+        "duration": 104
     },
     "cypress/integration/dataDownload.cy.js": {
         "include": true,
-        "duration": 55
+        "duration": 56
     },
     "cypress/integration/dataTable.cy.js": {
         "include": true,
-        "duration": 54
+        "duration": 53
     },
     "cypress/integration/fetcherrors.cy.js": {
         "include": true,
@@ -17,7 +17,7 @@
     },
     "cypress/integration/filemenu.cy.js": {
         "include": true,
-        "duration": 86
+        "duration": 85
     },
     "cypress/integration/interpretations.cy.js": {
         "include": true,
@@ -25,11 +25,11 @@
     },
     "cypress/integration/keyboard.cy.js": {
         "include": true,
-        "duration": 23
+        "duration": 24
     },
     "cypress/integration/manageLayerSources.cy.js": {
         "include": true,
-        "duration": 48
+        "duration": 50
     },
     "cypress/integration/mapDownload.cy.js": {
         "include": true,
@@ -45,7 +45,7 @@
     },
     "cypress/integration/pushAnalytics.cy.js": {
         "include": true,
-        "duration": 17
+        "duration": 18
     },
     "cypress/integration/requests.cy.js": {
         "include": false,
@@ -58,7 +58,7 @@
     },
     "cypress/integration/routes.cy.js": {
         "include": true,
-        "duration": 187
+        "duration": 196
     },
     "cypress/integration/systemsettings.cy.js": {
         "include": true,
@@ -66,7 +66,7 @@
     },
     "cypress/integration/ui.cy.js": {
         "include": true,
-        "duration": 47
+        "duration": 46
     },
     "cypress/integration/usersettings.cy.js": {
         "include": true,
@@ -74,7 +74,7 @@
     },
     "cypress/integration/layers/eventlayer.cy.js": {
         "include": true,
-        "duration": 159
+        "duration": 130
     },
     "cypress/integration/layers/multilayers.cy.js": {
         "include": true,
@@ -82,7 +82,7 @@
     },
     "cypress/integration/layers/externallayer.cy.js": {
         "include": true,
-        "duration": 7
+        "duration": 8
     },
     "cypress/integration/layers/duplicatelayer.cy.js": {
         "include": true,
@@ -94,11 +94,11 @@
     },
     "cypress/integration/layers/facilitylayer.cy.js": {
         "include": true,
-        "duration": 31
+        "duration": 32
     },
     "cypress/integration/layers/thematiclayer.cy.js": {
         "include": true,
-        "duration": 294
+        "duration": 288
     },
     "cypress/integration/layers/geojsonlayer.cy.js": {
         "include": true,
@@ -106,6 +106,6 @@
     },
     "cypress/integration/layers/trackedentitylayer.cy.js": {
         "include": true,
-        "duration": 47
+        "duration": 49
     }
 }

--- a/cypress/support/cypressFiles.json
+++ b/cypress/support/cypressFiles.json
@@ -1,43 +1,43 @@
 {
     "cypress/integration/basemaps.cy.js": {
         "include": true,
-        "duration": 104
+        "duration": 80
     },
     "cypress/integration/dataDownload.cy.js": {
         "include": true,
-        "duration": 56
+        "duration": 47
     },
     "cypress/integration/dataTable.cy.js": {
         "include": true,
-        "duration": 53
+        "duration": 50
     },
     "cypress/integration/fetcherrors.cy.js": {
         "include": true,
-        "duration": 39
+        "duration": 33
     },
     "cypress/integration/filemenu.cy.js": {
         "include": true,
-        "duration": 85
+        "duration": 73
     },
     "cypress/integration/interpretations.cy.js": {
         "include": true,
-        "duration": 46
+        "duration": 42
     },
     "cypress/integration/keyboard.cy.js": {
         "include": true,
-        "duration": 24
+        "duration": 19
     },
     "cypress/integration/manageLayerSources.cy.js": {
         "include": true,
-        "duration": 50
+        "duration": 41
     },
     "cypress/integration/mapDownload.cy.js": {
         "include": true,
-        "duration": 14
+        "duration": 13
     },
     "cypress/integration/orgUnitInfo.cy.js": {
         "include": true,
-        "duration": 13
+        "duration": 11
     },
     "cypress/integration/plugin.cy.js": {
         "include": false,
@@ -45,7 +45,7 @@
     },
     "cypress/integration/pushAnalytics.cy.js": {
         "include": true,
-        "duration": 18
+        "duration": 14
     },
     "cypress/integration/requests.cy.js": {
         "include": false,
@@ -58,35 +58,35 @@
     },
     "cypress/integration/routes.cy.js": {
         "include": true,
-        "duration": 196
+        "duration": 162
     },
     "cypress/integration/systemsettings.cy.js": {
         "include": true,
-        "duration": 48
+        "duration": 44
     },
     "cypress/integration/ui.cy.js": {
         "include": true,
-        "duration": 46
+        "duration": 39
     },
     "cypress/integration/usersettings.cy.js": {
         "include": true,
-        "duration": 63
+        "duration": 52
     },
     "cypress/integration/layers/eventlayer.cy.js": {
         "include": true,
-        "duration": 130
+        "duration": 131
     },
     "cypress/integration/layers/multilayers.cy.js": {
         "include": true,
-        "duration": 15
+        "duration": 13
     },
     "cypress/integration/layers/externallayer.cy.js": {
         "include": true,
-        "duration": 8
+        "duration": 6
     },
     "cypress/integration/layers/duplicatelayer.cy.js": {
         "include": true,
-        "duration": 11
+        "duration": 10
     },
     "cypress/integration/layers/orgunitlayer.cy.js": {
         "include": true,
@@ -94,18 +94,18 @@
     },
     "cypress/integration/layers/facilitylayer.cy.js": {
         "include": true,
-        "duration": 32
+        "duration": 27
     },
     "cypress/integration/layers/thematiclayer.cy.js": {
         "include": true,
-        "duration": 288
+        "duration": 283
     },
     "cypress/integration/layers/geojsonlayer.cy.js": {
         "include": true,
-        "duration": 27
+        "duration": 23
     },
     "cypress/integration/layers/trackedentitylayer.cy.js": {
         "include": true,
-        "duration": 49
+        "duration": 38
     }
 }

--- a/cypress/support/cypressFiles.json
+++ b/cypress/support/cypressFiles.json
@@ -1,0 +1,93 @@
+{
+    "cypress/integration/basemaps.cy.js": { "include": true, "duration": 60 },
+    "cypress/integration/dataDownload.cy.js": {
+        "include": true,
+        "duration": 45
+    },
+    "cypress/integration/dataTable.cy.js": { "include": true, "duration": 60 },
+    "cypress/integration/fetcherrors.cy.js": {
+        "include": true,
+        "duration": 15
+    },
+    "cypress/integration/filemenu.cy.js": { "include": true, "duration": 90 },
+    "cypress/integration/interpretations.cy.js": {
+        "include": true,
+        "duration": 45
+    },
+    "cypress/integration/keyboard.cy.js": { "include": true, "duration": 30 },
+    "cypress/integration/manageLayerSources.cy.js": {
+        "include": true,
+        "duration": 45
+    },
+    "cypress/integration/mapDownload.cy.js": {
+        "include": true,
+        "duration": 15
+    },
+    "cypress/integration/orgUnitInfo.cy.js": {
+        "include": true,
+        "duration": 15
+    },
+    "cypress/integration/plugin.cy.js": { "include": false, "duration": 15 },
+    "cypress/integration/pushAnalytics.cy.js": {
+        "include": true,
+        "duration": 15
+    },
+    "cypress/integration/requests.cy.js": {
+        "include": false,
+        "duration": 120,
+        "note": "TODO: E2E DB fix"
+    },
+    "cypress/integration/requestsErrors.cy.js": {
+        "include": false,
+        "duration": 480
+    },
+    "cypress/integration/routes.cy.js": {
+        "include": true,
+        "duration": 150
+    },
+    "cypress/integration/systemsettings.cy.js": {
+        "include": true,
+        "duration": 45
+    },
+    "cypress/integration/ui.cy.js": { "include": true, "duration": 30 },
+    "cypress/integration/usersettings.cy.js": {
+        "include": true,
+        "duration": 45
+    },
+    "cypress/integration/layers/eventlayer.cy.js": {
+        "include": true,
+        "duration": 120
+    },
+    "cypress/integration/layers/multilayers.cy.js": {
+        "include": true,
+        "duration": 15
+    },
+    "cypress/integration/layers/externallayer.cy.js": {
+        "include": true,
+        "duration": 15
+    },
+    "cypress/integration/layers/duplicatelayer.cy.js": {
+        "include": true,
+        "duration": 30
+    },
+    "cypress/integration/layers/orgunitlayer.cy.js": {
+        "include": true,
+        "duration": 30
+    },
+    "cypress/integration/layers/facilitylayer.cy.js": {
+        "include": true,
+        "duration": 30
+    },
+    "cypress/integration/layers/thematiclayer.cy.js": {
+        "include": true,
+        "duration": 270
+    },
+    "cypress/integration/layers/geojsonlayer.cy.js": {
+        "include": true,
+        "duration": 30
+    },
+    "cypress/integration/layers/trackedentitylayer.cy.js": {
+        "include": true,
+        "duration": 45
+    }
+}

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -36,8 +36,6 @@ const findSessionCookieForBaseUrl = (baseUrl, cookies) =>
     )
 
 before(() => {
-    const username = Cypress.env('dhis2Username')
-    const password = Cypress.env('dhis2Password')
     const baseUrl = Cypress.env('dhis2BaseUrl')
     const instanceVersion = Cypress.env('dhis2InstanceVersion')
     const hideRequestsFromLog = Cypress.env('hideRequestsFromLog')
@@ -46,6 +44,13 @@ before(() => {
         // disable Cypress's default behavior of logging all XMLHttpRequests and fetches
         cy.intercept({ resourceType: /xhr|fetch/ }, { log: false })
     }
+
+    const username = Cypress.env('useReplicaAccount')
+        ? Cypress.env('replicaUsername')
+        : Cypress.env('dhis2Username')
+    const password = Cypress.env('useReplicaAccount')
+        ? Cypress.env('replicaPassword')
+        : Cypress.env('dhis2Password')
 
     cy.loginByApi({ username, password, baseUrl })
         .its('status')
@@ -68,7 +73,7 @@ before(() => {
 
     cy.request({
         method: 'GET',
-        url: `${Cypress.env('dhis2BaseUrl')}/api/system/info?fields=version`,
+        url: `${baseUrl}/api/system/info?fields=version`,
     }).then(({ body: { version } }) => {
         const match = version.match(
             /^(\d+)\.(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([\w.]+))?$/

--- a/cypress/support/generateTestMatrix.js
+++ b/cypress/support/generateTestMatrix.js
@@ -1,75 +1,8 @@
 const fs = require('node:fs')
 const path = require('node:path')
+const CYPRESS_FILES = require('./cypressFiles.json')
 
 const NUMBER_OF_GROUPS = 5
-const CYPRESS_FILES = {
-    'cypress/integration/basemaps.cy.js': { include: true, duration: 60 },
-    'cypress/integration/dataDownload.cy.js': { include: true, duration: 45 },
-    'cypress/integration/dataTable.cy.js': { include: true, duration: 60 },
-    'cypress/integration/fetcherrors.cy.js': { include: true, duration: 15 },
-    'cypress/integration/filemenu.cy.js': { include: true, duration: 90 },
-    'cypress/integration/interpretations.cy.js': {
-        include: true,
-        duration: 45,
-    },
-    'cypress/integration/keyboard.cy.js': { include: true, duration: 30 },
-    'cypress/integration/manageLayerSources.cy.js': {
-        include: true,
-        duration: 45,
-    },
-    'cypress/integration/mapDownload.cy.js': { include: true, duration: 15 },
-    'cypress/integration/orgUnitInfo.cy.js': { include: true, duration: 15 },
-    'cypress/integration/plugin.cy.js': { include: false, duration: 15 },
-    'cypress/integration/pushAnalytics.cy.js': { include: true, duration: 15 },
-    'cypress/integration/requests.cy.js': { include: false, duration: 120 }, // TODO: E2E DB fix
-    'cypress/integration/requestsErrors.cy.js': {
-        include: false,
-        duration: 480,
-    },
-    'cypress/integration/routes.cy.js': { include: true, duration: 150 },
-    'cypress/integration/systemsettings.cy.js': {
-        include: true,
-        duration: 45,
-    },
-    'cypress/integration/ui.cy.js': { include: true, duration: 30 },
-    'cypress/integration/usersettings.cy.js': { include: true, duration: 45 },
-    'cypress/integration/layers/eventlayer.cy.js': {
-        include: true,
-        duration: 120,
-    },
-    'cypress/integration/layers/multilayers.cy.js': {
-        include: true,
-        duration: 15,
-    },
-    'cypress/integration/layers/externallayer.cy.js': {
-        include: true,
-        duration: 15,
-    },
-    'cypress/integration/layers/duplicatelayer.cy.js': {
-        include: true,
-        duration: 30,
-    },
-    'cypress/integration/layers/orgunitlayer.cy.js': {
-        include: true,
-        duration: 30,
-    },
-    'cypress/integration/layers/facilitylayer.cy.js': {
-        include: true,
-        duration: 30,
-    },
-    'cypress/integration/layers/thematiclayer.cy.js': {
-        include: true,
-        duration: 270,
-    },
-    'cypress/integration/layers/geojsonlayer.cy.js': {
-        include: true,
-        duration: 30,
-    },
-    'cypress/integration/layers/trackedentitylayer.cy.js': {
-        include: true,
-        duration: 45,
-    },
-}
 
 const filterFn = (fullPath) =>
     CYPRESS_FILES[fullPath] ? CYPRESS_FILES[fullPath].include : true // include files by default

--- a/cypress/support/updateTestDurations.js
+++ b/cypress/support/updateTestDurations.js
@@ -80,7 +80,7 @@ const fetchJobLog = async (jobId) => {
 // eslint-disable-next-line no-control-regex
 const ANSI_CODE = /\x1b\[[0-9;]*m/g
 const stripAnsi = (str) => str.replace(ANSI_CODE, '')
-const SUMMARY_ROW = /([\w-]+\.cy\.js)\s+(\d{2}):(\d{2})\s/
+const SUMMARY_ROW = /([\w-]{1,80}\.cy\.js)\s{1,120}(\d{2}):(\d{2})\s/
 
 const parseDurations = (log) => {
     const results = []
@@ -114,8 +114,13 @@ const collectDurationsFromRuns = async (runIds) => {
     const durationsBySpec = new Map()
 
     for (const runId of runIds) {
-        for (const jobId of await listE2eJobIds(runId)) {
-            console.log(`  run ${runId}, job ${jobId}: fetching log...`)
+        const jobIds = await listE2eJobIds(runId)
+        // A run that just flipped to "success" can briefly report an
+        // incomplete job list (GitHub API replication lag) - logging the
+        // count makes a suspiciously low number (e.g. 1 instead of ~15)
+        // visible instead of silently under-sampling.
+        console.log(`  run ${runId}: ${jobIds.length} e2e job(s)`)
+        for (const jobId of jobIds) {
             const log = await fetchJobLog(jobId)
             for (const { specFile, seconds } of parseDurations(log)) {
                 addSample(durationsBySpec, specFile, seconds)
@@ -126,12 +131,19 @@ const collectDurationsFromRuns = async (runIds) => {
     return durationsBySpec
 }
 
+// Returns a human-readable diff line per changed entry, plus the list of
+// included-but-unsampled specs - these are left untouched, which looks
+// identical to "already correct" unless called out explicitly.
 const applyDurationUpdates = (data, durationsBySpec) => {
     const diffLines = []
+    const missingData = []
 
     for (const [specPath, entry] of Object.entries(data)) {
         const samples = durationsBySpec.get(path.basename(specPath))
         if (!samples || samples.length === 0) {
+            if (entry.include) {
+                missingData.push(specPath)
+            }
             continue
         }
 
@@ -146,7 +158,7 @@ const applyDurationUpdates = (data, durationsBySpec) => {
         entry.duration = newDuration
     }
 
-    return diffLines
+    return { diffLines, missingData }
 }
 
 const main = async () => {
@@ -158,7 +170,22 @@ const main = async () => {
 
     const dataPath = path.join(__dirname, 'cypressFiles.json')
     const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'))
-    const diffLines = applyDurationUpdates(data, durationsBySpec)
+    const { diffLines, missingData } = applyDurationUpdates(
+        data,
+        durationsBySpec
+    )
+
+    if (missingData.length > 0) {
+        console.warn(
+            `\nWARNING: no samples found for ${missingData.length} included spec(s) - their durations were NOT refreshed:`
+        )
+        missingData.forEach((specPath) => console.warn(`  ${specPath}`))
+        console.warn(
+            'This usually means a sampled run had an incomplete job list ' +
+                '(see the per-run job counts above) or --runs was too low. ' +
+                "Don't treat this as a full refresh until that count looks right."
+        )
+    }
 
     if (diffLines.length === 0) {
         console.log('\nNo duration changes found.')

--- a/cypress/support/updateTestDurations.js
+++ b/cypress/support/updateTestDurations.js
@@ -1,0 +1,148 @@
+// One-off maintenance script: refreshes the `duration` values in
+// ./cypressFiles.json from real per-spec durations found in recent CI job
+// logs, so the shard-balancing matrix stays accurate.
+//
+// Run by hand whenever CI shard balance visibly drifts - not scheduled.
+//
+// Usage:
+//   yarn cy:update-durations [--runs=8] [--repo=dhis2/maps-app] [--workflow=verify-pr.yml] [--write]
+//
+// Without --write, prints an old-vs-new diff only and does not touch any file.
+// Requires the `gh` CLI to be installed and authenticated.
+
+const { execFileSync } = require('node:child_process')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const args = process.argv.slice(2)
+const getArg = (name, fallback) => {
+    const prefix = `--${name}=`
+    const found = args.find((arg) => arg.startsWith(prefix))
+    return found ? found.slice(prefix.length) : fallback
+}
+
+const REPO = getArg('repo', 'dhis2/maps-app')
+const WORKFLOW = getArg('workflow', 'verify-pr.yml')
+const NUM_RUNS = Number(getArg('runs', '8'))
+const WRITE = args.includes('--write')
+
+const gh = (ghArgs) =>
+    execFileSync('gh', ghArgs, {
+        encoding: 'utf8',
+        maxBuffer: 1024 * 1024 * 200,
+    })
+
+const listSuccessfulRunIds = () => {
+    const out = gh([
+        'run',
+        'list',
+        `--repo=${REPO}`,
+        `--workflow=${WORKFLOW}`,
+        '--status=success',
+        `--limit=${NUM_RUNS}`,
+        '--json=databaseId',
+    ])
+    return JSON.parse(out).map((run) => run.databaseId)
+}
+
+const listE2eJobIds = (runId) => {
+    const out = gh([
+        'run',
+        'view',
+        String(runId),
+        `--repo=${REPO}`,
+        '--json=jobs',
+    ])
+    const { jobs } = JSON.parse(out)
+    return jobs
+        .filter((job) => job.name.includes('call-workflow-e2e-prod'))
+        .map((job) => job.databaseId)
+}
+
+// GH Actions logs are colorized; strip ANSI codes first since they embed
+// digits (e.g. "\x1b[90m") that would otherwise break the summary-row match
+// eslint-disable-next-line no-control-regex
+const ANSI_CODE = /\x1b\[[0-9;]*m/g
+const stripAnsi = (str) => str.replace(ANSI_CODE, '')
+const SUMMARY_ROW = /([\w-]+\.cy\.js)\D+(\d{2}):(\d{2})\s/g
+
+const parseDurations = (log) => {
+    const cleaned = stripAnsi(log)
+    const results = []
+    let match
+    SUMMARY_ROW.lastIndex = 0
+    while ((match = SUMMARY_ROW.exec(cleaned))) {
+        const [, specFile, mm, ss] = match
+        results.push({ specFile, seconds: Number(mm) * 60 + Number(ss) })
+    }
+    return results
+}
+
+const median = (nums) => {
+    const sorted = [...nums].sort((a, b) => a - b)
+    const mid = Math.floor(sorted.length / 2)
+    return sorted.length % 2 !== 0
+        ? sorted[mid]
+        : Math.round((sorted[mid - 1] + sorted[mid]) / 2)
+}
+
+const main = () => {
+    console.log(
+        `Fetching last ${NUM_RUNS} successful "${WORKFLOW}" runs from ${REPO}...`
+    )
+    const runIds = listSuccessfulRunIds()
+
+    const durationsBySpec = new Map() // basename -> seconds[]
+
+    for (const runId of runIds) {
+        const jobIds = listE2eJobIds(runId)
+        for (const jobId of jobIds) {
+            console.log(`  run ${runId}, job ${jobId}: fetching log...`)
+            const log = gh(['api', `repos/${REPO}/actions/jobs/${jobId}/logs`])
+            for (const { specFile, seconds } of parseDurations(log)) {
+                if (!durationsBySpec.has(specFile)) {
+                    durationsBySpec.set(specFile, [])
+                }
+                durationsBySpec.get(specFile).push(seconds)
+            }
+        }
+    }
+
+    const dataPath = path.join(__dirname, 'cypressFiles.json')
+    const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'))
+
+    const diffLines = []
+    for (const [specPath, entry] of Object.entries(data)) {
+        const samples = durationsBySpec.get(path.basename(specPath))
+        if (!samples || samples.length === 0) {
+            continue
+        }
+
+        const newDuration = median(samples)
+        if (newDuration === entry.duration) {
+            continue
+        }
+
+        diffLines.push(
+            `  ${specPath}: ${entry.duration}s -> ${newDuration}s (n=${samples.length})`
+        )
+        entry.duration = newDuration
+    }
+
+    if (diffLines.length === 0) {
+        console.log('\nNo duration changes found.')
+        return
+    }
+
+    console.log('\nProposed duration changes:')
+    diffLines.forEach((line) => console.log(line))
+
+    if (WRITE) {
+        fs.writeFileSync(dataPath, JSON.stringify(data, null, 4) + '\n')
+        console.log(`\nWrote updated durations to ${dataPath}`)
+    } else {
+        console.log('\n(dry run - pass --write to apply these changes)')
+    }
+}
+
+main()

--- a/cypress/support/updateTestDurations.js
+++ b/cypress/support/updateTestDurations.js
@@ -8,9 +8,9 @@
 //   yarn cy:update-durations [--runs=8] [--repo=dhis2/maps-app] [--workflow=verify-pr.yml] [--write]
 //
 // Without --write, prints an old-vs-new diff only and does not touch any file.
-// Requires the `gh` CLI to be installed and authenticated.
+// Requires a GH_TOKEN or GITHUB_TOKEN env var with `repo` (or public-repo)
+// scope - e.g. `export GH_TOKEN=$(gh auth token)` if you use the gh CLI.
 
-const { execFileSync } = require('node:child_process')
 const fs = require('node:fs')
 const path = require('node:path')
 
@@ -26,37 +26,53 @@ const WORKFLOW = getArg('workflow', 'verify-pr.yml')
 const NUM_RUNS = Number(getArg('runs', '8'))
 const WRITE = args.includes('--write')
 
-const gh = (ghArgs) =>
-    execFileSync('gh', ghArgs, {
-        encoding: 'utf8',
-        maxBuffer: 1024 * 1024 * 200,
-    })
-
-const listSuccessfulRunIds = () => {
-    const out = gh([
-        'run',
-        'list',
-        `--repo=${REPO}`,
-        `--workflow=${WORKFLOW}`,
-        '--status=success',
-        `--limit=${NUM_RUNS}`,
-        '--json=databaseId',
-    ])
-    return JSON.parse(out).map((run) => run.databaseId)
+const TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN
+if (!TOKEN) {
+    console.error(
+        'Missing GH_TOKEN/GITHUB_TOKEN env var.\n' +
+            'If you use the gh CLI, run: export GH_TOKEN=$(gh auth token)'
+    )
+    process.exit(1)
 }
 
-const listE2eJobIds = (runId) => {
-    const out = gh([
-        'run',
-        'view',
-        String(runId),
-        `--repo=${REPO}`,
-        '--json=jobs',
-    ])
-    const { jobs } = JSON.parse(out)
+const githubApi = async (apiPath) => {
+    const res = await fetch(`https://api.github.com${apiPath}`, {
+        headers: {
+            Authorization: `Bearer ${TOKEN}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+        },
+    })
+    if (!res.ok) {
+        throw new Error(
+            `GitHub API ${apiPath} failed: ${res.status} ${res.statusText}`
+        )
+    }
+    return res
+}
+
+const listSuccessfulRunIds = async () => {
+    const res = await githubApi(
+        `/repos/${REPO}/actions/workflows/${WORKFLOW}/runs` +
+            `?status=success&per_page=${NUM_RUNS}`
+    )
+    const { workflow_runs: runs } = await res.json()
+    return runs.map((run) => run.id)
+}
+
+const listE2eJobIds = async (runId) => {
+    const res = await githubApi(
+        `/repos/${REPO}/actions/runs/${runId}/jobs?per_page=100`
+    )
+    const { jobs } = await res.json()
     return jobs
         .filter((job) => job.name.includes('call-workflow-e2e-prod'))
-        .map((job) => job.databaseId)
+        .map((job) => job.id)
+}
+
+const fetchJobLog = async (jobId) => {
+    const res = await githubApi(`/repos/${REPO}/actions/jobs/${jobId}/logs`)
+    return res.text()
 }
 
 // GH Actions logs are colorized; strip ANSI codes first since they embed
@@ -64,14 +80,15 @@ const listE2eJobIds = (runId) => {
 // eslint-disable-next-line no-control-regex
 const ANSI_CODE = /\x1b\[[0-9;]*m/g
 const stripAnsi = (str) => str.replace(ANSI_CODE, '')
-const SUMMARY_ROW = /([\w-]+\.cy\.js)\D+(\d{2}):(\d{2})\s/g
+const SUMMARY_ROW = /([\w-]+\.cy\.js)\s+(\d{2}):(\d{2})\s/
 
 const parseDurations = (log) => {
-    const cleaned = stripAnsi(log)
     const results = []
-    let match
-    SUMMARY_ROW.lastIndex = 0
-    while ((match = SUMMARY_ROW.exec(cleaned))) {
+    for (const rawLine of stripAnsi(log).split('\n')) {
+        const match = SUMMARY_ROW.exec(rawLine)
+        if (!match) {
+            continue
+        }
         const [, specFile, mm, ss] = match
         results.push({ specFile, seconds: Number(mm) * 60 + Number(ss) })
     }
@@ -86,32 +103,32 @@ const median = (nums) => {
         : Math.round((sorted[mid - 1] + sorted[mid]) / 2)
 }
 
-const main = () => {
-    console.log(
-        `Fetching last ${NUM_RUNS} successful "${WORKFLOW}" runs from ${REPO}...`
-    )
-    const runIds = listSuccessfulRunIds()
+const addSample = (durationsBySpec, specFile, seconds) => {
+    if (!durationsBySpec.has(specFile)) {
+        durationsBySpec.set(specFile, [])
+    }
+    durationsBySpec.get(specFile).push(seconds)
+}
 
-    const durationsBySpec = new Map() // basename -> seconds[]
+const collectDurationsFromRuns = async (runIds) => {
+    const durationsBySpec = new Map()
 
     for (const runId of runIds) {
-        const jobIds = listE2eJobIds(runId)
-        for (const jobId of jobIds) {
+        for (const jobId of await listE2eJobIds(runId)) {
             console.log(`  run ${runId}, job ${jobId}: fetching log...`)
-            const log = gh(['api', `repos/${REPO}/actions/jobs/${jobId}/logs`])
+            const log = await fetchJobLog(jobId)
             for (const { specFile, seconds } of parseDurations(log)) {
-                if (!durationsBySpec.has(specFile)) {
-                    durationsBySpec.set(specFile, [])
-                }
-                durationsBySpec.get(specFile).push(seconds)
+                addSample(durationsBySpec, specFile, seconds)
             }
         }
     }
 
-    const dataPath = path.join(__dirname, 'cypressFiles.json')
-    const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'))
+    return durationsBySpec
+}
 
+const applyDurationUpdates = (data, durationsBySpec) => {
     const diffLines = []
+
     for (const [specPath, entry] of Object.entries(data)) {
         const samples = durationsBySpec.get(path.basename(specPath))
         if (!samples || samples.length === 0) {
@@ -129,6 +146,20 @@ const main = () => {
         entry.duration = newDuration
     }
 
+    return diffLines
+}
+
+const main = async () => {
+    console.log(
+        `Fetching last ${NUM_RUNS} successful "${WORKFLOW}" runs from ${REPO}...`
+    )
+    const runIds = await listSuccessfulRunIds()
+    const durationsBySpec = await collectDurationsFromRuns(runIds)
+
+    const dataPath = path.join(__dirname, 'cypressFiles.json')
+    const data = JSON.parse(fs.readFileSync(dataPath, 'utf8'))
+    const diffLines = applyDurationUpdates(data, durationsBySpec)
+
     if (diffLines.length === 0) {
         console.log('\nNo duration changes found.')
         return
@@ -145,4 +176,7 @@ const main = () => {
     }
 }
 
-main()
+main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})

--- a/cypress/support/util.js
+++ b/cypress/support/util.js
@@ -3,8 +3,12 @@ export const POPUP_WAIT = 2500
 
 export const CURRENT_YEAR = new Date().getFullYear()
 
-export const uniqueId = () =>
-    `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+const randomHex = (byteLength) =>
+    Array.from(crypto.getRandomValues(new Uint8Array(byteLength)))
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('')
+
+export const uniqueId = () => `${Date.now()}-${randomHex(4)}`
 
 export const getApiBaseUrl = () => {
     const baseUrl = Cypress.env('dhis2BaseUrl') || ''

--- a/cypress/support/util.js
+++ b/cypress/support/util.js
@@ -1,5 +1,4 @@
 export const EXTENDED_TIMEOUT = { timeout: 25000 }
-export const POPUP_WAIT = 2500
 
 export const CURRENT_YEAR = new Date().getFullYear()
 

--- a/cypress/support/util.js
+++ b/cypress/support/util.js
@@ -3,6 +3,9 @@ export const POPUP_WAIT = 2500
 
 export const CURRENT_YEAR = new Date().getFullYear()
 
+export const uniqueId = () =>
+    `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
 export const getApiBaseUrl = () => {
     const baseUrl = Cypress.env('dhis2BaseUrl') || ''
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "validate-push": "yarn test",
         "cy:open": "start-server-and-test 'yarn start' http://localhost:3000 'yarn cypress open --e2e'",
         "cy:run": "start-server-and-test 'yarn start' http://localhost:3000 'yarn cypress run'",
+        "cy:update-durations": "node cypress/support/updateTestDurations.js",
         "docs:build": "yarn docs:format && node scripts/build-docs.js",
         "docs:format": "prettier --write --prose-wrap always --print-width 100 'docs/src/*.md'"
     },

--- a/src/components/periods/Timeline.jsx
+++ b/src/components/periods/Timeline.jsx
@@ -93,6 +93,16 @@ const Timeline = ({ period, periods, onChange, resizeCount }) => {
         setTimeAxis()
     }, [timeScale, setTimeAxis])
 
+    // onChange is a fresh function reference on every parent render
+    // (Map.jsx passes an inline arrow function). Reading it via a ref
+    // keeps play()'s own identity stable across those unrelated
+    // re-renders, so the effect below doesn't keep restarting the
+    // countdown and starving the auto-advance entirely.
+    const onChangeRef = useRef(onChange)
+    useEffect(() => {
+        onChangeRef.current = onChange
+    }, [onChange])
+
     const play = useCallback(() => {
         timeoutRef.current = setTimeout(() => {
             const currentPeriodIndex = sortedPeriods.findIndex(
@@ -101,13 +111,13 @@ const Timeline = ({ period, periods, onChange, resizeCount }) => {
             const nextPeriodIndex = currentPeriodIndex + 1
             if (nextPeriodIndex < sortedPeriods.length) {
                 setCurrentPeriod(sortedPeriods[nextPeriodIndex])
-                onChange(sortedPeriods[nextPeriodIndex])
+                onChangeRef.current(sortedPeriods[nextPeriodIndex])
             } else {
                 setMode(MODE_PAUSE)
             }
         }, DELAY)
         setMode(MODE_PLAY)
-    }, [sortedPeriods, currentPeriod, onChange])
+    }, [sortedPeriods, currentPeriod])
 
     const pause = useCallback(() => {
         clearTimeout(timeoutRef.current)


### PR DESCRIPTION
Replaces 23 of 29 arbitrary `cy.wait(N)` sleeps with condition-based waits — a new `cy.waitForMap()` command that polls maps-gl's actual render-complete state instead of guessing a fixed delay. The remaining 6 (all in `thematiclayer.cy.js`) guard genuine animation/render-settle gaps with no observable condition to sync on, and are explicitly marked with `eslint-disable-next-line cypress/no-unnecessary-waiting` plus a justifying comment. Fixes the flaky/failing tests this surfaced, plus CI speedups found along the way: yarn dependency caching, video recording gated to only record when actually needed, and outdated GitHub Actions bumped to current majors. Net: ~28% faster pipeline (measured), and tests wait exactly as long as needed instead of a guessed constant.