### PR TITLE
fix: restore overlay interactivity after switching vector basemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@dhis2/analytics": "^29.5.5",
         "@dhis2/app-runtime": "^3.17.3",
         "@dhis2/app-service-datastore": "^1.0.0-beta.3",
-        "@dhis2/maps-gl": "^4.4.1",
+        "@dhis2/maps-gl": "^4.4.3",
         "@dhis2/ui": "^10.17.0",
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/modifiers": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2431,10 +2431,10 @@
   resolved "https://registry.yarnpkg.com/@dhis2/data-engine/-/data-engine-3.17.3.tgz#0347416e9919efbf4d9739c4141fa543f89669ad"
   integrity sha512-hLXt7LFrFitR7QgKfGQ3ComTLrY5IAdtERonhdo/SIrsRYWoeVaMiCOkUUzC48pEaeo1/BL5qwA7Tw7jZgROQw==
 
-"@dhis2/maps-gl@^4.4.1":
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-4.4.1.tgz#af057c065a03a19b60edcd9f8c5148dee8a64697"
-  integrity sha512-kfFZaR0PrOcaPLQb4jUQVVduKw+i2JYfzA0ActbVHU9tsMsZpuSn5L/Q1DVU++SEf8lXWSLxcuLcDX54XGTr7Q==
+"@dhis2/maps-gl@^4.4.3":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/@dhis2/maps-gl/-/maps-gl-4.4.3.tgz#5584caee92c3fd164e3ab2cb67b78a428c7d1cb3"
+  integrity sha512-C2aDFNV3l3v5wbo0LJHr1lydQE6St04U11kCXtzU1WGqnEMEZKzuHyEoCfhIa/gas3e7HpNVfAbL1ZHI1OqDSw==
   dependencies:
     "@mapbox/sphericalmercator" "^1.2.0"
     "@turf/area" "^7.3.5"


### PR DESCRIPTION
### Description

After switching to or from a vector-style basemap (OSM Light/Dark/Fiord), mouse interaction with other layers - hover, click-to-select, datatable highlight - stopped working. Root-caused and fixed in `@dhis2/maps-gl` (`4.4.1` → `4.4.3`):

- A cache of interactive layer ids could get stuck on an empty list forever if a mouse event fired while overlays were briefly off the map during a style change, silently killing interactivity for every overlay.
- Overlay layers weren't reliably finished being restored before the app moved on, and their stacking order wasn't reconciled afterward.

No maps-app code changes needed - this is a dependency bump only.

---

### Quality checklist

Add _N/A_ to items that are not applicable.

- [ ] Dashboard tested _N/A_
- [ ] Cypress and/or Jest tests added/updated _N/A_
- [ ] Docs added _N/A_
- [x] d2-ci dependencies replaced
- [x] Tester approved (BR)