### PR TITLE
chore: switch to instance manager workflow

### DIFF
--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -85,7 +85,7 @@ jobs:
     call-workflow-e2e-prod:
         if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
         needs: [build, lint, test, setup-matrix]
-        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests-prod.yml@maps-app
+        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests-prod.yml@feat/hardcoded-e2e-versions-im
         with:
             should_record: ${{ contains(github.event.head_commit.message, '[e2e record]') || contains(join(github.event.pull_request.labels.*.name), 'e2e record')}}
             spec-group: ${{ needs.setup-matrix.outputs.matrix }}

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -85,7 +85,7 @@ jobs:
     call-workflow-e2e-prod:
         if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
         needs: [build, lint, test, setup-matrix]
-        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests-prod.yml@feat/hardcoded-e2e-versions-im
+        uses: dhis2/workflows/.github/workflows/analytics-e2e-tests-prod.yml@maps-app
         with:
             should_record: ${{ contains(github.event.head_commit.message, '[e2e record]') || contains(join(github.event.pull_request.labels.*.name), 'e2e record')}}
             spec-group: ${{ needs.setup-matrix.outputs.matrix }}

--- a/cypress/elements/event_layer.js
+++ b/cypress/elements/event_layer.js
@@ -53,6 +53,18 @@ export class EventLayer extends Layer {
         return this
     }
 
+    selectRadius(radius) {
+        cy.getByDataTest('eventdialog-styletab')
+            .find('input[type="number"]')
+            .as('radiusInput')
+
+        cy.get('@radiusInput').clear()
+        cy.get('@radiusInput').type(radius)
+        cy.get('@radiusInput').blur()
+
+        return this
+    }
+
     selectIncludeUnclassifiedEvents() {
         cy.contains('Include unclassified events').click()
 

--- a/cypress/integration/basemaps.cy.js
+++ b/cypress/integration/basemaps.cy.js
@@ -11,10 +11,31 @@ describe('Basemap checks', () => {
         })
     })
 
-    it('open map with basemap = none uses default basemap set to not visible', () => {
+    it('open map with basemaps = [{ hidden: true }] uses default basemap set to not visible', () => {
         cy.intercept({ method: 'GET', url: /\/maps\/ytkZY3ChM6J/ }, (req) => {
             delete req.headers['if-none-match']
             req.continue((res) => {
+                delete res.body.basemap
+                res.body.basemaps = [{ hidden: true }]
+                res.send({ body: res.body })
+            })
+        }).as('openMap')
+
+        cy.visit('/?id=ytkZY3ChM6J')
+        cy.wait('@openMap', EXTENDED_TIMEOUT)
+
+        cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
+
+        checkBasemap.cardIsVisible()
+        checkBasemap.isNotVisible()
+    })
+
+    // basemap (singular) is the pre-43 format, kept for maps saved before the DHIS2-20417 migration
+    it('open map with legacy basemap = none uses default basemap set to not visible', () => {
+        cy.intercept({ method: 'GET', url: /\/maps\/ytkZY3ChM6J/ }, (req) => {
+            delete req.headers['if-none-match']
+            req.continue((res) => {
+                delete res.body.basemaps
                 res.body.basemap = 'none'
                 res.send({ body: res.body })
             })
@@ -29,10 +50,32 @@ describe('Basemap checks', () => {
         checkBasemap.isNotVisible()
     })
 
-    it('open map with basemap = object uses id from the object', () => {
+    it('open map with basemaps = [{ id }] uses id from the basemaps array', () => {
         cy.intercept({ method: 'GET', url: /\/maps\/zDP78aJU8nX/ }, (req) => {
             delete req.headers['if-none-match']
             req.continue((res) => {
+                delete res.body.basemap
+                res.body.basemaps = [{ id: 'openStreetMap' }]
+                res.send({ body: res.body })
+            })
+        }).as('openMap')
+
+        cy.visit('/?id=zDP78aJU8nX')
+        cy.wait('@openMap', EXTENDED_TIMEOUT)
+
+        cy.get('canvas', EXTENDED_TIMEOUT).should('be.visible')
+
+        checkBasemap.cardIsVisible()
+        checkBasemap.isVisible()
+        checkBasemap.activeBasemap('OSM Detailed')
+    })
+
+    // basemap (singular) is the pre-43 format, kept for maps saved before the DHIS2-20417 migration
+    it('open map with legacy basemap object uses id from the object', () => {
+        cy.intercept({ method: 'GET', url: /\/maps\/zDP78aJU8nX/ }, (req) => {
+            delete req.headers['if-none-match']
+            req.continue((res) => {
+                delete res.body.basemaps
                 res.body.basemap = { id: 'openStreetMap' }
                 res.send({ body: res.body })
             })

--- a/cypress/integration/fetcherrors.cy.js
+++ b/cypress/integration/fetcherrors.cy.js
@@ -43,7 +43,8 @@ describe('Fetch errors', () => {
     })
 
     it('failed timeline thematic layer does not crash app', () => {
-        cy.intercept('GET', '**/api/**/analytics*', { statusCode: 500 })
+        // narrower than /api/**/analytics*/ so it excludes DHIS2 43+ systemSettings/analytics* endpoints
+        cy.intercept('GET', /\/analytics\?/, { statusCode: 500 })
 
         cy.visit('/')
 

--- a/cypress/integration/layers/eventlayer.cy.js
+++ b/cypress/integration/layers/eventlayer.cy.js
@@ -242,6 +242,8 @@ context('Event Layers', () => {
     })
 
     it('adds an event layer with multiple periods', () => {
+        cy.intercept('GET', /analytics\/events\/query\//).as('analyticsQuery')
+
         selectProgramAndStage(Layer, programIP.name, {
             stageName: programIP.stage,
             validateOnly: true,
@@ -272,6 +274,7 @@ context('Event Layers', () => {
         Layer.validateCardPeriod(`March ${CURRENT_YEAR - 1}`)
         Layer.validateCardPeriod(`September ${CURRENT_YEAR - 1}`)
 
+        cy.wait('@analyticsQuery')
         cy.waitForMap()
 
         cy.intercept('GET', '**/tracker/events/*').as('getEventPopupData')

--- a/cypress/integration/layers/eventlayer.cy.js
+++ b/cypress/integration/layers/eventlayer.cy.js
@@ -242,8 +242,6 @@ context('Event Layers', () => {
     })
 
     it('adds an event layer with multiple periods', () => {
-        cy.intercept('GET', /analytics\/events\/query\//).as('analyticsQuery')
-
         selectProgramAndStage(Layer, programIP.name, {
             stageName: programIP.stage,
             validateOnly: true,
@@ -266,6 +264,8 @@ context('Event Layers', () => {
             .selectOu(programIP.ous[0])
             .selectTab('Style')
             .selectViewAllEvents()
+            // A bigger radius makes the center-of-map click below less fragile
+            .selectRadius(20)
             .addToMap()
 
         Layer.validateDialogClosed(true)
@@ -274,7 +274,6 @@ context('Event Layers', () => {
         Layer.validateCardPeriod(`March ${CURRENT_YEAR - 1}`)
         Layer.validateCardPeriod(`September ${CURRENT_YEAR - 1}`)
 
-        cy.wait('@analyticsQuery')
         cy.waitForMap()
 
         cy.intercept('GET', '**/tracker/events/*').as('getEventPopupData')

--- a/cypress/integration/systemsettings.cy.js
+++ b/cypress/integration/systemsettings.cy.js
@@ -28,6 +28,23 @@ describe('systemSettings', () => {
             })
         })
 
+        // DHIS2 43+ sources enabled period types from this endpoint instead of keyHideWeeklyPeriods
+        cy.intercept(
+            'GET',
+            '**/configuration/dataOutputPeriodTypes*',
+            (req) => {
+                req.continue((res) => {
+                    if (Array.isArray(res.body)) {
+                        res.body = res.body.filter(
+                            (periodType) =>
+                                !periodType.name.startsWith('Weekly')
+                        )
+                    }
+                    res.send({ body: res.body })
+                })
+            }
+        )
+
         cy.visit('/')
 
         const ThemLayer = new ThematicLayer()

--- a/cypress/integration/systemsettings.cy.js
+++ b/cypress/integration/systemsettings.cy.js
@@ -8,6 +8,11 @@ const SYSTEM_SETTINGS_ENDPOINT = {
     times: 1,
 }
 
+const DATA_OUTPUT_PERIOD_TYPES_ENDPOINT = {
+    method: 'GET',
+    url: '**/configuration/dataOutputPeriodTypes*',
+}
+
 describe('systemSettings', () => {
     beforeEach(() => {
         cy.intercept(SYSTEM_SETTINGS_ENDPOINT, (req) => {
@@ -29,21 +34,16 @@ describe('systemSettings', () => {
         })
 
         // DHIS2 43+ sources enabled period types from this endpoint instead of keyHideWeeklyPeriods
-        cy.intercept(
-            'GET',
-            '**/configuration/dataOutputPeriodTypes*',
-            (req) => {
-                req.continue((res) => {
-                    if (Array.isArray(res.body)) {
-                        res.body = res.body.filter(
-                            (periodType) =>
-                                !periodType.name.startsWith('Weekly')
-                        )
-                    }
-                    res.send({ body: res.body })
-                })
-            }
-        )
+        cy.intercept(DATA_OUTPUT_PERIOD_TYPES_ENDPOINT, (req) => {
+            req.continue((res) => {
+                if (Array.isArray(res.body)) {
+                    res.body = res.body.filter(
+                        (periodType) => !periodType.name.startsWith('Weekly')
+                    )
+                }
+                res.send({ body: res.body })
+            })
+        })
 
         cy.visit('/')
 


### PR DESCRIPTION
Rolls the e2e-prod matrix forward to DHIS2 43 by picking up the Instance Manager migration in dhis2/workflows (test.e2e.dhis2.org → e2e.im.dhis2.org, versions 40/41/42 → 41/42/43).
See: https://github.com/dhis2/workflows/blob/maps-app/.github/workflows/analytics-e2e-tests-prod.yml and https://github.com/dhis2/workflows/commit/ba29fb350a6b8385ed64a5d99be55558e2e43a32

Running against v43 for the first time surfaced 4 Cypress failures caused by genuine backend changes, not app regressions.

No maps-app application code changed.